### PR TITLE
fix: remove invalid rootDirectory property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "rootDirectory": "frontend",
   "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/"
 }


### PR DESCRIPTION
The rootDirectory property is not valid in vercel.json schema and must
be configured through Vercel project settings instead.

https://claude.ai/code/session_019e4ERAVdMiqbRhUDUvpvc8