### PR TITLE
fix: lock apt cache during docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,8 +6,8 @@ FROM python:3.12-slim AS builder
 WORKDIR /app
 
 # Install build tools with apt cache
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /var/lib/apt/lists/lock && apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
@@ -37,8 +37,8 @@ FROM python:3.12-slim AS runtime
 WORKDIR /app
 
 # Install minimal runtime dependencies
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /var/lib/apt/lists/lock && apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \


### PR DESCRIPTION
## Summary
- lock apt cache mounts to avoid concurrent access during builds

## Testing
- `docker build backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689e89094ebc8328af8eceb7f18a1c9b