### PR TITLE
fix: include root config files in Vercel ignore command check

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/"
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/ package.json vercel.json"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/"
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/ package.json vercel.json"
 }


### PR DESCRIPTION
The ignoreCommand only checked frontend/ for changes, so commits that modified root package.json or vercel.json were skipped by Vercel. Now the ignore command also checks these root-level deployment config files.

https://claude.ai/code/session_01XnsBWfFUfkU2Kh6HV5bhDU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config-only change to Vercel build skipping logic; low risk aside from potentially triggering more builds when root files change.
> 
> **Overview**
> Updates Vercel `ignoreCommand` in both `vercel.json` and `frontend/vercel.json` to consider changes to root `package.json` and `vercel.json` (in addition to `frontend/`) when deciding whether to skip a deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ca5ba012ce865f7976244bfd5a6c5f3a5f0afde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->