### PR TITLE
Add footer to frontend main page

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -290,6 +290,22 @@ export default function Home() {
           </div>
         </div>
       </main>
+      <footer className="text-center text-sm text-gray-500 py-4">
+        © 2025 sopher.ai •{' '}
+        <a
+          href="https://github.com/cheesejaguar/sopher.ai/blob/main/LICENSE"
+          className="underline"
+        >
+          MIT License
+        </a>{' '}
+        •{' '}
+        <a
+          href="https://github.com/cheesejaguar/sopher.ai"
+          className="underline"
+        >
+          GitHub Repository
+        </a>
+      </footer>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add footer with copyright and links to license and GitHub repo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689f77797d488328bd3306449d37274a