### PR TITLE
Fix Docker build error in CI/CD pipeline

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,9 @@ COPY requirements.txt ./
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --prefer-binary -r requirements.txt
 
+# Copy application code and pyproject.toml for editable install
 COPY pyproject.toml ./
+COPY app ./app
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --prefer-binary -e . --no-deps
 


### PR DESCRIPTION
## Summary
- Fixes the failing Docker build in the CI/CD pipeline
- Resolves "package directory 'app' does not exist" error during pip install
- Ensures the backend Docker image can be built successfully

## Problem
The CI/CD pipeline was failing during the backend Docker build step with the error:
```
error: package directory 'app' does not exist
```

This occurred when attempting to run `pip install -e .` in the Dockerfile before the `app` directory had been copied into the build context.

## Solution
Modified the Dockerfile to copy the `app` directory before running the editable pip install command. The build sequence is now:
1. Copy requirements.txt and install dependencies
2. Copy pyproject.toml
3. **Copy app directory** (new step)
4. Run pip install -e . --no-deps

## Test Plan
- [x] Identified the root cause of the build failure
- [x] Applied the fix to the Dockerfile
- [ ] CI/CD pipeline should pass all checks
- [ ] Docker build should complete successfully
- [ ] Backend container should be pushed to registry

## Related Issues
Fixes the failing CI/CD pipeline run #17078190536

🤖 Generated with [Claude Code](https://claude.ai/code)