### PR TITLE
Fix: Docker build failure after removing standalone mode

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -70,8 +70,9 @@ COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
 
 # Copy built application files with proper ownership
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nodejs /app/next.config.js ./next.config.js
 
 # Switch to non-root user
 USER nextjs
@@ -85,4 +86,4 @@ HEALTHCHECK --interval=30s --timeout=15s --start-period=60s --retries=3 \
 
 # Use dumb-init for proper signal handling in containers
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "server.js"]
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
Fixes the Docker build failure on main branch caused by the removal of `output: 'standalone'` from next.config.js.

## Problem
The previous PR #52 removed `output: 'standalone'` from next.config.js to fix Lighthouse CI issues, but the Dockerfile still expected the standalone build output, causing CI/CD failures on main branch.

## Solution
Updated the Dockerfile to work with standard Next.js build output:
- Copy entire `.next` directory instead of `.next/standalone`
- Copy `package.json` and `next.config.js` for runtime
- Use `npm start` instead of `node server.js`

## Testing
- Docker build should now succeed
- Application runs correctly with the standard build

## Related
- Fixes CI/CD failure introduced after merging #52
- Completes the migration away from standalone mode

🤖 Generated with [Claude Code](https://claude.ai/code)