### PR TITLE
Restore haiku cheap tier + metered-data estimate calibration

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,6 +1,6 @@
 ---
 active: true
-iteration: 5
+iteration: 6
 max_iterations: 0
 completion_promise: null
 started_at: "2025-12-29T20:54:52Z"

--- a/TODO.md
+++ b/TODO.md
@@ -41,15 +41,19 @@ in-document Mermaid figure → valid EPUB + 115-page PDF exports → $6.39 acros
 
 ## Blocked on operator actions (not completable from code)
 
-- [ ] Top up AI Gateway credits (Vercel → AI → Top up; Pro hosting does not
-      include gateway model credits), then restore the cheap tier: revert the
-      `TODO(credits)` alias in `src/ai/models.ts` to `anthropic/claude-haiku-4.5`
-      and recalibrate `src/ai/estimate.ts` against real `llm_calls` data.
-      Last checked 2026-07-27: haiku still returns the free-tier restriction.
-- [ ] Create a Clerk production instance for sopher.ai (dashboard + DNS records);
-      sign-in currently runs on the dev instance.
-- [ ] After a soak week: tear down the GKE cluster and revoke legacy GCP secrets
-      (steps in doc/CUTOVER.md).
+- [x] Top up AI Gateway credits — done by the operator 2026-07-27 (verified:
+      haiku-4.5 responds through the gateway). Cheap tier restored to
+      `anthropic/claude-haiku-4.5` in `src/ai/models.ts` and
+      `src/ai/estimate.ts` recalibrated against the real `llm_calls` data from
+      the first production book (12×3,000 words now quotes ≈ $1.05 draft /
+      $1.73 standard / $3.09 premium, ~34-40 min). Estimator unit tests added;
+      268/268 unit tests + 12/12 E2E green.
+- [ ] Create a Clerk production instance for sopher.ai (Clerk dashboard + DNS
+      records on the domain — operator-owned); sign-in currently runs on the
+      dev instance.
+- [ ] After a soak week (from 2026-07-27): tear down the GKE cluster and revoke
+      legacy GCP secrets (steps in doc/CUTOVER.md). Deliberately time-gated —
+      do not automate.
 
 ## Nice-to-have (post-launch) — complete
 

--- a/src/ai/estimate.test.ts
+++ b/src/ai/estimate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { estimateBookCost } from "./estimate";
+
+describe("estimateBookCost", () => {
+  it("orders tiers by cost and keeps totals positive", () => {
+    const draft = estimateBookCost("draft", 12, 3000);
+    const standard = estimateBookCost("standard", 12, 3000);
+    const premium = estimateBookCost("premium", 12, 3000);
+    expect(draft.totalUsd).toBeGreaterThan(0);
+    expect(standard.totalUsd).toBeGreaterThan(draft.totalUsd);
+    expect(premium.totalUsd).toBeGreaterThan(standard.totalUsd);
+  });
+
+  it("sums stages to the total (within rounding)", () => {
+    const e = estimateBookCost("standard", 20, 3000);
+    const stageSum = e.stages.reduce((acc, s) => acc + s.usd, 0);
+    expect(Math.abs(stageSum - e.totalUsd)).toBeLessThan(0.05 * e.stages.length);
+  });
+
+  it("scales with book size and reports realistic durations", () => {
+    const small = estimateBookCost("standard", 6, 1000);
+    const large = estimateBookCost("standard", 40, 6000);
+    expect(large.totalUsd).toBeGreaterThan(small.totalUsd * 4);
+    expect(small.estimatedMinutes).toBeGreaterThanOrEqual(10);
+    expect(large.estimatedMinutes).toBeGreaterThan(small.estimatedMinutes);
+  });
+});

--- a/src/ai/estimate.ts
+++ b/src/ai/estimate.ts
@@ -28,16 +28,18 @@ export function estimateBookCost(
 ): BookEstimate {
   const m = MODELS[tier];
   const chapterOutputTokens = wordsPerChapter * TOKENS_PER_WORD;
-  // Context discipline: cached system prefix + outline slice + rolling summaries + tool results.
-  const chapterInputTokens = 6_500;
-  const cachedShare = 0.65;
+  // Calibrated 2026-07-27 against llm_calls from a real 12x3,000-word run:
+  // draft inputs ~9.5k with ~50% served from cache (system prefix + outline
+  // slice + summaries + tool results).
+  const chapterInputTokens = 9_500;
+  const cachedShare = 0.5;
 
   const stages: StageEstimate[] = [];
 
-  const conceptOutline = calculateUsd(m.concept, { inputTokens: 3_000, outputTokens: 1_500 });
+  const conceptOutline = calculateUsd(m.concept, { inputTokens: 12_000, outputTokens: 6_000 });
   const outlineUsd = calculateUsd(m.outline, {
-    inputTokens: 5_000,
-    outputTokens: 350 * chapters,
+    inputTokens: 8_000,
+    outputTokens: 700 * chapters,
   });
   stages.push({ stage: "Concept + outline", usd: conceptOutline + outlineUsd });
 
@@ -73,21 +75,24 @@ export function estimateBookCost(
   }
 
   const summaryUsd = calculateUsd(m.summarizer, {
-    inputTokens: chapterOutputTokens,
-    outputTokens: 400,
+    inputTokens: chapterOutputTokens + 1_500,
+    outputTokens: 1_200,
   });
   stages.push({ stage: "Summaries + character bible", usd: summaryUsd * chapters });
 
   const continuityCalls = tier === "draft" ? 1 : 6;
+  // Each phase re-reads the summary corpus and spot-checks prose via tools.
+  const continuityInput = 20_000 + 350 * chapters;
   const continuityUsd = calculateUsd(m.continuity, {
-    inputTokens: 350 * chapters + 2_500,
-    outputTokens: 1_200,
+    inputTokens: continuityInput,
+    outputTokens: 2_000,
+    cachedInputTokens: continuityInput * cachedShare,
   });
   stages.push({ stage: "Continuity review", usd: continuityUsd * continuityCalls });
 
   const totalUsd = stages.reduce((acc, s) => acc + s.usd, 0);
   const parallelWaves = Math.ceil(chapters / 4);
-  const estimatedMinutes = Math.round(4 + parallelWaves * (tier === "premium" ? 5 : 3));
+  const estimatedMinutes = Math.round(10 + parallelWaves * (tier === "premium" ? 10 : 8));
 
   return {
     tier,

--- a/src/ai/models.ts
+++ b/src/ai/models.ts
@@ -15,10 +15,7 @@ export type TierModels = {
   image: string;
 };
 
-// TODO(credits): restore to "anthropic/claude-haiku-4.5" once AI Gateway
-// credits are added — the gateway's free-credit tier blocks haiku today, and
-// sonnet-5 is the cheapest unblocked model.
-const HAIKU = "anthropic/claude-sonnet-5";
+const HAIKU = "anthropic/claude-haiku-4.5";
 const SONNET = "anthropic/claude-sonnet-5";
 const OPUS = "anthropic/claude-opus-5";
 const IMAGE = "google/gemini-3.1-flash-image";


### PR DESCRIPTION
Gateway credits are live, so the sonnet alias is reverted and the estimator is recalibrated against the real llm_calls data from the first production book. New 12-chapter quotes: ~$1.05 draft / $1.73 standard / $3.09 premium (~34-40 min). Estimator unit tests added; 268 unit + 12 E2E green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)