### PR TITLE
[GPT-5 prompt gen into Codex] improve error handling and diagnostics

### DIFF
--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,0 +1,69 @@
+"""Utilities for standardized API errors."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, Optional
+from uuid import uuid4
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+# Context variable to store request ID
+request_id_ctx_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class ErrorCode(str, Enum):
+    """Common API error codes."""
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_FOUND = "NOT_FOUND"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    FORBIDDEN = "FORBIDDEN"
+    METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"
+    HTTP_ERROR = "HTTP_ERROR"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    OUTLINE_INVALID_PARAMETER = "OUTLINE_INVALID_PARAMETER"
+    OUTLINE_STREAM_INIT_FAILED = "OUTLINE_STREAM_INIT_FAILED"
+
+
+class APIError(BaseModel):
+    """Pydantic model for API error responses."""
+
+    error_id: str
+    error_code: str
+    message: str
+    hint: Optional[str] = None
+    details: Optional[Dict[str, object]] = None
+    request_id: str
+    timestamp: str
+
+
+def generate_error_id() -> str:
+    """Generate a UUIDv4 error ID."""
+
+    return str(uuid4())
+
+
+def api_error(
+    code: str,
+    message: str,
+    *,
+    hint: str | None = None,
+    details: Dict[str, object] | None = None,
+    status: int = 400,
+) -> JSONResponse:
+    """Create a standardized API error response."""
+
+    error = APIError(
+        error_id=generate_error_id(),
+        error_code=code,
+        message=message,
+        hint=hint,
+        details=details,
+        request_id=request_id_ctx_var.get(),
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+    return JSONResponse(status_code=status, content=error.model_dump())

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,33 @@
+"""Middleware utilities for request handling."""
+
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+from .errors import request_id_ctx_var
+
+logger = logging.getLogger(__name__)
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Middleware to attach a request ID to each request."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        request_id = request.headers.get("X-Request-ID", f"req-{uuid4()}")
+        request.state.request_id = request_id
+        request_id_ctx_var.set(request_id)
+        logger.info(
+            "request start",
+            extra={"request_id": request_id, "path": request.url.path, "method": request.method},
+        )
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response

--- a/backend/app/routers/outline.py
+++ b/backend/app/routers/outline.py
@@ -8,7 +8,6 @@ from typing import AsyncIterator, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response, status
-from fastapi.responses import JSONResponse
 from litellm import acompletion
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse

--- a/backend/app/routers/outline.py
+++ b/backend/app/routers/outline.py
@@ -2,11 +2,13 @@
 
 import hashlib
 import json
+import logging
 import time
 from typing import AsyncIterator, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response, status
+from fastapi.responses import JSONResponse
 from litellm import acompletion
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
@@ -14,12 +16,15 @@ from sse_starlette.sse import EventSourceResponse
 from ..agents.agents import BookWritingAgents
 from ..cache import cache
 from ..db import get_db
+from ..errors import ErrorCode, api_error
 from ..metrics import MetricsTracker, active_sessions
 from ..models import Artifact, Cost, Event, Session
 from ..schemas import OutlineRequest
 from ..security import TokenData, get_current_user
 
 router = APIRouter(prefix="/projects/{project_id}", tags=["outline"])
+
+logger = logging.getLogger(__name__)
 
 
 async def event_generator(
@@ -225,7 +230,27 @@ Format as structured markdown."""
 
     except Exception as e:
         MetricsTracker.track_model_error(model, type(e).__name__)
-        yield {"event": "error", "data": json.dumps({"error": str(e)})}
+        err_response = api_error(
+            ErrorCode.OUTLINE_STREAM_INIT_FAILED.value,
+            "Could not start the outline stream.",
+            hint="Retry in a few seconds. If it persists, check service readiness or credentials.",
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+        body_bytes = bytes(err_response.body)
+        body = body_bytes.decode()
+        data = json.loads(body)
+        logger.error(
+            f"outline stream failed: {e}",
+            extra={
+                "error_id": data["error_id"],
+                "request_id": data["request_id"],
+                "error_code": data["error_code"],
+                "path": request.url.path,
+                "method": request.method,
+                "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
+            },
+        )
+        yield {"event": "error", "data": body}
     finally:
         active_sessions.dec()
 
@@ -241,16 +266,56 @@ async def stream_outline(
     db: AsyncSession = Depends(get_db),
     user: TokenData = Depends(get_current_user),
     background_tasks: BackgroundTasks = BackgroundTasks(),
-) -> EventSourceResponse:
+) -> Response:
     """Stream outline generation via Server-Sent Events"""
 
     # Validate brief length
     if len(brief) < 10 or len(brief) > 10000:
-        raise HTTPException(status_code=422, detail="Brief must be between 10 and 10000 characters")
+        MetricsTracker.track_api_request(request.method, request.url.path, 422)
+        response = api_error(
+            ErrorCode.OUTLINE_INVALID_PARAMETER.value,
+            "Brief must be between 10 and 10000 characters.",
+            hint="Ensure 'brief' is 10-10000 characters.",
+            details={"field": "brief"},
+            status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+        data = json.loads(response.body)
+        logger.error(
+            "invalid parameter",
+            extra={
+                "error_id": data["error_id"],
+                "request_id": data["request_id"],
+                "error_code": data["error_code"],
+                "path": request.url.path,
+                "method": request.method,
+                "status": status.HTTP_422_UNPROCESSABLE_ENTITY,
+            },
+        )
+        return response
 
     # Validate target_chapters
     if target_chapters < 1 or target_chapters > 50:
-        raise HTTPException(status_code=422, detail="Target chapters must be between 1 and 50")
+        MetricsTracker.track_api_request(request.method, request.url.path, 422)
+        response = api_error(
+            ErrorCode.OUTLINE_INVALID_PARAMETER.value,
+            "Target chapters must be between 1 and 50.",
+            hint="Provide a value between 1 and 50.",
+            details={"field": "target_chapters"},
+            status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+        data = json.loads(response.body)
+        logger.error(
+            "invalid parameter",
+            extra={
+                "error_id": data["error_id"],
+                "request_id": data["request_id"],
+                "error_code": data["error_code"],
+                "path": request.url.path,
+                "method": request.method,
+                "status": status.HTTP_422_UNPROCESSABLE_ENTITY,
+            },
+        )
+        return response
 
     # Create outline request from query parameters
     outline_request = OutlineRequest(
@@ -277,7 +342,7 @@ async def stream_outline(
     await db.refresh(session)
 
     # Track API request
-    MetricsTracker.track_api_request("POST", "/outline/stream", 200)
+    MetricsTracker.track_api_request(request.method, request.url.path, 200)
 
     return EventSourceResponse(
         event_generator(

--- a/backend/tests/test_errors.py
+++ b/backend/tests/test_errors.py
@@ -40,4 +40,3 @@ def test_api_error_builds_response_with_context():
     assert payload["request_id"] == "req-test-123"
     # timestamp is ISO8601
     datetime.fromisoformat(payload["timestamp"])
-

--- a/backend/tests/test_errors.py
+++ b/backend/tests/test_errors.py
@@ -1,0 +1,43 @@
+"""Tests for standardized API error utilities."""
+
+import json
+from datetime import datetime
+from unittest.mock import patch
+from uuid import UUID
+
+from fastapi.responses import JSONResponse
+
+from app.errors import ErrorCode, api_error, generate_error_id, request_id_ctx_var
+
+
+def test_generate_error_id_produces_uuid4():
+    """generate_error_id should return a valid UUID4 string."""
+    eid = generate_error_id()
+    uuid_obj = UUID(eid, version=4)
+    assert str(uuid_obj) == eid
+
+
+def test_api_error_builds_response_with_context():
+    """api_error should include request context and structured fields."""
+    request_id_ctx_var.set("req-test-123")
+    fixed_id = "00000000-0000-4000-8000-000000000000"
+    with patch("app.errors.generate_error_id", return_value=fixed_id):
+        response = api_error(
+            ErrorCode.NOT_FOUND,
+            "Resource missing",
+            hint="Verify resource identifier",
+            details={"item": "value"},
+            status=404,
+        )
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 404
+    payload = json.loads(response.body)
+    assert payload["error_id"] == fixed_id
+    assert payload["error_code"] == ErrorCode.NOT_FOUND
+    assert payload["message"] == "Resource missing"
+    assert payload["hint"] == "Verify resource identifier"
+    assert payload["details"] == {"item": "value"}
+    assert payload["request_id"] == "req-test-123"
+    # timestamp is ISO8601
+    datetime.fromisoformat(payload["timestamp"])
+

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,6 +11,14 @@ export default function Home() {
   const [targetChapters, setTargetChapters] = useState(10)
   const [model, setModel] = useState('gpt-5')
   const [streamedContent, setStreamedContent] = useState('')
+  const [errorInfo, setErrorInfo] = useState<
+    | null
+    | {
+        message: string
+        hint?: string
+        diagnostics?: { error_id?: string; request_id?: string; error_code?: string; timestamp: string }
+      }
+  >(null)
   
   const messages = useStore((state: AppState) => state.messages)
   const addMessage = useStore((state: AppState) => state.addMessage)
@@ -33,6 +41,7 @@ export default function Home() {
     setGenerating(true)
     setProgress(0)
     setStreamedContent('')
+    setErrorInfo(null)
     
     // Add user message
     addMessage({
@@ -116,16 +125,46 @@ export default function Home() {
         console.error('SSE error:', event)
         eventSource.close()
         setGenerating(false)
-        
-        // Add error message
+
+        if (event instanceof MessageEvent && event.data) {
+          try {
+            const err = JSON.parse(event.data)
+            setErrorInfo({
+              message: err.message,
+              hint: err.hint,
+              diagnostics: {
+                error_id: err.error_id,
+                request_id: err.request_id,
+                error_code: err.error_code,
+                timestamp: err.timestamp,
+              },
+            })
+            addMessage({
+              id: Date.now().toString(),
+              role: 'system',
+              content: `Error: ${err.message}${err.hint ? ` Hint: ${err.hint}` : ''}`,
+              timestamp: new Date(),
+            })
+            return
+          } catch (e) {
+            console.error('Error parsing server error:', e)
+          }
+        }
+
+        const ts = new Date().toISOString()
+        setErrorInfo({
+          message: 'Connection issue: outline stream',
+          hint: 'Possible CORS, network, or server issue. Retry in a few seconds.',
+          diagnostics: { timestamp: ts, error_code: 'CONNECTION_ERROR' },
+        })
         addMessage({
           id: Date.now().toString(),
           role: 'system',
-          content: 'Error: Failed to generate outline. Please try again.',
+          content: 'Connection issue: outline stream. Please retry.',
           timestamp: new Date(),
         })
       })
-      
+
       eventSource.onerror = () => {
         eventSource.close()
         setGenerating(false)
@@ -134,11 +173,16 @@ export default function Home() {
     } catch (error) {
       console.error('Error starting generation:', error)
       setGenerating(false)
-      
+      const ts = new Date().toISOString()
+      setErrorInfo({
+        message: 'Connection issue: outline stream',
+        hint: 'Possible CORS, network, or server issue. Retry in a few seconds.',
+        diagnostics: { timestamp: ts, error_code: 'CONNECTION_ERROR' },
+      })
       addMessage({
         id: Date.now().toString(),
         role: 'system',
-        content: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        content: 'Connection issue: outline stream. Please retry.',
         timestamp: new Date(),
       })
     }
@@ -172,6 +216,24 @@ export default function Home() {
 
       {/* Main Content */}
       <main className="container mx-auto px-4 py-8">
+        {errorInfo && (
+          <div className="mb-4 border border-red-200 bg-red-50 text-red-800 p-4 rounded">
+            <p className="font-semibold">{errorInfo.message}</p>
+            {errorInfo.hint && <p className="text-sm mt-1">{errorInfo.hint}</p>}
+            {errorInfo.diagnostics && (
+              <button
+                className="mt-2 text-sm underline"
+                onClick={() =>
+                  navigator.clipboard.writeText(
+                    JSON.stringify(errorInfo.diagnostics)
+                  )
+                }
+              >
+                Copy diagnostics
+              </button>
+            )}
+          </div>
+        )}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Input Panel */}
           <div className="lg:col-span-1">


### PR DESCRIPTION
## Summary
- standardize API error responses with APIError model and helper utilities
- add request ID middleware and detailed exception handlers
- surface structured errors and diagnostics in outline streaming UI
- add unit tests for API error utilities

## Testing
- `ruff check . --fix && ruff check .`
- `mypy .`
- `PYTHONPATH=. pytest -q`
- `npm run type-check`
- `npm run lint`
- `pre-commit run --files app/errors.py app/middleware.py app/main.py app/routers/outline.py ../frontend/app/page.tsx tests/test_errors.py` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a22279e95c83289327cba604db0893