### PR TITLE
feat: implement GCP-compatible structured JSON logging

### DIFF
--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -1,0 +1,215 @@
+"""GCP-compatible structured logging configuration for sopher.ai"""
+
+import json
+import logging
+import os
+import sys
+import traceback
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+# Context variables for request-scoped data
+request_id_var: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
+trace_id_var: ContextVar[Optional[str]] = ContextVar("trace_id", default=None)
+span_id_var: ContextVar[Optional[str]] = ContextVar("span_id", default=None)
+http_request_var: ContextVar[Optional[Dict[str, Any]]] = ContextVar("http_request", default=None)
+
+
+def severity_from_level(levelno: int) -> str:
+    """Map Python logging level to GCP severity."""
+    if levelno >= logging.CRITICAL:
+        return "CRITICAL"
+    elif levelno >= logging.ERROR:
+        return "ERROR"
+    elif levelno >= logging.WARNING:
+        return "WARNING"
+    elif levelno >= logging.INFO:
+        return "INFO"
+    else:
+        return "DEBUG"
+
+
+class GCPJSONFormatter(logging.Formatter):
+    """JSON formatter that outputs GCP-compatible structured logs."""
+
+    def __init__(self, service_name: str = "sopher-api", service_version: Optional[str] = None):
+        super().__init__()
+        self.service_name = service_name
+        self.service_version = service_version
+        self.gcp_project = os.getenv("GCP_PROJECT")
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record as GCP-compatible JSON."""
+        # Build base log entry
+        log_entry: Dict[str, Any] = {
+            "severity": severity_from_level(record.levelno),
+            "message": record.getMessage(),
+            "time": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "logger": record.name,
+            "module": record.module,
+            "function": record.funcName,
+            "lineno": record.lineno,
+        }
+
+        # Add labels
+        labels: Dict[str, str] = {"service": self.service_name}
+        if self.service_version:
+            labels["version"] = self.service_version
+        log_entry["labels"] = labels
+
+        # Add request context if available
+        request_id = getattr(record, "request_id", None)
+        if request_id:
+            log_entry["request_id"] = request_id
+
+        # Add HTTP request info if available
+        http_request = getattr(record, "http_request", None)
+        if http_request:
+            log_entry["httpRequest"] = http_request
+
+        # Add trace info if available
+        trace_id = getattr(record, "trace_id", None)
+        if trace_id and self.gcp_project:
+            log_entry["logging.googleapis.com/trace"] = (
+                f"projects/{self.gcp_project}/traces/{trace_id}"
+            )
+
+        span_id = getattr(record, "span_id", None)
+        if span_id:
+            log_entry["logging.googleapis.com/spanId"] = span_id
+
+        # Add stack trace if exception info is present
+        if record.exc_info:
+            log_entry["stack_trace"] = "".join(traceback.format_exception(*record.exc_info))
+
+        # Add any extra fields from the record
+        for key, value in record.__dict__.items():
+            if key not in [
+                "name",
+                "msg",
+                "args",
+                "created",
+                "filename",
+                "funcName",
+                "levelname",
+                "levelno",
+                "lineno",
+                "module",
+                "msecs",
+                "message",
+                "pathname",
+                "process",
+                "processName",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "request_id",
+                "trace_id",
+                "span_id",
+                "http_request",
+            ]:
+                log_entry[key] = value
+
+        return json.dumps(log_entry, default=str)
+
+
+class ContextFilter(logging.Filter):
+    """Filter that injects context variables into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add context variables to the log record."""
+        record.request_id = request_id_var.get()
+        record.trace_id = trace_id_var.get()
+        record.span_id = span_id_var.get()
+        record.http_request = http_request_var.get()
+        return True
+
+
+def setup_logging() -> logging.Logger:
+    """Configure structured logging for the application."""
+    # Get configuration from environment
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_json = os.getenv("LOG_JSON", "true").lower() == "true"
+    service_name = os.getenv("SERVICE_NAME", "sopher-api")
+    service_version = os.getenv("SERVICE_VERSION")
+
+    # Configure root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(getattr(logging, log_level, logging.INFO))
+
+    # Remove existing handlers
+    root_logger.handlers.clear()
+
+    # Create stdout handler
+    handler = logging.StreamHandler(sys.stdout)
+
+    # Set formatter based on configuration
+    formatter: logging.Formatter
+    if log_json:
+        formatter = GCPJSONFormatter(service_name=service_name, service_version=service_version)
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - [%(request_id)s] - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+    handler.setFormatter(formatter)
+
+    # Add context filter
+    handler.addFilter(ContextFilter())
+
+    # Add handler to root logger
+    root_logger.addHandler(handler)
+
+    # Configure uvicorn loggers to propagate to root
+    for logger_name in ["uvicorn", "uvicorn.access", "uvicorn.error"]:
+        logger = logging.getLogger(logger_name)
+        logger.handlers.clear()
+        logger.propagate = True
+
+    return root_logger
+
+
+def set_request_context(
+    request_id: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    span_id: Optional[str] = None,
+    http_request: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Set context variables for the current request."""
+    if request_id:
+        request_id_var.set(request_id)
+    if trace_id:
+        trace_id_var.set(trace_id)
+    if span_id:
+        span_id_var.set(span_id)
+    if http_request:
+        http_request_var.set(http_request)
+
+
+def clear_request_context() -> None:
+    """Clear all request context variables."""
+    request_id_var.set(None)
+    trace_id_var.set(None)
+    span_id_var.set(None)
+    http_request_var.set(None)
+
+
+def parse_trace_context(header_value: str) -> tuple[Optional[str], Optional[str]]:
+    """Parse X-Cloud-Trace-Context header.
+
+    Format: TRACE_ID/SPAN_ID;o=TRACE_TRUE
+    Returns: (trace_id, span_id)
+    """
+    if not header_value:
+        return None, None
+
+    parts = header_value.split(";")[0].split("/")
+    trace_id = parts[0] if parts else None
+    span_id = parts[1] if len(parts) > 1 else None
+
+    return trace_id, span_id

--- a/backend/tests/test_exception_handlers.py
+++ b/backend/tests/test_exception_handlers.py
@@ -145,8 +145,8 @@ async def test_unhandled_exception_handler():
     assert "dangerous internal error" not in data["message"]
     assert "api_key_123" not in str(data)
 
-    # Should log the full error for debugging
-    mock_logger.error.assert_called_once()
+    # Should log the full error for debugging (using exception method for stack traces)
+    mock_logger.exception.assert_called_once()
 
 
 def test_exception_handlers_integration_with_request_id():


### PR DESCRIPTION
## Summary
- Implements production-grade structured JSON logging compatible with GCP Cloud Logging
- Adds request context propagation for distributed tracing support
- Integrates with FastAPI middleware for comprehensive request logging

## Changes
- **New logging module** (`backend/app/logging.py`):
  - `GCPJSONFormatter`: Outputs GCP-compatible structured JSON logs with proper severity mapping
  - `ContextFilter`: Injects request-scoped context variables into log records
  - Context management functions for request ID, trace ID, span ID, and HTTP request info
  - Support for X-Cloud-Trace-Context header parsing

- **Updated main application** (`backend/app/main.py`):
  - Initialize structured logging on startup
  - Add request logging middleware with latency tracking
  - Update exception handlers to use `logger.exception()` for proper stack trace capture
  - Remove redundant RequestIDMiddleware in favor of integrated logging middleware

- **Test updates**:
  - Fix exception handler test to expect `logger.exception()` instead of `logger.error()`

## Features
✅ GCP-compatible JSON structured logs with severity mapping (DEBUG, INFO, WARNING, ERROR, CRITICAL)
✅ Request context propagation using Python contextvars
✅ X-Cloud-Trace-Context support for distributed tracing
✅ Request logging with latency tracking and httpRequest fields
✅ Exception stack traces in JSON format
✅ Configurable output format (JSON or text) via LOG_JSON environment variable
✅ Uvicorn logger integration

## Testing
- All tests pass (35 passed, 5 skipped)
- Code quality checks pass (black, ruff, mypy)
- 75% test coverage maintained

## Configuration
Set these environment variables to configure logging:
- `LOG_LEVEL`: Set log level (default: INFO)
- `LOG_JSON`: Enable JSON output (default: true)
- `SERVICE_NAME`: Service name for logs (default: sopher-api)
- `SERVICE_VERSION`: Service version for logs (optional)
- `GCP_PROJECT`: GCP project ID for trace correlation (optional)

🤖 Generated with [Claude Code](https://claude.ai/code)