### PR TITLE
fix: pin footer to bottom

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -145,7 +145,7 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-parchment dark:bg-indigo">
+    <div className="flex min-h-screen flex-col bg-parchment dark:bg-indigo">
       {/* Header */}
       <header className="sticky top-0 z-10 border-b border-slate bg-indigo text-snow">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
@@ -171,7 +171,7 @@ export default function Home() {
       </header>
 
       {/* Main Content */}
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto flex-1 px-4 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Input Panel */}
           <div className="lg:col-span-1">

--- a/index.html
+++ b/index.html
@@ -48,19 +48,21 @@
             padding: 0;
             background-color: var(--bg);
             color: var(--text);
-            display: flex;
-            justify-content: center;
-            align-items: center;
             min-height: 100vh;
+            display: flex;
+            flex-direction: column;
         }
 
         .container {
             max-width: 800px;
-            margin: 2rem;
+            margin: 2rem auto;
             padding: 2rem;
             background-color: var(--card);
             border-radius: var(--border-radius);
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+            flex: 1;
+            display: flex;
+            flex-direction: column;
         }
 
         header { text-align: center; }
@@ -119,7 +121,7 @@
 
         /* Footer */
         .footer {
-            margin-top: 2rem;
+            margin-top: auto;
             font-size: 0.95rem;
             color: #606770;
             text-align: center;


### PR DESCRIPTION
## Summary
- Ensure the Next.js app layout stretches to full height so the footer stays at the bottom.
- Update static landing page CSS to anchor the footer at the bottom of the viewport.

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a22501afdc8328be727c3b53cc4fc1