### PR TITLE
chore: remove completed ralph-loop state file

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 7
-max_iterations: 0
-completion_promise: null
-started_at: "2025-12-29T20:54:52Z"
----
-
-Complete all TODO items in the TODO.md, checking them off as complete only after ALL associated unit tests and integration tests pass as complete.


### PR DESCRIPTION
The loop's objective (all TODO.md items complete with tests passing) is met — 19/19 checked, 268 unit + 12 E2E green. Local plugin state should not have been committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)