### PR TITLE
chore: fix lint in outline router

### DIFF
--- a/backend/app/routers/outline.py
+++ b/backend/app/routers/outline.py
@@ -8,7 +8,6 @@ from typing import AsyncIterator, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Request, Response, status
-from fastapi.responses import JSONResponse
 from litellm import acompletion
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse

--- a/backend/tests/test_errors.py
+++ b/backend/tests/test_errors.py
@@ -40,4 +40,3 @@ def test_api_error_builds_response_with_context():
     assert payload["request_id"] == "req-test-123"
     # timestamp is ISO8601
     datetime.fromisoformat(payload["timestamp"])
-


### PR DESCRIPTION
## Summary
- remove unused import from outline router
- format test_errors for black

## Testing
- `ruff check app tests`
- `black --check app tests`
- `mypy app`
- `pytest tests/ -v --cov=app --cov-report=term --cov-report=xml`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2f402226c83289540a710fbdd55ab