### PR TITLE
infra(k8s): Add PostgreSQL StatefulSet & Redis Deployment (fixes #6)

### DIFF
--- a/infra/k8s/postgres-deployment.yaml
+++ b/infra/k8s/postgres-deployment.yaml
@@ -1,0 +1,67 @@
+# PostgreSQL StatefulSet and Config
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: sopher-ai
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_DB
+          value: "sopher"
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: sopher-ai-secret
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sopher-ai-secret
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+      volumes:
+      - name: postgres-init
+        configMap:
+          name: postgres-init
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  namespace: sopher-ai
+data:
+  init.sql: |
+    -- Example: CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    -- Add custom initialization SQL here

--- a/infra/k8s/postgres-service.yaml
+++ b/infra/k8s/postgres-service.yaml
@@ -1,0 +1,13 @@
+# PostgreSQL Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: sopher-ai
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres

--- a/infra/k8s/redis-deployment.yaml
+++ b/infra/k8s/redis-deployment.yaml
@@ -1,0 +1,34 @@
+# Redis Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: sopher-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "250m"
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+      volumes:
+      - name: redis-data
+        emptyDir: {}

--- a/infra/k8s/redis-service.yaml
+++ b/infra/k8s/redis-service.yaml
@@ -1,0 +1,13 @@
+# Redis Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: sopher-ai
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis


### PR DESCRIPTION
Add Kubernetes manifests for PostgreSQL and Redis to enable database and cache infrastructure.

Summary
- Adds a PostgreSQL StatefulSet with persistent volume claim and initialization ConfigMap.
- Adds a ClusterIP Service for PostgreSQL.
- Adds a Redis Deployment with resource requests/limits and ClusterIP Service.

Files added
- infra/k8s/postgres-deployment.yaml  — StatefulSet, PVC template, ConfigMap for init SQL
- infra/k8s/postgres-service.yaml     — ClusterIP service for PostgreSQL (5432)
- infra/k8s/redis-deployment.yaml     — Deployment for Redis 7+ with resources
- infra/k8s/redis-service.yaml        — ClusterIP service for Redis (6379)

Requirements coverage
- PostgreSQL 15+: image set to postgresql:15 and data persistence via PVC (10Gi request).
- Redis 7+: image set to redis:7.
- Persistent volumes: StatefulSet uses volumeClaimTemplates requesting 10Gi storage.
- Resource limits: sensible requests/limits added (can be tuned per cluster).
- Secrets: reads credentials from existing secret `sopher-ai-secret` (see `infra/k8s/secret.yaml`).

How to test (cluster-context)
1. Ensure the namespace exists: `kubectl create ns sopher-ai` or use your existing namespace.
2. Ensure `infra/k8s/secret.yaml` contains `POSTGRES_USER` and `POSTGRES_PASSWORD` and apply it:
   kubectl apply -f infra/k8s/secret.yaml -n sopher-ai
3. Apply the manifests:
   kubectl apply -f infra/k8s/postgres-deployment.yaml -n sopher-ai
   kubectl apply -f infra/k8s/postgres-service.yaml -n sopher-ai
   kubectl apply -f infra/k8s/redis-deployment.yaml -n sopher-ai
   kubectl apply -f infra/k8s/redis-service.yaml -n sopher-ai
4. Verify pods and PVCs are running and bound:
   kubectl get sts,deploy,svc,pvc -n sopher-ai
5. Connect from within the cluster (example):
   kubectl run -it --rm --image=postgres:15 psql --namespace sopher-ai -- psql -h postgres -U $POSTGRES_USER -d sopher

Notes & follow-ups
- The PostgreSQL init ConfigMap is provided for lightweight SQL setup. For complex initializations, consider using an initContainer or dedicated job.
- Redis currently uses an ephemeral `emptyDir` volume for simplicity. For production durability, replace with a PVC and use Redis persistence or an operator (e.g., bitnami/redis-operator or Redis Cluster setup).
- StorageClass and sizing may need adjustment to match your cluster provider.
- Consider adding PodDisruptionBudgets, readiness/liveness probes, and anti-affinity rules for HA.

References
- Fixes GitHub issue #6.

Please review the resource sizing, secrets reference, and whether we want a Redis PVC or operator before promoting to production.
