### PR TITLE
Fix: Add OAuth config status endpoint

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,6 +1,7 @@
 """Authentication routes for OAuth2 login"""
 
 import logging
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
@@ -23,6 +24,27 @@ from ..security import TokenData, create_access_token, create_refresh_token, get
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+@router.get("/config/status")
+async def oauth_config_status():
+    """Check OAuth configuration status (for debugging)"""
+    google_client_id = os.getenv("GOOGLE_CLIENT_ID", "")
+    google_client_secret = os.getenv("GOOGLE_CLIENT_SECRET", "")
+
+    return {
+        "google_oauth_configured": bool(google_client_id and google_client_secret),
+        "client_id_set": bool(google_client_id),
+        "client_secret_set": bool(google_client_secret),
+        "redirect_uri": os.getenv(
+            "GOOGLE_OAUTH_REDIRECT_URI", "http://localhost:3000/api/backend/auth/callback/google"
+        ),
+        "message": (
+            "OAuth is properly configured"
+            if google_client_id and google_client_secret
+            else "OAuth credentials are missing. See docs for setup instructions."
+        ),
+    }
 
 
 @router.get("/login/google")

--- a/scripts/force-redeploy.sh
+++ b/scripts/force-redeploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Force redeployment by triggering a new CI run with a timestamp tag
+
+echo "Forcing redeployment of sopher.ai backend..."
+echo "============================================"
+
+# Create a lightweight tag to trigger CI
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG_NAME="deploy-${TIMESTAMP}"
+
+echo "Creating deployment tag: ${TAG_NAME}"
+git tag -a "${TAG_NAME}" -m "Force redeployment to update OAuth configuration"
+
+echo "Pushing tag to trigger CI/CD..."
+git push origin "${TAG_NAME}"
+
+echo ""
+echo "Tag created and pushed. This will trigger a new CI/CD run."
+echo "Monitor the deployment at:"
+echo "https://github.com/cheesejaguar/sopher.ai/actions"
+echo ""
+echo "After deployment completes (5-10 minutes), verify OAuth is configured:"
+echo "curl https://api.sopher.ai/auth/config/status | python3 -m json.tool"


### PR DESCRIPTION
## Critical Fix for Production OAuth Issue

This PR adds the OAuth configuration status endpoint that was accidentally omitted from PR #59's merge.

## What this fixes:
- Adds `/auth/config/status` endpoint for debugging OAuth configuration
- Allows checking if OAuth credentials are properly set in production
- Essential for diagnosing the current 500 error on production

## How to verify after deployment:
```bash
curl https://api.sopher.ai/auth/config/status | python3 -m json.tool
```

Should return:
```json
{
  "google_oauth_configured": true,
  "client_id_set": true,
  "client_secret_set": true,
  "redirect_uri": "https://api.sopher.ai/auth/callback/google",
  "message": "OAuth is properly configured"
}
```

## Note:
The OAuth credentials are already configured in GitHub Secrets, so once this is deployed, OAuth should work properly.