### PR TITLE
speed up backend docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,14 @@
-# Build stage with dependency caching optimization
+# syntax=docker/dockerfile:1.4
+
+# Build stage with cached dependencies
 FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
-# Install system dependencies for building Python packages
-# Group frequently changing packages separately for better caching
-RUN apt-get update && apt-get install -y \
+# Install build tools with apt cache
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
     libc6-dev \
@@ -13,61 +16,50 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     curl \
     git \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists*
 
-# Upgrade pip and install build tools in separate layer for caching
-RUN pip install --no-cache-dir --upgrade pip==24.3.1 setuptools==75.1.0 wheel==0.44.0
+# Upgrade pip and build tools
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip==24.3.1 setuptools==75.1.0 wheel==0.44.0
 
-# Copy requirements first for better layer caching
+# Install python dependencies using cached wheels when possible
 COPY requirements.txt ./
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefer-binary -r requirements.txt
 
-# Install dependencies and create wheels (optimized for caching)
-RUN pip wheel --no-cache-dir \
-    --wheel-dir /tmp/wheels \
-    -r requirements.txt \
-    && pip install --no-cache-dir \
-    --find-links /tmp/wheels \
-    -r requirements.txt
-
-# Copy pyproject.toml and install package in development mode (minimal impact)
 COPY pyproject.toml ./
-RUN pip install --no-cache-dir -e . --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefer-binary -e . --no-deps
 
 # Production runtime stage
 FROM python:3.12-slim AS runtime
 
 WORKDIR /app
 
-# Install minimal runtime dependencies in single layer
-RUN apt-get update && apt-get install -y \
+# Install minimal runtime dependencies
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     dumb-init \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists*
 
-# Create non-root user with specific UID for security
+# Create non-root user
 RUN groupadd -r -g 1001 appgroup && \
     useradd -r -u 1001 -g appgroup -d /home/appuser -s /bin/bash -c "App User" appuser && \
     mkdir -p /home/appuser && \
     chown -R appuser:appgroup /home/appuser
 
-# Install dependencies from wheels (faster than copying site-packages)
-RUN pip install --no-cache-dir --upgrade pip==24.3.1
-COPY --from=builder /tmp/wheels /tmp/wheels
-COPY --from=builder /app/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --no-index --find-links /tmp/wheels -r /tmp/requirements.txt \
-    && rm -rf /tmp/wheels /tmp/requirements.txt
-
-# Copy application code with proper ownership
+# Copy installed packages and application code
+COPY --from=builder /usr/local /usr/local
 COPY --chown=appuser:appgroup app ./app
 
 # Create necessary directories and set permissions
 RUN mkdir -p /app/logs /tmp/app && \
     chown -R appuser:appgroup /app/logs /tmp/app
 
-# Set comprehensive environment variables for production
+# Environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONIOENCODING=utf-8 \
@@ -78,17 +70,13 @@ ENV PYTHONUNBUFFERED=1 \
     TMPDIR=/tmp/app \
     HOME=/home/appuser
 
-# Switch to non-root user
 USER appuser
 
-# Expose application and metrics ports
 EXPOSE 8000 9000
 
-# Enhanced health check with proper error handling
 HEALTHCHECK --interval=30s --timeout=15s --start-period=60s --retries=3 \
     CMD curl -f -X GET http://localhost:8000/healthz || exit 1
 
-# Production-optimized command with proper signal handling using dumb-init
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["python", "-m", "uvicorn", "app.main:app", \
      "--host", "0.0.0.0", \


### PR DESCRIPTION
## Summary
- cache apt and pip operations in backend Docker build
- install dependencies with `--prefer-binary` and copy installed site-packages

## Testing
- `pytest backend/tests`
- `docker build -t backend-test backend` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_689e6e1e8a78832894ca19716b986cac