### PR TITLE
Fix OAuth cookie domain issue by using frontend proxy

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -5,9 +5,9 @@ import { BookOpen } from 'lucide-react'
 export default function LoginPage() {
 
   const handleGoogleLogin = () => {
-    // Redirect directly to backend OAuth endpoint
-    // This avoids proxy path issues and ensures correct OAuth flow
-    window.location.href = 'https://api.sopher.ai/auth/login/google'
+    // Use relative URL to go through frontend proxy
+    // This ensures cookies are set on the correct domain
+    window.location.href = '/api/backend/auth/login/google'
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixed OAuth authentication cookies not being visible in browser DevTools
- Resolved cookie domain mismatch preventing successful authentication
- Changed OAuth flow to use frontend proxy instead of direct API calls

## Problem
After completing the OAuth2 process, users were not seeing authentication cookies in their browser DevTools. The root cause was that the login page was redirecting directly to `api.sopher.ai`, causing cookies to be set on the wrong domain.

### Issues:
1. OAuth login redirected to `https://api.sopher.ai/auth/login/google`
2. Cookies were set on `api.sopher.ai` domain
3. Frontend at `localhost:3000` or `sopher.ai` couldn't access these cookies
4. Authentication failed despite successful OAuth flow

## Solution
Changed the OAuth login to use a relative URL that goes through the Next.js proxy:
- From: `https://api.sopher.ai/auth/login/google`
- To: `/api/backend/auth/login/google`

This ensures:
- OAuth flow routes through the frontend proxy (configured in `next.config.js`)
- Cookies are set on the correct domain (frontend's domain)
- Both `access_token` and `refresh_token` cookies are visible to the frontend
- Middleware can properly check authentication status

## Testing
1. Clear all cookies for the site
2. Navigate to `/login`
3. Click "Sign in with Google"
4. Complete OAuth flow
5. Check browser DevTools > Application > Cookies
6. Verify `access_token` and `refresh_token` cookies are present

## Impact
- Fixes authentication in both development (`localhost:3000`) and production (`sopher.ai`)
- No changes to backend code required
- Maintains security while fixing cookie visibility

🤖 Generated with [Claude Code](https://claude.ai/code)