### PR TITLE
Add Fly.io deployment configuration for backend

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,6 +1,35 @@
 # fly.toml - Fly.io configuration for sopher.ai backend
-# Deploy with: fly deploy --config backend/fly.toml
 # Docs: https://fly.io/docs/reference/configuration/
+#
+# === Setup Instructions ===
+#
+# 1. Create the app (if not already created):
+#      fly apps create sopherai-backend
+#
+# 2. Provision Fly Postgres (managed, in same region):
+#      fly postgres create --name sopherai-db --region sjc
+#      fly postgres attach sopherai-db --app sopherai-backend
+#    This auto-sets DATABASE_URL as a secret on the app.
+#    NOTE: Fly sets DATABASE_URL with a "postgres://" scheme. The app expects
+#    "postgresql+asyncpg://", so set the correct URL as a secret:
+#      fly secrets set DATABASE_URL="postgresql+asyncpg://<user>:<pass>@<host>:5432/sopherai_backend"
+#    (Use the credentials from `fly postgres attach` output, just swap the scheme.)
+#
+# 3. Provision Upstash Redis (managed):
+#      fly redis create --name sopherai-redis --region sjc
+#    This auto-sets REDIS_URL as a secret on the app.
+#
+# 4. Set remaining secrets:
+#      fly secrets set \
+#        JWT_SECRET="$(openssl rand -hex 32)" \
+#        FERNET_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')" \
+#        ANTHROPIC_API_KEY="sk-ant-..." \
+#        OPENAI_API_KEY="sk-..." \
+#        GOOGLE_API_KEY="..." \
+#        CORS_ORIGINS="https://your-frontend-domain.com"
+#
+# 5. Deploy:
+#      fly deploy --config backend/fly.toml
 
 app = "sopherai-backend"
 primary_region = "sjc"
@@ -26,6 +55,8 @@ primary_region = "sjc"
   SSE_RETRY_INTERVAL = "5000"
   MAX_REQUEST_SIZE_MB = "10"
   PORT = "8000"
+  # DATABASE_URL and REDIS_URL are injected automatically by
+  # `fly postgres attach` and `fly redis create` as secrets.
 
 [http_service]
   internal_port = 8000

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,0 +1,82 @@
+# fly.toml - Fly.io configuration for sopher.ai backend
+# Deploy with: fly deploy --config backend/fly.toml
+# Docs: https://fly.io/docs/reference/configuration/
+
+app = "sopherai-backend"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[deploy]
+  strategy = "rolling"
+  release_command = "python -m alembic upgrade head"
+
+[env]
+  ENVIRONMENT = "production"
+  LOG_LEVEL = "INFO"
+  PYTHONUNBUFFERED = "1"
+  PRIMARY_MODEL = "anthropic/claude-sonnet-4.5"
+  SECONDARY_MODEL = "anthropic/claude-haiku-4.5"
+  OVERFLOW_MODEL = "anthropic/claude-opus-4.6"
+  METRICS_ENABLED = "true"
+  RATE_LIMIT_PER_MINUTE = "60"
+  RATE_LIMIT_BURST = "120"
+  SSE_KEEPALIVE_INTERVAL = "30"
+  SSE_RETRY_INTERVAL = "5000"
+  MAX_REQUEST_SIZE_MB = "10"
+  PORT = "8000"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 250
+    soft_limit = 200
+
+  [http_service.http_options]
+    # Long idle timeout for SSE streaming connections
+    idle_timeout = 300
+
+  # Proxy headers so the app sees real client IPs
+  [http_service.headers]
+    X-Forwarded-Proto = "https"
+
+[[http_service.checks]]
+  grace_period = "30s"
+  interval = "15s"
+  method = "GET"
+  timeout = "5s"
+  path = "/healthz"
+
+[[http_service.checks]]
+  grace_period = "60s"
+  interval = "30s"
+  method = "GET"
+  timeout = "10s"
+  path = "/readyz"
+
+# Prometheus metrics port
+[[services]]
+  internal_port = 9000
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 9000
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 2
+
+# Statics are not applicable since this is an API server
+
+[metrics]
+  port = 9000
+  path = "/api/metrics"


### PR DESCRIPTION
## Summary
This PR adds a comprehensive Fly.io deployment configuration file for the sopher.ai backend, enabling containerized deployment to Fly.io infrastructure.

## Key Changes
- **Deployment Configuration**: Added `backend/fly.toml` with complete Fly.io deployment settings
  - App name: `sopherai-backend` in primary region `sjc` (San Jose)
  - Rolling deployment strategy with automatic database migrations via Alembic
  - Production environment configuration with appropriate logging and feature flags

- **Service Configuration**:
  - HTTP service on port 8000 with HTTPS enforcement
  - Prometheus metrics service on port 9000
  - Connection limits: 250 hard limit, 200 soft limit
  - Long idle timeout (300s) optimized for SSE streaming connections

- **Health Checks**:
  - Liveness probe: `/healthz` endpoint (15s interval, 30s grace period)
  - Readiness probe: `/readyz` endpoint (30s interval, 60s grace period)

- **Resource Allocation**:
  - VM: 1GB memory, 2 shared CPUs
  - Minimum 1 machine running with auto-scaling enabled

- **Application Settings**:
  - Model configuration: Claude Sonnet 4.5 (primary), Haiku 4.5 (secondary), Opus 4.6 (overflow)
  - Rate limiting: 60 requests/minute with 120 burst capacity
  - SSE keepalive: 30s interval with 5s retry
  - Max request size: 10MB

## Notable Details
- Proxy headers configured to preserve real client IPs
- Auto-stop machines enabled for cost optimization
- Metrics endpoint exposed at `/api/metrics` on port 9000
- Release command runs database migrations before deployment

https://claude.ai/code/session_01AQTQfj9nEeaDnP5UfByrVn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds deployment configuration only, with no application code changes; risk is limited to potential misconfiguration of runtime env/health checks during deployment.
> 
> **Overview**
> Adds `backend/fly.toml` to enable deploying the backend API to Fly.io with a rolling strategy and a `release_command` that runs Alembic migrations.
> 
> Configures the Fly HTTP service (HTTPS enforced, connection limits, SSE-friendly idle timeout) with `/healthz` and `/readyz` health checks, and exposes Prometheus metrics on port `9000` mapped to `/api/metrics`, along with production env defaults (model selection, rate limits, request size, and SSE intervals).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 645273bc4ef9efdd53f0e0a3fdbbaaf628c47bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->