### PR TITLE
Add user-selectable model options for outline generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,9 +62,9 @@ DEBUG=false
 SQL_ECHO=false
 
 # Model selection (primary model for main operations)
-PRIMARY_MODEL=claude-3-5-sonnet
-SECONDARY_MODEL=gpt-4o
-OVERFLOW_MODEL=gemini-1.5-pro
+PRIMARY_MODEL=gpt-5
+SECONDARY_MODEL=claude-sonnet-4.0
+OVERFLOW_MODEL=gemini-2.5-pro
 
 # Cost controls
 MONTHLY_BUDGET_USD=100

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Production-ready AI book-writing system that transforms author briefs into compl
 ## Tech Stack 🧰
 
 - **Backend**: FastAPI, SQLAlchemy (async), PostgreSQL, Redis
-- **AI/ML**: LiteLLM, CrewAI, Claude 3.5 Sonnet, GPT-4o, Gemini 1.5 Pro
+- **AI/ML**: LiteLLM, CrewAI, ChatGPT-5, Claude Sonnet 4.0, Gemini 2.5 Pro
 - **Frontend**: Next.js 14 (App Router), TypeScript, Tailwind CSS, Zustand
 - **Infrastructure**: Docker, Kubernetes (GKE), Prometheus, Grafana
 - **CI/CD**: GitHub Actions, automated testing, security scanning
@@ -160,9 +160,9 @@ kubectl create secret generic sopher-ai-secrets \
 ### LiteLLM Router
 
 Configure model routing in `router/litellm.config.yaml`:
-- Primary: Claude 3.5 Sonnet
-- Secondary: GPT-4o
-- Overflow: Gemini 1.5 Pro
+- Primary: ChatGPT-5
+- Secondary: Claude Sonnet 4.0
+- Overflow: Gemini 2.5 Pro
 - Budget allocation by agent
 
 ### Environment Variables
@@ -183,7 +183,7 @@ See `.env.example` for a complete list with descriptions. Key variables:
 | `REDIS_URL` | Redis connection string | `redis://localhost:6379/0` |
 | `JWT_SECRET` | JWT signing secret | `dev-secret-key-change-in-production` |
 | `MONTHLY_BUDGET_USD` | Monthly cost limit | `100` |
-| `PRIMARY_MODEL` | Main LLM model | `claude-3-5-sonnet` |
+| `PRIMARY_MODEL` | Main LLM model | `gpt-5` |
 | `LOG_LEVEL` | Logging verbosity | `INFO` |
 | `CORS_ORIGINS` | Allowed origins | `http://localhost:3000` |
 

--- a/backend/app/agents/agents.py
+++ b/backend/app/agents/agents.py
@@ -12,7 +12,7 @@ class BookWritingAgents:
     """Collection of specialized agents for book writing"""
 
     def __init__(self, model: Optional[str] = None):
-        self.model = model or os.getenv("PRIMARY_MODEL", "claude-3-5-sonnet")
+        self.model = model or os.getenv("PRIMARY_MODEL", "gpt-5")
         self._setup_agents()
 
     def _setup_agents(self):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -88,7 +88,7 @@ class Cost(Base):
     id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
     session_id = Column(PGUUID(as_uuid=True), ForeignKey("sessions.id"), nullable=False)
     agent = Column(Text, nullable=False)  # writer, editor, etc.
-    model = Column(Text)  # claude-3-5-sonnet, gpt-4o, etc.
+    model = Column(Text)  # gpt-5, claude-sonnet-4.0, etc.
     prompt_tokens = Column(Integer, default=0)
     completion_tokens = Column(Integer, default=0)
     usd = Column(Numeric(10, 6), default=0)

--- a/backend/app/routers/outline.py
+++ b/backend/app/routers/outline.py
@@ -35,12 +35,15 @@ async def event_generator(
     active_sessions.inc()
     start_time = time.perf_counter()
     tokens_emitted = 0
-    model = "claude-3-5-sonnet"
+    model = outline_request.model
 
     try:
         # Check cache
         cache_key = cache.cache_key(
-            "outline", str(project_id), hashlib.md5(outline_request.brief.encode()).hexdigest()
+            "outline",
+            str(project_id),
+            outline_request.model,
+            hashlib.md5(outline_request.brief.encode()).hexdigest(),
         )
 
         cached_result = await cache.get(cache_key)
@@ -266,6 +269,7 @@ async def stream_outline(
             "style_guide": outline_request.style_guide,
             "genre": outline_request.genre,
             "target_chapters": outline_request.target_chapters,
+            "model": outline_request.model,
         },
     )
     db.add(session)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -52,6 +52,7 @@ class OutlineRequest(BaseModel):
     style_guide: Optional[str] = Field(None, max_length=5000)
     genre: Optional[str] = Field(None, max_length=50)
     target_chapters: int = Field(default=10, ge=1, le=50)
+    model: Literal["gpt-5", "claude-sonnet-4.0", "gemini-2.5-pro"] = "gpt-5"
 
 
 class ChapterDraftRequest(BaseModel):

--- a/backend/tests/test_properties.py
+++ b/backend/tests/test_properties.py
@@ -58,6 +58,7 @@ def valid_outline_request(draw):
         style_guide=draw(st.one_of(st.none(), st.text(max_size=500))),
         genre=draw(st.one_of(st.none(), st.text(max_size=50))),
         target_chapters=draw(st.integers(min_value=1, max_value=50)),
+        model=draw(st.sampled_from(["gpt-5", "claude-sonnet-4.0", "gemini-2.5-pro"])),
     )
 
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,6 +9,7 @@ export default function Home() {
   const [brief, setBrief] = useState('')
   const [styleGuide, setStyleGuide] = useState('')
   const [targetChapters, setTargetChapters] = useState(10)
+  const [model, setModel] = useState('gpt-5')
   const [streamedContent, setStreamedContent] = useState('')
   
   const messages = useStore((state: AppState) => state.messages)
@@ -68,6 +69,7 @@ export default function Home() {
           brief: brief.trim(),
           style_guide: styleGuide || '',
           target_chapters: targetChapters.toString(),
+          model,
         }),
         {
           withCredentials: true,
@@ -203,7 +205,23 @@ export default function Home() {
                   disabled={isGenerating}
                 />
               </div>
-              
+
+              <div>
+                <label className="block text-sm font-medium mb-2">
+                  Model
+                </label>
+                <select
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  disabled={isGenerating}
+                >
+                  <option value="gpt-5">ChatGPT-5 (Default)</option>
+                  <option value="claude-sonnet-4.0">Claude Sonnet 4.0</option>
+                  <option value="gemini-2.5-pro">Google Gemini 2.5 Pro</option>
+                </select>
+              </div>
+
               <div>
                 <label className="block text-sm font-medium mb-2">
                   Target Chapters

--- a/infra/.env.production.template
+++ b/infra/.env.production.template
@@ -37,9 +37,9 @@ GOOGLE_API_KEY=your-google-ai-key-here
 # =============================================================================
 # MODEL CONFIGURATION
 # =============================================================================
-PRIMARY_MODEL=claude-3-5-sonnet
-SECONDARY_MODEL=gpt-4o
-OVERFLOW_MODEL=gemini-1.5-pro
+PRIMARY_MODEL=gpt-5
+SECONDARY_MODEL=claude-sonnet-4.0
+OVERFLOW_MODEL=gemini-2.5-pro
 
 # =============================================================================
 # COST CONTROLS AND BUDGETS

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -52,7 +52,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
-      PRIMARY_MODEL: claude-3-5-sonnet
+      PRIMARY_MODEL: gpt-5
       CORS_ORIGINS: "http://localhost:3000,http://frontend:3000"
       LOG_LEVEL: INFO
     ports:

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -111,9 +111,9 @@ services:
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
       
       # Model Configuration
-      PRIMARY_MODEL: ${PRIMARY_MODEL:-claude-3-5-sonnet}
-      SECONDARY_MODEL: ${SECONDARY_MODEL:-gpt-4o}
-      OVERFLOW_MODEL: ${OVERFLOW_MODEL:-gemini-1.5-pro}
+      PRIMARY_MODEL: ${PRIMARY_MODEL:-gpt-5}
+      SECONDARY_MODEL: ${SECONDARY_MODEL:-claude-sonnet-4.0}
+      OVERFLOW_MODEL: ${OVERFLOW_MODEL:-gemini-2.5-pro}
       
       # Cost Controls
       MONTHLY_BUDGET_USD: ${MONTHLY_BUDGET_USD:-500}

--- a/infra/k8s/configmap.yaml
+++ b/infra/k8s/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sopher-ai-config
   namespace: sopher-ai
 data:
-  PRIMARY_MODEL: "claude-3-5-sonnet"
+  PRIMARY_MODEL: "gpt-5"
   LOG_LEVEL: "INFO"
   CORS_ORIGINS: "*"
   REDIS_DB: "0"

--- a/prompt.xml
+++ b/prompt.xml
@@ -79,9 +79,9 @@
   </db_schema>
 
   <model_routing>
-    <primary role="writer">anthropic/claude-3-5-sonnet</primary>
-    <secondary role="writer">openai/gpt-4o</secondary>
-    <overflow route_to="google/gemini-1.5-pro" reason="context_window_exceeded"/>
+    <primary role="writer">openai/gpt-5</primary>
+    <secondary role="writer">anthropic/claude-4.0-sonnet</secondary>
+    <overflow route_to="google/gemini-2.5-pro" reason="context_window_exceeded"/>
     <cache>
       <response ttl="3600s"/>
       <history ttl="86400s"/>

--- a/router/litellm.config.yaml
+++ b/router/litellm.config.yaml
@@ -1,35 +1,21 @@
 model_list:
-  - model_name: claude-3-5-sonnet
+  - model_name: gpt-5
     litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
+      model: openai/gpt-5
+      api_key: ${OPENAI_API_KEY}
+      max_tokens: 8192
+      temperature: 0.7
+
+  - model_name: claude-sonnet-4.0
+    litellm_params:
+      model: anthropic/claude-4.0-sonnet
       api_key: ${ANTHROPIC_API_KEY}
       max_tokens: 8192
       temperature: 0.7
-      
-  - model_name: gpt-4o
+
+  - model_name: gemini-2.5-pro
     litellm_params:
-      model: openai/gpt-4o
-      api_key: ${OPENAI_API_KEY}
-      max_tokens: 4096
-      temperature: 0.7
-      
-  - model_name: gpt-4o-mini
-    litellm_params:
-      model: openai/gpt-4o-mini
-      api_key: ${OPENAI_API_KEY}
-      max_tokens: 4096
-      temperature: 0.7
-      
-  - model_name: gemini-1.5-pro
-    litellm_params:
-      model: google/gemini-1.5-pro-latest
-      api_key: ${GOOGLE_API_KEY}
-      max_tokens: 8192
-      temperature: 0.7
-      
-  - model_name: gemini-1.5-flash
-    litellm_params:
-      model: google/gemini-1.5-flash-latest
+      model: google/gemini-2.5-pro
       api_key: ${GOOGLE_API_KEY}
       max_tokens: 8192
       temperature: 0.7
@@ -37,17 +23,17 @@ model_list:
 routing:
   strategy: usage-based-routing
   fallbacks:
-    - primary: claude-3-5-sonnet
-      secondary: gpt-4o
-    - primary: gpt-4o
-      secondary: claude-3-5-sonnet
+    - primary: gpt-5
+      secondary: claude-sonnet-4.0
+    - primary: claude-sonnet-4.0
+      secondary: gpt-5
   overflow:
     trigger: context_window_exceeded
-    route_to: gemini-1.5-pro
+    route_to: gemini-2.5-pro
   cheap_fallback:
     models:
-      - gpt-4o-mini
-      - gemini-1.5-flash
+      - claude-sonnet-4.0
+      - gemini-2.5-pro
 
 redis:
   url: ${REDIS_URL:-redis://localhost:6379/0}


### PR DESCRIPTION
## Summary
- allow choosing language model in outline requests
- wire selected model through backend processing
- expose model dropdown in the book configuration UI
- configure LiteLLM router and infrastructure defaults for gpt-5, claude-sonnet-4.0, and gemini-2.5-pro

## Testing
- `pip install hypothesis setuptools pytest-asyncio`
- `cd backend && PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f76ce08fc8328842153a038de8f35