### PR TITLE
test: verify color contrast for teal on indigo

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "node tests/color-contrast.test.js"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.0",

--- a/frontend/tests/color-contrast.test.js
+++ b/frontend/tests/color-contrast.test.js
@@ -1,0 +1,55 @@
+/* eslint-env node */
+const assert = require('assert');
+
+/**
+ * Convert a hex color string to its relative luminance.
+ * @param {string} hex - Hex color in the form '#RRGGBB'
+ * @returns {number} Relative luminance
+ */
+function luminance(hex) {
+  const raw = hex.replace('#', '');
+  const r = parseInt(raw.slice(0, 2), 16) / 255;
+  const g = parseInt(raw.slice(2, 4), 16) / 255;
+  const b = parseInt(raw.slice(4, 6), 16) / 255;
+
+  const [rLin, gLin, bLin] = [r, g, b].map((c) =>
+    c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+  );
+
+  return 0.2126 * rLin + 0.7152 * gLin + 0.0722 * bLin;
+}
+
+/**
+ * Calculate contrast ratio between two hex colors.
+ * @param {string} fg - Foreground color
+ * @param {string} bg - Background color
+ * @returns {number} Contrast ratio
+ */
+function contrast(fg, bg) {
+  const l1 = luminance(fg);
+  const l2 = luminance(bg);
+  const [bright, dark] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (bright + 0.05) / (dark + 0.05);
+}
+
+const colors = {
+  teal: '#11C5B2',
+  indigo: '#1B2559',
+};
+
+const combinations = [
+  {
+    fg: colors.teal,
+    bg: colors.indigo,
+    description: 'teal text on indigo background',
+  },
+];
+
+for (const combo of combinations) {
+  const ratio = contrast(combo.fg, combo.bg);
+  assert(
+    ratio >= 4.5,
+    `${combo.description} contrast ratio ${ratio.toFixed(2)} fails WCAG AA`
+  );
+  console.log(`✓ ${combo.description} contrast ratio ${ratio.toFixed(2)} passes WCAG AA`);
+}


### PR DESCRIPTION
## Summary
- add npm script to run accessibility contrast check
- verify teal text on indigo background meets WCAG AA contrast ratio

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f5e598b08328974e0abd1bfed7b5