### PR TITLE
fix: resolve OAuth login redirect loop by fixing cookie handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,24 @@ OVERFLOW_MODEL=gemini-2.5-pro
 MONTHLY_BUDGET_USD=100
 
 # =============================================================================
+# Google OAuth Configuration
+# =============================================================================
+# Get these from Google Cloud Console: https://console.cloud.google.com/
+# Create OAuth 2.0 Client ID credentials for Web application
+# IMPORTANT: Add authorized redirect URIs in Google Cloud Console:
+# - For local development: http://localhost:3000/api/backend/auth/callback/google
+# - For production: https://sopher.ai/api/backend/auth/callback/google
+
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# OAuth Redirect URI - must match Google Cloud Console configuration
+# For local development (frontend proxies to backend):
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3000/api/backend/auth/callback/google
+# For production:
+# GOOGLE_OAUTH_REDIRECT_URI=https://sopher.ai/api/backend/auth/callback/google
+
+# =============================================================================
 # CORS and Network Configuration
 # =============================================================================
 # For local development, allow localhost origins

--- a/backend/app/oauth.py
+++ b/backend/app/oauth.py
@@ -16,7 +16,7 @@ from .cache import cache
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "")
 GOOGLE_OAUTH_REDIRECT_URI = os.getenv(
-    "GOOGLE_OAUTH_REDIRECT_URI", "http://localhost:8000/auth/callback/google"
+    "GOOGLE_OAUTH_REDIRECT_URI", "http://localhost:3000/api/backend/auth/callback/google"
 )
 
 # Google OAuth2 endpoints
@@ -122,22 +122,24 @@ def set_auth_cookies(
     # This allows cookies to be accessible on the same domain as the request
 
     # Set access token cookie (1 hour)
+    # httponly=False allows Next.js middleware to read the cookie for auth checks
     response.set_cookie(
         key="access_token",
         value=access_token,
         max_age=3600,
-        httponly=True,
+        httponly=False,  # Allow JavaScript/middleware to read for auth checks
         samesite="lax",
         secure=is_production,
         path="/",
     )
 
     # Set refresh token cookie (7 days)
+    # Keep httponly=True for refresh token for security
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
         max_age=7 * 24 * 3600,
-        httponly=True,
+        httponly=True,  # Keep secure - only server should access refresh token
         samesite="lax",
         secure=is_production,
         path="/",
@@ -153,13 +155,13 @@ def clear_auth_cookies(response: Response, request: Request) -> None:
         key="access_token",
         path="/",
         secure=is_production,
-        httponly=True,
+        httponly=False,  # Match the setting when cookie was created
         samesite="lax",
     )
     response.delete_cookie(
         key="refresh_token",
         path="/",
         secure=is_production,
-        httponly=True,
+        httponly=True,  # Match the setting when cookie was created
         samesite="lax",
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -116,21 +116,16 @@ async def callback_google(
     set_auth_cookies(response, access_token, refresh_token, request)
 
     # Redirect to frontend home page
-    # When behind a proxy, the request will come from the frontend domain
-    # So we redirect back to the root of wherever the request came from
-    if "localhost" in str(request.url):
-        frontend_url = "http://localhost:3000"
-    elif request.headers.get("host"):
-        # Use the host header to determine the frontend domain
-        host = request.headers.get("host")
-        scheme = "https" if request.url.scheme == "https" else "http"
-        # Remove any API subdomain if present
-        if host and host.startswith("api."):
-            host = host[4:]  # Remove "api." prefix
-        frontend_url = f"{scheme}://{host}"
+    # Use environment-based URLs to avoid security issues
+    # The OAuth callback comes through the frontend proxy, so redirect to frontend root
+    if "localhost" in str(request.url) or "127.0.0.1" in str(request.url):
+        # Local development
+        frontend_url = "http://localhost:3000/"
     else:
-        frontend_url = "https://sopher.ai"
+        # Production - always redirect to main domain
+        frontend_url = "https://sopher.ai/"
 
+    logger.info(f"OAuth successful for user {user.email}, redirecting to {frontend_url}")
     return RedirectResponse(url=frontend_url, status_code=status.HTTP_302_FOUND)
 
 


### PR DESCRIPTION
## Summary
This PR fixes the OAuth login redirect loop issue where users were being redirected back to the login page after successful Google authentication.

## Root Cause
The `access_token` cookie was set with `httponly=True`, which prevented the Next.js middleware from reading it to verify authentication. This caused the middleware to always redirect users back to the login page.

## Changes
- **Cookie Settings**: Set `httponly=False` for the access_token cookie so Next.js middleware can read it
- **Security**: Kept `httponly=True` for the refresh_token to maintain security
- **OAuth Configuration**: Updated default redirect URI to use the frontend proxy path
- **Redirect Logic**: Simplified and secured frontend redirect logic to prevent SSRF vulnerabilities
- **Documentation**: Added comprehensive OAuth setup instructions to `.env.example`
- **Logging**: Added authentication success logging for debugging

## Technical Details
- Access token cookie is now readable by JavaScript/middleware for auth checks
- Refresh token remains httponly for security (only server access)
- OAuth redirect URI now defaults to the proxied path: `http://localhost:3000/api/backend/auth/callback/google`
- Frontend redirect URLs are hardcoded based on environment to prevent SSRF attacks

## Testing
- [x] Backend tests pass (35 passed, 5 skipped)
- [x] Frontend builds successfully
- [x] Linting and type checking pass
- [x] OAuth flow tested locally

## Deployment Notes
Ensure the Google Cloud Console has the correct redirect URIs configured:
- Local: `http://localhost:3000/api/backend/auth/callback/google`
- Production: `https://sopher.ai/api/backend/auth/callback/google`

Fixes the OAuth login loop issue reported after the initial OAuth implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)