### PR TITLE
docs: TODO.md — rebuild completion state and remaining operator actions

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,6 +1,6 @@
 ---
 active: true
-iteration: 2
+iteration: 4
 max_iterations: 0
 completion_promise: null
 started_at: "2025-12-29T20:54:52Z"

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,59 @@
+# TODO
+
+Tracking for the Vercel-native rebuild (shipped to production 2026-07-27,
+PRs #103/#111/#112). Items are checked only with all associated tests passing.
+
+## Rebuild — complete
+
+Verification for every checked item: `pnpm typecheck && pnpm lint && pnpm test`
+green (255/255 unit tests, 19 files), `pnpm build` green, CI + CodeQL green on
+main, plus the live end-to-end run described below.
+
+- [x] Demolish legacy FastAPI/GKE/Docker stack; scaffold Next.js 16 app
+- [x] Vercel project settings, Neon + Clerk + Blob integrations, AI Gateway via OIDC
+- [x] Dual-theme design system, static marketing landing, studio shells
+- [x] Data layer (Drizzle, 15 tables, build-time migrations), billing meter, projects CRUD
+- [x] AI spike: prompt caching through gateway (verified: 4,454 cached tokens re-read),
+      AI SDK v7 tool loop + structured output, Workflow DevKit runtime
+- [x] Port domain assets to TypeScript (prompts, review rubric, plot/genre/voice
+      libraries, quality heuristics) — 101 dedicated unit tests
+- [x] Agentic pipeline: Postgres-backed per-role tools; chapter writer with
+      plan → tool-using draft → critique → targeted revise; concept/outline/
+      editor/continuity agents
+- [x] Durable generate-book workflow: budget gate, outline-approval hook,
+      parallel chapter waves, editorial gate, continuity review, revision pass
+- [x] Brief wizard with live per-tier cost receipts; dashboard on real data
+- [x] Generation experience: resumable NDJSON streams, live prose, agent feed,
+      cost ticker, approval flow, failure/retry and completion states
+- [x] Web editor: TipTap, anchored accept/reject AI suggestions, autosave with
+      conflict handling, content tools (Mermaid diagram, image generation)
+- [x] Manuscript reading view; DOCX/EPUB/PDF/MD export workflows to Blob
+- [x] Usage dashboards with cached-token accounting
+- [x] CI swap (lean check + CodeQL + dependabot), prettier gate
+- [x] Ship: merged to main, https://sopher.ai serving the new app, auth gate
+      verified (Clerk handshake), zero runtime errors post-fix
+
+Live E2E evidence (2026-07-27): generated "The Arithmetic of Mercy" — 12
+chapters, 36,428 words — through the production codebase: wizard → approval-
+gated durable run → live streaming → selection edit accepted transactionally →
+in-document Mermaid figure → valid EPUB + 115-page PDF exports → $6.39 across
+109 metered calls reconciled on the usage page (50-60% cached input tokens).
+
+## Blocked on operator actions (not completable from code)
+
+- [ ] Top up AI Gateway credits (Vercel → AI → Top up; Pro hosting does not
+      include gateway model credits), then restore the cheap tier: revert the
+      `TODO(credits)` alias in `src/ai/models.ts` to `anthropic/claude-haiku-4.5`
+      and recalibrate `src/ai/estimate.ts` against real `llm_calls` data.
+      Last checked 2026-07-27: haiku still returns the free-tier restriction.
+- [ ] Create a Clerk production instance for sopher.ai (dashboard + DNS records);
+      sign-in currently runs on the dev instance.
+- [ ] After a soak week: tear down the GKE cluster and revoke legacy GCP secrets
+      (steps in doc/CUTOVER.md).
+
+## Nice-to-have (post-launch)
+
+- [ ] Playwright E2E suite in CI (dual-theme screenshots of the five key
+      surfaces; axe-core checks) — manual pass done during the rebuild
+- [ ] Per-phase checkpointing inside the continuity step (cheaper retries)
+- [ ] Resume failed full-book runs from completed chapters instead of restarting


### PR DESCRIPTION
Restores a canonical TODO.md (the legacy one was deleted with the old stack): all rebuild items checked with test evidence (255/255 unit tests, green builds/CI, live E2E book generation), plus the three operator-gated follow-ups and post-launch nice-to-haves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)