### PR TITLE
Review hardening: security, correctness & performance fixes

### DIFF
--- a/.agents/skills/clerk-backend-api/scripts/api-specs-context 2.sh
+++ b/.agents/skills/clerk-backend-api/scripts/api-specs-context 2.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Fetches all available BAPI spec versions, determines the latest,
+# and extracts tags from it. Output is used as skill context.
+
+set -euo pipefail
+
+API_URL="https://api.github.com/repos/clerk/openapi-specs/contents/bapi"
+RAW_BASE="https://raw.githubusercontent.com/clerk/openapi-specs/main/bapi"
+
+# Fetch version list, parse dates, sort, pick latest
+versions=$(curl -s "$API_URL" | node -e "
+  let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>{
+    const items = JSON.parse(d)
+      .map(i=>i.name)
+      .filter(n=>/^\d{4}-\d{2}-\d{2}\.yml$/.test(n))
+      .sort();
+    items.forEach(n=>console.log(n));
+  });
+")
+
+latest=$(echo "$versions" | tail -1)
+
+echo "AVAILABLE VERSIONS: $(echo "$versions" | tr '\n' ' ')"
+echo "LATEST VERSION: $latest"
+echo ""
+echo "TAGS:"
+curl -s "${RAW_BASE}/${latest}" | node "$(dirname "$0")/extract-tags.js"

--- a/.agents/skills/clerk-backend-api/scripts/execute-request 2.sh
+++ b/.agents/skills/clerk-backend-api/scripts/execute-request 2.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Execute a Clerk Backend API request with scope enforcement.
+#
+# Usage: bash execute-request.sh [--admin] <METHOD> <PATH> [BODY]
+#
+# Scope enforcement:
+#   GET     — always allowed
+#   POST, PUT, PATCH — requires CLERK_BAPI_SCOPES="write" or --admin flag
+#   DELETE  — requires CLERK_BAPI_SCOPES="write,delete" or --admin flag
+
+set -euo pipefail
+
+# Walk up from $PWD to find .env/.env.local (mirrors Clerk CLI behavior).
+# Stops at the first directory that provides CLERK_SECRET_KEY.
+_dir="$PWD"
+while true; do
+  for _envfile in "$_dir/.env" "$_dir/.env.local"; do
+    if [[ -f "$_envfile" ]]; then
+      set -a
+      source "$_envfile"
+      set +a
+    fi
+  done
+  [[ -n "${CLERK_SECRET_KEY:-}" ]] && break
+  _parent="$(dirname "$_dir")"
+  [[ "$_parent" == "$_dir" ]] && break
+  _dir="$_parent"
+done
+unset _dir _parent _envfile
+
+# Parse --admin flag
+ADMIN=false
+if [[ "${1:-}" == "--admin" ]]; then
+  ADMIN=true
+  shift
+fi
+
+METHOD="${1:?Usage: execute-request.sh [--admin] <METHOD> <PATH> [BODY]}"
+PATH_ARG="${2:?Usage: execute-request.sh [--admin] <METHOD> <PATH> [BODY]}"
+BODY="${3:-}"
+
+METHOD_UPPER=$(echo "$METHOD" | tr '[:lower:]' '[:upper:]')
+SCOPES="${CLERK_BAPI_SCOPES:-}"
+
+# Scope check
+if [[ "$ADMIN" == false ]]; then
+  case "$METHOD_UPPER" in
+    GET)
+      ;; # always allowed
+    POST|PUT|PATCH)
+      if [[ "$SCOPES" != *"write"* ]]; then
+        echo "ERROR: $METHOD_UPPER requests require CLERK_BAPI_SCOPES=\"write\" or --admin flag." >&2
+        echo "Current CLERK_BAPI_SCOPES: \"$SCOPES\"" >&2
+        exit 1
+      fi
+      ;;
+    DELETE)
+      if [[ "$SCOPES" != *"write"* ]] || [[ "$SCOPES" != *"delete"* ]]; then
+        echo "ERROR: DELETE requests require CLERK_BAPI_SCOPES=\"write,delete\" or --admin flag." >&2
+        echo "Current CLERK_BAPI_SCOPES: \"$SCOPES\"" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "ERROR: Unknown HTTP method: $METHOD_UPPER" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+# Base URL: use CLERK_REST_API_URL if set, otherwise default to production
+BASE_URL="${CLERK_REST_API_URL:-https://api.clerk.com}"
+
+# Build curl command
+CURL_ARGS=(
+  -s
+  -X "$METHOD_UPPER"
+  "${BASE_URL}/v1${PATH_ARG}"
+  -H "Authorization: Bearer ${CLERK_SECRET_KEY:?CLERK_SECRET_KEY is not set}"
+  -H "Content-Type: application/json"
+)
+
+if [[ -n "$BODY" ]]; then
+  CURL_ARGS+=(-d "$BODY")
+fi
+
+curl "${CURL_ARGS[@]}"

--- a/.agents/skills/clerk-backend-api/scripts/extract-endpoint-detail 2.sh
+++ b/.agents/skills/clerk-backend-api/scripts/extract-endpoint-detail 2.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# extract-endpoint-detail.sh
+#
+# Extracts full details for a specific endpoint from an OpenAPI YAML spec (stdin),
+# including parameters, request body, responses, and all referenced component schemas.
+#
+# Usage:
+#   curl -s <spec-url> | bash extract-endpoint-detail.sh "/users/{user_id}/billing/subscription" "get"
+
+set -euo pipefail
+
+ENDPOINT="${1:?Usage: extract-endpoint-detail.sh <path> <method>}"
+METHOD="${2:?Usage: extract-endpoint-detail.sh <path> <method>}"
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+SPEC="$TMPDIR_WORK/spec.yml"
+cat > "$SPEC"
+
+node - "$ENDPOINT" "$METHOD" "$SPEC" <<'SCRIPT'
+const fs = require("fs");
+const endpoint = process.argv[2];
+const method = process.argv[3].toLowerCase();
+const specFile = process.argv[4];
+const lines = fs.readFileSync(specFile, "utf8").split("\n");
+
+const httpMethods = ["get", "post", "put", "patch", "delete", "options", "head"];
+
+// Locate paths: and components: sections
+let pathsStart = -1, pathsEnd = -1, componentsStart = -1;
+for (let i = 0; i < lines.length; i++) {
+  if (/^paths:\s*$/.test(lines[i])) pathsStart = i;
+  else if (pathsStart >= 0 && pathsEnd < 0 && /^\S/.test(lines[i]) && i > pathsStart) pathsEnd = i;
+  if (/^components:\s*$/.test(lines[i])) componentsStart = i;
+}
+if (pathsEnd < 0) pathsEnd = lines.length;
+
+// Find the target path + method block
+let targetStart = -1, targetEnd = -1;
+let currentPath = null;
+
+for (let i = pathsStart + 1; i < pathsEnd; i++) {
+  const line = lines[i];
+
+  // Path line: exactly 2 spaces + /
+  if (/^ {2}\/\S/.test(line)) {
+    currentPath = line.trim().replace(/:$/, "");
+    continue;
+  }
+
+  // Method line: exactly 4 spaces + method name
+  const methodMatch = line.match(/^ {4}(\w+):\s*$/);
+  if (methodMatch && httpMethods.includes(methodMatch[1])) {
+    if (currentPath === endpoint && methodMatch[1] === method) {
+      targetStart = i;
+      // Find end of this method block
+      for (let j = i + 1; j < pathsEnd; j++) {
+        const nextLine = lines[j];
+        // New method or new path
+        if (/^ {2}\/\S/.test(nextLine) || (/^ {4}\w+:\s*$/.test(nextLine) && httpMethods.some(m => nextLine.trim().startsWith(m + ":")))) {
+          targetEnd = j;
+          break;
+        }
+      }
+      if (targetEnd < 0) targetEnd = pathsEnd;
+      break;
+    }
+  }
+}
+
+if (targetStart < 0) {
+  console.error(`Endpoint not found: ${method.toUpperCase()} ${endpoint}`);
+  process.exit(1);
+}
+
+const blockLines = lines.slice(targetStart, targetEnd);
+
+// Collect all $refs from the block
+const allRefs = new Set();
+for (const bl of blockLines) {
+  const refMatch = bl.match(/\$ref:\s*['"]?(#\/[^'"}\s]+)['"]?/);
+  if (refMatch) allRefs.add(refMatch[1]);
+}
+
+// Resolve a $ref path to the raw YAML lines for that component
+function resolveRef(ref) {
+  const parts = ref.replace("#/", "").split("/");
+  // Find the component in the file by walking indentation
+  let searchStart = 0;
+  for (let p = 0; p < parts.length; p++) {
+    const indent = p * 2;
+    const target = " ".repeat(indent) + parts[p] + ":";
+    let found = false;
+    for (let i = searchStart; i < lines.length; i++) {
+      if (lines[i].startsWith(target) && (lines[i] === target || lines[i][target.length] === " ")) {
+        searchStart = i + 1;
+        found = true;
+        break;
+      }
+    }
+    if (!found) return null;
+  }
+
+  // Collect lines for this component (until same or lower indent)
+  const componentStart = searchStart - 1;
+  const baseIndent = parts.length * 2;
+  const result = [];
+  for (let i = searchStart; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") { result.push(line); continue; }
+    const lineIndent = line.length - line.trimStart().length;
+    if (lineIndent < baseIndent) break;
+    result.push(line);
+  }
+  return result;
+}
+
+// Recursively resolve refs from component bodies
+function collectDeepRefs(refSet, visited) {
+  const toProcess = [...refSet].filter(r => !visited.has(r));
+  for (const ref of toProcess) {
+    visited.add(ref);
+    const body = resolveRef(ref);
+    if (!body) continue;
+    for (const bl of body) {
+      const refMatch = bl.match(/\$ref:\s*['"]?(#\/[^'"}\s]+)['"]?/);
+      if (refMatch && !visited.has(refMatch[1])) {
+        refSet.add(refMatch[1]);
+      }
+    }
+  }
+  // Recurse if new refs were found
+  const newRefs = [...refSet].filter(r => !visited.has(r));
+  if (newRefs.length > 0) collectDeepRefs(refSet, visited);
+}
+
+collectDeepRefs(allRefs, new Set());
+
+// Output
+console.log(`## \`${method.toUpperCase()}\` \`${endpoint}\`\n`);
+console.log("### Endpoint Definition\n");
+console.log("```yaml");
+for (const bl of blockLines) {
+  console.log(bl);
+}
+console.log("```\n");
+
+if (allRefs.size > 0) {
+  console.log(`### Referenced Components (${allRefs.size})\n`);
+  const sorted = [...allRefs].sort();
+  for (const ref of sorted) {
+    const name = ref.split("/").pop();
+    const category = ref.replace("#/", "").split("/").slice(0, -1).join("/");
+    console.log(`#### \`${name}\` (${category})\n`);
+    const body = resolveRef(ref);
+    if (body) {
+      console.log("```yaml");
+      for (const bl of body) console.log(bl);
+      console.log("```\n");
+    } else {
+      console.log("_(could not resolve)_\n");
+    }
+  }
+}
+SCRIPT

--- a/.agents/skills/clerk-backend-api/scripts/extract-tag-endpoints 2.sh
+++ b/.agents/skills/clerk-backend-api/scripts/extract-tag-endpoints 2.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# extract-tag-endpoints.sh
+#
+# Extracts all endpoints for a given tag from an OpenAPI YAML spec (stdin),
+# along with any $ref'd schemas/components.
+#
+# Usage:
+#   curl -s <spec-url> | bash extract-tag-endpoints.sh "Billing"
+
+set -euo pipefail
+
+TAG="${1:?Usage: extract-tag-endpoints.sh <tag-name>}"
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+SPEC="$TMPDIR_WORK/spec.yml"
+cat > "$SPEC"
+
+# 1. Find all path+method blocks that have a matching tag
+#    Strategy: find line numbers of path entries (lines starting with "  /"),
+#    then for each method block under that path, check if it contains the tag.
+
+node - "$TAG" "$SPEC" <<'SCRIPT'
+const fs = require("fs");
+const tag = process.argv[2];
+const specFile = process.argv[3];
+const lines = fs.readFileSync(specFile, "utf8").split("\n");
+
+const tagLower = tag.toLowerCase();
+
+// Phase 1: Find all path definitions and their method blocks
+// Paths start at indent 2 with "  /"
+// Methods start at indent 4 with "    get:", "    post:", etc.
+const methods = ["get", "post", "put", "patch", "delete", "options", "head"];
+const endpoints = [];
+const refs = new Set();
+
+let currentPath = null;
+let currentMethod = null;
+let blockStart = -1;
+let blockLines = [];
+let inPaths = false;
+let inComponents = false;
+
+// First pass: locate the "paths:" and "components:" top-level keys
+let pathsStart = -1;
+let pathsEnd = -1;
+let componentsStart = -1;
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  if (/^paths:\s*$/.test(line)) {
+    pathsStart = i;
+  } else if (pathsStart >= 0 && pathsEnd < 0 && /^\S/.test(line) && i > pathsStart) {
+    pathsEnd = i;
+  }
+  if (/^components:\s*$/.test(line)) {
+    componentsStart = i;
+  }
+}
+if (pathsEnd < 0) pathsEnd = lines.length;
+
+// Second pass: extract endpoints matching the tag
+function flushBlock() {
+  if (!currentPath || !currentMethod || blockLines.length === 0) return;
+
+  // Check if this block has the target tag
+  let inTags = false;
+  let hasTag = false;
+  const blockRefs = [];
+
+  for (const bl of blockLines) {
+    const trimmed = bl.trim();
+
+    // Detect tags section
+    if (/^tags:\s*$/.test(trimmed)) {
+      inTags = true;
+      continue;
+    }
+    if (inTags) {
+      if (/^- /.test(trimmed)) {
+        const tagVal = trimmed.replace(/^- /, "").trim().replace(/^['"]|['"]$/g, "");
+        if (tagVal.toLowerCase() === tagLower) hasTag = true;
+      } else {
+        inTags = false;
+      }
+    }
+
+    // Collect $ref values
+    const refMatch = bl.match(/\$ref:\s*['"]?(#\/[^'"}\s]+)['"]?/);
+    if (refMatch) blockRefs.push(refMatch[1]);
+  }
+
+  if (hasTag) {
+    // Extract summary, operationId, description
+    let summary = "";
+    let operationId = "";
+    let description = "";
+    let params = [];
+    let inDesc = false;
+    let inParams = false;
+
+    for (const bl of blockLines) {
+      const trimmed = bl.trim();
+      const indent = bl.length - bl.trimStart().length;
+
+      // Only capture operation-level keys (indent 6 = direct children of the method block)
+      if (indent === 6) {
+        const sumMatch = trimmed.match(/^summary:\s*(.+)/);
+        if (sumMatch) summary = sumMatch[1].replace(/^['"]|['"]$/g, "");
+
+        const opMatch = trimmed.match(/^operationId:\s*(.+)/);
+        if (opMatch) operationId = opMatch[1].replace(/^['"]|['"]$/g, "");
+
+        const descMatch = trimmed.match(/^description:\s*(.+)/);
+        if (descMatch && !inDesc) {
+          const val = descMatch[1].trim();
+          if (val === "|-" || val === "|" || val === ">-" || val === ">") {
+            inDesc = true;
+          } else {
+            description = val.replace(/^['"]|['"]$/g, "");
+          }
+          continue;
+        }
+      }
+
+      if (inDesc) {
+        // Continuation lines of description — grab first non-empty line
+        if (!description && trimmed.length > 0) {
+          description = trimmed;
+        }
+        // Stop when we hit the next operation-level key
+        if (indent === 6 && trimmed.length > 0 && !/^description:/.test(trimmed)) {
+          inDesc = false;
+        }
+      }
+    }
+
+    endpoints.push({
+      method: currentMethod.toUpperCase(),
+      path: currentPath,
+      operationId,
+      summary,
+      description,
+      refs: blockRefs,
+    });
+
+    for (const r of blockRefs) refs.add(r);
+  }
+}
+
+for (let i = pathsStart + 1; i < pathsEnd; i++) {
+  const line = lines[i];
+
+  // Path line: exactly 2 spaces + /
+  if (/^ {2}\/\S/.test(line)) {
+    flushBlock();
+    currentPath = line.trim().replace(/:$/, "");
+    currentMethod = null;
+    blockLines = [];
+    continue;
+  }
+
+  // Method line: exactly 4 spaces + method name
+  const methodMatch = line.match(/^ {4}(\w+):\s*$/);
+  if (methodMatch && methods.includes(methodMatch[1])) {
+    flushBlock();
+    currentMethod = methodMatch[1];
+    blockLines = [];
+    continue;
+  }
+
+  if (currentMethod) {
+    blockLines.push(line);
+  }
+}
+flushBlock();
+
+// Output endpoints
+if (endpoints.length === 0) {
+  console.error(`No endpoints found for tag: "${tag}"`);
+  process.exit(1);
+}
+
+console.log(`## Endpoints for "${tag}" (${endpoints.length} total)\n`);
+for (const ep of endpoints) {
+  console.log(`### \`${ep.method}\` \`${ep.path}\``);
+  if (ep.operationId) console.log(`- **operationId**: \`${ep.operationId}\``);
+  if (ep.summary) console.log(`- **summary**: ${ep.summary}`);
+  if (ep.description && ep.description !== ep.summary)
+    console.log(`- **description**: ${ep.description}`);
+  if (ep.refs.length > 0) {
+    console.log(`- **refs**: ${ep.refs.map(r => "\`" + r.split("/").pop() + "\`").join(", ")}`);
+  }
+  console.log();
+}
+
+// Output unique refs list
+if (refs.size > 0) {
+  console.log(`## Referenced Components (${refs.size} unique)\n`);
+  const sorted = [...refs].sort();
+  for (const r of sorted) {
+    const name = r.split("/").pop();
+    const category = r.split("/").slice(0, -1).join("/").replace("#/", "");
+    console.log(`- \`${name}\` (${category})`);
+  }
+}
+SCRIPT

--- a/.agents/skills/clerk-backend-api/scripts/extract-tags 2.js
+++ b/.agents/skills/clerk-backend-api/scripts/extract-tags 2.js
@@ -1,0 +1,14 @@
+let input = "";
+process.stdin.on("data", d => input += d);
+process.stdin.on("end", () => {
+  const lines = input.replace(/\r/g, "").split("\n");
+  let inTags = false;
+  for (const line of lines) {
+    if (line === "tags:") { inTags = true; continue; }
+    if (inTags && line.length > 0 && line[0] !== " ") break;
+    if (inTags) {
+      const m = line.match(/^\s{2}- name:\s*(.+)/);
+      if (m) console.log(m[1]);
+    }
+  }
+});

--- a/.claude/ralph-loop.local 3.md
+++ b/.claude/ralph-loop.local 3.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 9
+max_iterations: 0
+completion_promise: null
+started_at: "2025-12-29T20:54:52Z"
+---
+
+Complete all TODO items in the TODO.md, checking them off as complete only after ALL associated unit tests and integration tests pass as complete.

--- a/.claude/skills/clerk-backend-api 2
+++ b/.claude/skills/clerk-backend-api 2
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-backend-api

--- a/.claude/skills/clerk-nextjs-patterns 2
+++ b/.claude/skills/clerk-nextjs-patterns 2
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-nextjs-patterns

--- a/.claude/skills/clerk-orgs 2
+++ b/.claude/skills/clerk-orgs 2
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-orgs

--- a/.claude/skills/clerk-setup 2
+++ b/.claude/skills/clerk-setup 2
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-setup

--- a/.claude/skills/clerk-testing 2
+++ b/.claude/skills/clerk-testing 2
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-testing

--- a/.claude/skills/clerk-webhooks 2
+++ b/.claude/skills/clerk-webhooks 2
@@ -1,0 +1,1 @@
+../../.agents/skills/clerk-webhooks

--- a/.claude/skills/neon 2
+++ b/.claude/skills/neon 2
@@ -1,0 +1,1 @@
+../../.agents/skills/neon

--- a/.claude/skills/neon-postgres 2
+++ b/.claude/skills/neon-postgres 2
@@ -1,0 +1,1 @@
+../../.agents/skills/neon-postgres

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ pnpm-lock.yaml
 drizzle
 .agents
 .claude
+doc
+src/app/.well-known

--- a/.prettierignore 2
+++ b/.prettierignore 2
@@ -1,0 +1,5 @@
+.next
+node_modules
+pnpm-lock.yaml
+_port
+drizzle

--- a/.workflow-data/version 2.txt
+++ b/.workflow-data/version 2.txt
@@ -1,0 +1,1 @@
+@workflow/world-local@4.2.2

--- a/doc/review-report.html
+++ b/doc/review-report.html
@@ -1,0 +1,318 @@
+<title>sopher.ai — Code Review</title>
+<style>
+  :root {
+    --bg: #f5f6f9;
+    --panel: #ffffff;
+    --ink: #1b2230;
+    --ink-soft: #55607a;
+    --ink-faint: #8892a8;
+    --line: #e2e5ee;
+    --line-soft: #eef0f6;
+    --indigo: #4a5fd0;
+    --indigo-soft: #eef0fc;
+    --high: #c14a2b;
+    --high-soft: #fbe9e2;
+    --medium: #a9791f;
+    --medium-soft: #f8efd8;
+    --low: #5b6b86;
+    --low-soft: #eceff4;
+    --fixed: #227a5a;
+    --fixed-soft: #dcf0e7;
+    --defer: #74809a;
+    --defer-soft: #eceef4;
+    --teal: #1f8a86;
+    --shadow: 0 1px 2px rgba(20, 28, 48, 0.05), 0 6px 22px rgba(20, 28, 48, 0.05);
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f141d;
+      --panel: #171e2a;
+      --ink: #e7ebf3;
+      --ink-soft: #a3adc2;
+      --ink-faint: #6f7b93;
+      --line: #262f3f;
+      --line-soft: #1e2634;
+      --indigo: #8296f4;
+      --indigo-soft: #232c47;
+      --high: #e2795a;
+      --high-soft: #3a2620;
+      --medium: #d6ac5a;
+      --medium-soft: #352c1c;
+      --low: #94a2be;
+      --low-soft: #232b3a;
+      --fixed: #5cc196;
+      --fixed-soft: #1a3229;
+      --defer: #8a97b1;
+      --defer-soft: #232a38;
+      --teal: #55c2ba;
+      --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 30px rgba(0, 0, 0, 0.28);
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #0f141d; --panel: #171e2a; --ink: #e7ebf3; --ink-soft: #a3adc2; --ink-faint: #6f7b93;
+    --line: #262f3f; --line-soft: #1e2634; --indigo: #8296f4; --indigo-soft: #232c47;
+    --high: #e2795a; --high-soft: #3a2620; --medium: #d6ac5a; --medium-soft: #352c1c;
+    --low: #94a2be; --low-soft: #232b3a; --fixed: #5cc196; --fixed-soft: #1a3229;
+    --defer: #8a97b1; --defer-soft: #232a38; --teal: #55c2ba;
+    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 8px 30px rgba(0,0,0,.28);
+  }
+  :root[data-theme="light"] {
+    --bg: #f5f6f9; --panel: #fff; --ink: #1b2230; --ink-soft: #55607a; --ink-faint: #8892a8;
+    --line: #e2e5ee; --line-soft: #eef0f6; --indigo: #4a5fd0; --indigo-soft: #eef0fc;
+    --high: #c14a2b; --high-soft: #fbe9e2; --medium: #a9791f; --medium-soft: #f8efd8;
+    --low: #5b6b86; --low-soft: #eceff4; --fixed: #227a5a; --fixed-soft: #dcf0e7;
+    --defer: #74809a; --defer-soft: #eceef4; --teal: #1f8a86;
+    --shadow: 0 1px 2px rgba(20,28,48,.05), 0 6px 22px rgba(20,28,48,.05);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1000px; margin: 0 auto; padding: clamp(1.5rem, 4vw, 4rem) clamp(1rem, 4vw, 2rem) 5rem; }
+
+  header.masthead { border-bottom: 1px solid var(--line); padding-bottom: 1.75rem; margin-bottom: 2rem; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--indigo);
+    margin: 0 0 0.75rem;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 600;
+    font-size: clamp(1.9rem, 4.5vw, 2.9rem);
+    line-height: 1.08;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
+    margin: 0 0 0.6rem;
+  }
+  .lede { color: var(--ink-soft); max-width: 60ch; margin: 0; font-size: 1.02rem; }
+  .meta {
+    display: flex; flex-wrap: wrap; gap: 0.5rem 1.5rem;
+    margin-top: 1.25rem; font-size: 0.82rem; color: var(--ink-faint);
+    font-family: var(--mono);
+  }
+  .meta b { color: var(--ink-soft); font-weight: 500; }
+
+  .tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; margin-bottom: 1rem; }
+  @media (max-width: 640px) { .tiles { grid-template-columns: repeat(2, 1fr); } }
+  .tile {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+    padding: 1rem 1.1rem; box-shadow: var(--shadow);
+  }
+  .tile .n { font-family: var(--mono); font-size: 2rem; font-weight: 600; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; line-height: 1; }
+  .tile .l { font-size: 0.78rem; color: var(--ink-faint); margin-top: 0.4rem; }
+  .tile.accent .n { color: var(--indigo); }
+  .tile.fixed .n { color: var(--fixed); }
+
+  .methodology {
+    background: var(--indigo-soft); border: 1px solid color-mix(in srgb, var(--indigo) 22%, transparent);
+    border-radius: 12px; padding: 0.9rem 1.1rem; margin: 1.5rem 0 2rem;
+    font-size: 0.9rem; color: var(--ink-soft); display: flex; gap: 0.7rem; align-items: baseline;
+  }
+  .methodology .tag {
+    font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--teal); white-space: nowrap; padding-top: 0.05rem;
+  }
+
+  .controls { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; margin: 2.25rem 0 1rem; }
+  .controls .grp { display: flex; gap: 0.3rem; }
+  .controls .spacer { flex: 1; }
+  button.filter {
+    font-family: var(--sans); font-size: 0.8rem; color: var(--ink-soft);
+    background: var(--panel); border: 1px solid var(--line); border-radius: 999px;
+    padding: 0.32rem 0.8rem; cursor: pointer; transition: all 0.15s ease;
+  }
+  button.filter:hover { border-color: var(--ink-faint); }
+  button.filter[aria-pressed="true"] { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+  button.filter:focus-visible { outline: 2px solid var(--indigo); outline-offset: 2px; }
+
+  h2.sec {
+    font-family: var(--serif); font-weight: 600; font-size: 1.35rem; letter-spacing: -0.01em;
+    margin: 2.5rem 0 0.4rem; display: flex; align-items: baseline; gap: 0.6rem;
+  }
+  h2.sec .count { font-family: var(--mono); font-size: 0.85rem; color: var(--ink-faint); font-weight: 400; }
+  .sec-note { color: var(--ink-faint); font-size: 0.85rem; margin: 0 0 1rem; }
+
+  .list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .finding {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+    box-shadow: var(--shadow); overflow: hidden; transition: border-color 0.15s ease;
+  }
+  .finding[hidden] { display: none; }
+  .finding summary {
+    list-style: none; cursor: pointer; display: grid;
+    grid-template-columns: 4px auto 1fr auto; align-items: center; gap: 0.85rem;
+    padding: 0.8rem 1rem 0.8rem 0; position: relative;
+  }
+  .finding summary::-webkit-details-marker { display: none; }
+  .finding summary:focus-visible { outline: 2px solid var(--indigo); outline-offset: -2px; border-radius: 12px; }
+  .stripe { align-self: stretch; border-radius: 4px 0 0 4px; }
+  .sev-high .stripe { background: var(--high); }
+  .sev-medium .stripe { background: var(--medium); }
+  .sev-low .stripe { background: var(--low); }
+
+  .badges { display: flex; flex-direction: column; gap: 0.3rem; align-items: flex-start; }
+  .chip {
+    font-family: var(--mono); font-size: 0.64rem; letter-spacing: 0.06em; text-transform: uppercase;
+    padding: 0.14rem 0.44rem; border-radius: 5px; white-space: nowrap; font-weight: 500;
+  }
+  .chip.sev-high { background: var(--high-soft); color: var(--high); }
+  .chip.sev-medium { background: var(--medium-soft); color: var(--medium); }
+  .chip.sev-low { background: var(--low-soft); color: var(--low); }
+  .chip.dim { background: var(--line-soft); color: var(--ink-faint); }
+
+  .fmain { min-width: 0; }
+  .ftitle { font-size: 0.94rem; font-weight: 500; color: var(--ink); line-height: 1.35; }
+  .floc { font-family: var(--mono); font-size: 0.74rem; color: var(--ink-faint); margin-top: 0.2rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  .status {
+    font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.05em; text-transform: uppercase;
+    padding: 0.28rem 0.6rem; border-radius: 999px; white-space: nowrap; font-weight: 600;
+    display: inline-flex; align-items: center; gap: 0.35rem; margin-right: 1rem;
+  }
+  .status.fixed { background: var(--fixed-soft); color: var(--fixed); }
+  .status.deferred { background: var(--defer-soft); color: var(--defer); }
+  .status .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+  .detail { padding: 0.2rem 1rem 1.1rem calc(1rem + 4px + 0.85rem); border-top: 1px solid var(--line-soft); margin-top: -0.2rem; }
+  .detail .row { margin-top: 0.85rem; }
+  .detail .k { font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-faint); margin-bottom: 0.3rem; }
+  .detail .v { font-size: 0.9rem; color: var(--ink-soft); line-height: 1.6; }
+  .detail code { font-family: var(--mono); font-size: 0.82em; background: var(--line-soft); padding: 0.08em 0.35em; border-radius: 4px; word-break: break-word; }
+
+  footer { margin-top: 3.5rem; padding-top: 1.5rem; border-top: 1px solid var(--line); color: var(--ink-faint); font-size: 0.8rem; }
+  footer b { color: var(--ink-soft); font-weight: 500; }
+
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+</style>
+
+<div class="wrap">
+  <header class="masthead">
+    <p class="eyebrow">Code review · sopher.ai</p>
+    <h1>Full review: bugs, security, and performance</h1>
+    <p class="lede">An adversarially-verified sweep of the production codebase across security, correctness, and performance. Every finding below was traced by an independent verifier before it was reported; two candidate findings were refuted and dropped.</p>
+    <div class="meta">
+      <span><b>Scope</b> ~23.7k lines, src/</span>
+      <span><b>Method</b> 6 area reviewers → 38 verify passes</span>
+      <span><b>Confirmed</b> 36 · refuted 2</span>
+    </div>
+  </header>
+
+  <div class="tiles">
+    <div class="tile"><div class="n">33</div><div class="l">distinct defects<br>(36 confirmed, deduped)</div></div>
+    <div class="tile fixed"><div class="n">21</div><div class="l">fixed &amp; shipped<br>in this review</div></div>
+    <div class="tile accent"><div class="n">8</div><div class="l">high-severity<br>all fixed</div></div>
+    <div class="tile"><div class="n">12</div><div class="l">deferred<br>(tracked follow-ups)</div></div>
+  </div>
+
+  <div class="methodology">
+    <span class="tag">Verified</span>
+    <span>Each finding was independently checked against the real control flow before reporting. During the fixes, live testing against the database caught an operator-precedence bug in the atomic character-bible upsert (a <code>||</code> / <code>-&gt;</code> mistake that returned NULL on conflict) — fixed and re-verified with 4 concurrent writers before shipping.</span>
+  </div>
+
+  <div class="controls" role="group" aria-label="Filter findings">
+    <div class="grp" data-dim="sev">
+      <button class="filter" aria-pressed="true" data-f="all">All</button>
+      <button class="filter" aria-pressed="false" data-f="high">High</button>
+      <button class="filter" aria-pressed="false" data-f="medium">Medium</button>
+      <button class="filter" aria-pressed="false" data-f="low">Low</button>
+    </div>
+    <div class="spacer"></div>
+    <div class="grp" data-dim="dim">
+      <button class="filter" aria-pressed="false" data-d="security">Security</button>
+      <button class="filter" aria-pressed="false" data-d="correctness">Correctness</button>
+      <button class="filter" aria-pressed="false" data-d="performance">Performance</button>
+    </div>
+  </div>
+
+  <section>
+    <h2 class="sec">Fixed &amp; shipped <span class="count" id="fixed-count"></span></h2>
+    <p class="sec-note">Applied in this review, verified green (272 unit tests + 12 E2E), migration applied.</p>
+    <div class="list" id="fixed-list"></div>
+  </section>
+
+  <section>
+    <h2 class="sec">Deferred <span class="count" id="defer-count"></span></h2>
+    <p class="sec-note">Real defects that need a migration, a redesign, or careful staging — tracked for a follow-up rather than rushed into this batch.</p>
+    <div class="list" id="defer-list"></div>
+  </section>
+
+  <footer>
+    <p><b>Refuted (not defects):</b> a claimed budget-cache race — blocked by the pre-flight full-book budget check; and a claimed metering double-count — the audit row never enters spend.</p>
+    <p style="margin-top:.6rem">Dependency audit: the 5 high advisories GitHub flags are transitive through Next.js (<code>sharp</code>, <code>postcss</code> — fix on a Next bump) or dev-only tooling (<code>esbuild</code> via drizzle-kit, <code>brace-expansion</code> via eslint — never shipped). Dependabot PRs are open.</p>
+  </footer>
+</div>
+
+<script>
+  const DATA = [{"sev": "high", "dim": "correctness", "file": "workflows/steps.ts", "line": 357, "title": "Continuity revision pass writes internal continuity notes into the final manuscript", "status": "fixed", "detail": "editChapterStep appends issue notes to the chapter body before passing it to the editor: content = `${chapter.content}\\n\\n<!-- CONTINUITY NOTES TO ADDRESS -->\\n${issueNotes}`", "fix": "Preferred fix: keep the chapter body pure"}, {"sev": "high", "dim": "correctness", "file": "ai/agents/summarizer.ts", "line": 73, "title": "character_bible writes race under wave parallelism: lost updates and a unique-violation that fails the whole run", "status": "fixed", "detail": "With waveSize=4, up to 4 writeChapterSteps run concurrently, each executing summarizeChapter and the writer's characterBibleUpdate tool (src/ai/tools/index.ts:53-86)", "fix": "Replace the select/if/else read-modify-write in BOTH writers (src/ai/agents/summarizer.ts:52-80 and characterBibleUpdate in src/ai/tools/index.ts:53-86) with a "}, {"sev": "high", "dim": "correctness", "file": "ai/agents/outline.ts", "line": 336, "title": "Retry runs regenerate concept/outline and clobber completed chapters' real summaries with new plan summaries", "status": "fixed", "detail": "Resume semantics only cover chapters: conceptStep and outlineStep (src/workflows/steps.ts:152-197) have no 'already done' check, so a retry POST /generate after a failed run re-bil", "fix": "Three coordinated changes (the reviewer's persistOutline-only guard is insufficient because remaining chapters would still be drafted from a different outline t"}, {"sev": "high", "dim": "correctness", "file": "app/api/chapters/[chapterId]/edits/[suggestionId]/route.ts", "line": 86, "title": "Accept re-anchors by first occurrence, splicing the wrong duplicate passage", "status": "fixed", "detail": "When the chapter version has moved since the suggestion was created (any autosave keystroke or a prior accept in the accept-all loop does this), the accept path falls back to resol", "fix": "Two-part fix, slightly stronger than proposed"}, {"sev": "high", "dim": "correctness", "file": "lib/editor/doc-text.ts", "line": 87, "title": "Client highlight anchors to first occurrence; edit-then-accept writes the author's text into the wrong passage", "status": "fixed", "detail": "findTextRange uses haystack.indexOf(needle) (and a first-match fuzzy regex), so findAnchorRangeInDoc \u2014 used by the suggestion plugin (suggestion-plugin.ts:94) \u2014 always highlights t", "fix": "The reviewer's direction is right; refine it as follows"}, {"sev": "high", "dim": "correctness", "file": "components/editor/use-autosave.ts", "line": 147, "title": "Unmount cancels the debounced save without flushing \u2014 client-side navigation loses the last edits", "status": "fixed", "detail": "The unmount cleanup (lines 146-151) only does clearTimeout(timerRef.current)", "fix": "Flush on unmount in useAutosave: change the unmount cleanup (use-autosave.ts:146-151) to, after clearing the timer, check `dirtyRef.current && !conflictRef.curr"}, {"sev": "high", "dim": "correctness", "file": "components/editor/editor-shell.tsx", "line": 268, "title": "applyServerChapter overwrites the doc and clears dirty state, discarding keystrokes typed during accept round-trips", "status": "fixed", "detail": "The editor stays fully editable while busy === 'apply' (only buttons are disabled)", "fix": "The reviewer's first option is the right minimal fix; it just needs correct placement"}, {"sev": "high", "dim": "security", "file": "lib/billing/pricing.ts", "line": 36, "title": "Image generation billed at token rates instead of per-image: budget guard bypass", "status": "fixed", "detail": "The AI Gateway prices google/gemini-3.1-flash-image per generated image (verified live: image_dimension_quality_pricing = $0.045 at 512px, $0.067 default/1K, $0.151 at 4K), but MOD", "fix": "Meter images per-file at recording time; do not fold contentToolRuns.usd into spend (that would double-count the token portion and keep audit and metering entan"}, {"sev": "medium", "dim": "correctness", "file": "workflows/steps.ts", "line": 88, "title": "toWorkflowError maps transient DB/network errors to FatalError, killing runs and re-billing in-flight chapters", "status": "fixed", "detail": "toWorkflowError's catch-all (`throw new FatalError(...)` at line 88) converts every error that is not an APICallError and lacks an isRetryable property \u2014 including transient Neon c", "fix": "Two parts"}, {"sev": "medium", "dim": "correctness", "file": "ai/agents/chapter-writer.ts", "line": 219, "title": "Revision that applies zero replacements still bumps qualityScore by +0.1, letting a failed chapter dodge the edit gate", "status": "fixed", "detail": "applyReplacements (chapter-writer.ts:107-115) silently drops any replacement whose 'original' span is not a verbatim match (unlike the editor's version, it doesn't even count skips", "fix": "Minimal correct fix in chapter-writer.ts: gate the bonus on actual change"}, {"sev": "medium", "dim": "correctness", "file": "ai/agents/outline.ts", "line": 278, "title": "Standard-tier outline validation is computed and then discarded \u2014 chapter-count mismatch passes through silently", "status": "fixed", "detail": "generateOutline runs codeCheckIssues for every non-draft tier (line 278) but only acts on the result when tier === 'premium' (line 281)", "fix": "Two independent fixes, both worth applying"}, {"sev": "medium", "dim": "correctness", "file": "app/api/projects/[projectId]/generate/route.ts", "line": 41, "title": "TOCTOU on the active-run check allows two concurrent workflows writing the same book", "status": "fixed", "detail": "POST /generate does select-for-active-run (lines 41-56) then insert + start(), with no DB constraint preventing two active runs per project (generation_runs has only non-unique ind", "fix": "Enforce uniqueness in Postgres, but scope it by kind so the export flow keeps working: (1) add two partial unique indexes to generation_runs in src/db/schema.ts"}, {"sev": "medium", "dim": "correctness", "file": "components/editor/use-autosave.ts", "line": 46, "title": "flush() returns a stale in-flight save's success, falsely reporting the server matches the editor", "status": "fixed", "detail": "save() begins with `if (inflightRef.current) return inflightRef.current;`", "fix": "The reviewer's fix is correct and sufficient for this finding"}, {"sev": "medium", "dim": "performance", "file": "app/(studio)/projects/[projectId]/layout.tsx", "line": 30, "title": "Project/chapter queries run 2-3x per request \u2014 no React.cache dedup anywhere", "status": "fixed", "detail": "generateMetadata (line 23) and the layout body (line 30) each call requireUser() + getProjectWithBook(), and every stage page repeats the same pair a third time (editor/[chapterNum", "fix": "The reviewer's fix is correct; refine it as follows"}, {"sev": "medium", "dim": "performance", "file": "db/queries/books.ts", "line": 13, "title": "getProjectWithBook makes two dependent round trips instead of one LEFT JOIN", "status": "fixed", "detail": "The function SELECTs the project, awaits it, then SELECTs the book by projectId (lines 7-18)", "fix": "The reviewer's join is correct but only halves the waste (6 round trips \u2192 3)"}, {"sev": "medium", "dim": "security", "file": "lib/clerk.ts", "line": 3, "title": "Authentication fails open when Clerk publishable key env var is absent", "status": "fixed", "detail": "clerkEnabled is derived solely from Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)", "fix": "The reviewer's proposed NODE_ENV guard is the wrong signal: Vercel preview deployments also run with NODE_ENV='production', so it would both break the explicitl"}, {"sev": "medium", "dim": "security", "file": "workflows/export.ts", "line": 80, "title": "Manuscript exports are public blobs at deterministic paths and are never deleted", "status": "fixed", "detail": "assembleAndUploadStep uploads the full rendered manuscript with put(`exports/${projectId}/${dbRunId}.${ext}`, ..., { access: 'public', allowOverwrite: true })", "fix": "Three changes, refining the reviewer's proposal: (1) Make the export pathname unguessable: in assembleAndUploadStep, upload to `exports/${ref.projectId}/${ref.d"}, {"sev": "low", "dim": "correctness", "file": "app/api/runs/[runId]/route.ts", "line": 21, "title": "Malformed UUID path params reach Postgres and cause unhandled 500s", "status": "fixed", "detail": "The runs routes (GET /api/runs/[runId], /stream, /input) and the project routes (/api/projects/[projectId]/generate and /export) pass the raw path segment straight into eq() agains", "fix": "The proposed fix is correct; make it complete by covering both handlers in each file"}, {"sev": "low", "dim": "correctness", "file": "lib/editor/markdown-offsets.ts", "line": 47, "title": "Selection containing U+E001 silently truncates at the sentinel \u2014 the verification passes on the truncated span", "status": "fixed", "detail": "markdownSelection locates sentinels with indexOf", "fix": "The reviewer's first option is the right minimal fix; the lastIndexOf alternative is subtly wrong on its own (a user U+E001 located after the selection would th"}, {"sev": "low", "dim": "correctness", "file": "components/editor/editor-shell.tsx", "line": 436, "title": "Accept-409 removes the suggestion client-side but it stays 'pending' in the DB \u2014 zombie suggestions reappear on reload", "status": "fixed", "detail": "When accept returns 409 because the anchor no longer resolves (edits/[suggestionId]/route.ts:87-94), the server leaves the suggestion row status='pending' \u2014 it is neither applied n", "fix": "In the accept handler's anchor-unresolvable branch (edits/[suggestionId]/route.ts:87-95), mark the suggestion resolved before returning 409, e.g.: `await db.upd"}, {"sev": "low", "dim": "security", "file": "ai/schemas/index.ts", "line": 54, "title": "Outline chapter count has no upper bound \u2014 drafting loop writes outline.chapters, bypassing the pre-flight budget estimate", "status": "fixed", "detail": "bookOutlineSchema.chapters is z.array(chapterOutlineSchema).min(3) with no .max(), and the 'exactly N chapters' constraint is prompt-level only (src/ai/agents/outline.ts:137)", "fix": "Two layers, both cheap: (1) In src/ai/schemas/index.ts add `.max(60)` to `bookOutlineSchema.chapters` (matches the product cap in createProjectSchema, src/lib/v"}, {"sev": "medium", "dim": "correctness", "file": "workflows/steps.ts", "line": 221, "title": "Step retry after summarizer failure permanently skips the chapter summary and character-bible facts", "status": "deferred", "detail": "In writeChapterStep, persistChapter sets status='drafted' with content (line 298) before summarizeChapter runs (line 305)", "fix": "Backfill on the resume path (the reviewer's first option), with one correction: the early-return query doesn't currently select the fields needed"}, {"sev": "medium", "dim": "correctness", "file": "workflows/steps.ts", "line": 305, "title": "Step retry after persistChapter permanently skips summarizeChapter \u2014 story memory and bible facts lost", "status": "deferred", "detail": "writeChapterStep persists the chapter (status='drafted', steps.ts:298-304) BEFORE summarizeChapter runs (line 305)", "fix": "Make summarization its own retryable unit instead of piggybacking on the write step, and make the resume check aware of it"}, {"sev": "medium", "dim": "correctness", "file": "workflows/steps.ts", "line": 293, "title": "Retried writeChapterStep appends the full chapter's prose after the aborted attempt's deltas, garbling the live draft pane", "status": "deferred", "detail": "writeChapterStep streams every prose delta into the durable `chapter:N` namespace (line 293)", "fix": "The reviewer's in-band reset sentinel is the right approach; two refinements make it concrete and replay-safe"}, {"sev": "medium", "dim": "correctness", "file": "hooks/use-run-stream.ts", "line": 430, "title": "Chapter prose loop treats any clean stream end as final, freezing the live draft with no recovery", "status": "deferred", "detail": "When readNdjson returns without throwing, subscribeChapterProse assumes 'the run finished, so the prose replay is complete' and returns permanently (lines 429-430) \u2014 it never recon", "fix": "In subscribeChapterProse (src/hooks/use-run-stream.ts), replace the unconditional `return` at lines 429-430 with a guard mirroring the progress loop"}, {"sev": "low", "dim": "correctness", "file": "workflows/steps.ts", "line": 46, "title": "generation_events seq via coalesce(max(seq))+1 is non-atomic and non-idempotent under at-least-once step execution", "status": "deferred", "detail": "persistEvent allocates seq with a correlated max-subquery inside the insert (same pattern in src/workflows/export.ts:33) against the unique index uq_event_seq (runId, seq)", "fix": "Make the (runId, seq) pair deterministic across step re-execution instead of derived from table state: maintain an event counter in the workflow functions (work"}, {"sev": "low", "dim": "correctness", "file": "workflows/generate-book.ts", "line": 135, "title": "Failure-path steps in the catch block can mask the original error and leave the run stuck in 'running'", "status": "deferred", "detail": "The catch block awaits markRunStatus(ref,'failed') and emitProgress before rethrowing", "fix": "Two parts, applied to both generateBook (src/workflows/generate-book.ts:133-138) and exportBook (src/workflows/export.ts:130-135)"}, {"sev": "low", "dim": "correctness", "file": "components/editor/mermaid-code-block-view.ts", "line": 118, "title": "Out-of-order mermaid renders let a stale diagram overwrite the current one permanently", "status": "deferred", "detail": "render() sets this.lastRenderId before awaiting `mermaid.render` (lines 116-118) but never verifies after the await that it is still the latest render before writing `this.preview.", "fix": "In render(), generate the id before any await using a monotonic per-instance counter instead of Date.now() (which can collide within one millisecond): add `priv"}, {"sev": "low", "dim": "performance", "file": "lib/billing/meter.ts", "line": 103, "title": "Budget spend cache is 100% miss in the generation hot path", "status": "deferred", "detail": "metered() calls checkBudget() before every LLM call (src/ai/metering.ts:47), and recordLlmCall() deletes the runtime-cache spend key after every insert (meter.ts:103)", "fix": "Two safe changes: (1) Cache getBudget per user (short TTL, tag `budget:{userId}`) and invalidate that tag in the budget-settings mutation \u2014 budgets change rarel"}, {"sev": "low", "dim": "performance", "file": "ai/tools/index.ts", "line": 223, "title": "chaptersGetText fetches full chapter content, then slices in JS", "status": "deferred", "detail": "The continuity agent's chaptersGetText tool SELECTs the entire chapters.content column (line 215) and applies startChar/endChar slicing in JavaScript (line 223), defaulting to a 6,", "fix": "In chaptersGetText's execute (src/ai/tools/index.ts:213), compute the window in JS, clamp the length to non-negative, and push it into SQL:  execute: async ({ n"}, {"sev": "low", "dim": "performance", "file": "ai/tools/index.ts", "line": 28, "title": "characterBibleGet loads the whole character bible on every lookup", "status": "deferred", "detail": "The tool SELECTs every character_bible row for the book \u2014 including full jsonb facts \u2014 and filters case-insensitively in JS (lines 28-33), even though the input is capped at 8 name", "fix": "In `characterBibleGet` (src/ai/tools/index.ts), push the name filter into SQL and keep the miss computation in JS:  ```ts execute: async ({ names }) => {   cons"}, {"sev": "low", "dim": "performance", "file": "app/(studio)/projects/[projectId]/write/page.tsx", "line": 20, "title": "Write page runs sequential run lookups plus serial chapter fetch", "status": "deferred", "detail": "`(await getActiveRun(projectId)) ?? (await getLatestRun(projectId))` issues two sequential queries against generation_runs whenever there is no active run \u2014 which is the common idl", "fix": "In src/db/queries/books.ts add a combined helper, e.g.:  export async function getActiveOrLatestRun(projectId: string) {   const db = getDb();   const [run] = a"}, {"sev": "low", "dim": "performance", "file": "components/generation/live-draft-pane.tsx", "line": 154, "title": "ChapterProseView re-splits and re-reconciles the entire chapter, and forces synchronous layout, on every streamed delta batch", "status": "deferred", "detail": "`const paragraphs = text.length > 0 ? text.split(/\\n{2,}/) : []` (line 154) runs inline on every render with no memoization, re-scanning the full accumulated chapter text and re-al", "fix": "Three targeted changes in src/components/generation/live-draft-pane.tsx (plus optionally use-run-stream.ts): (1) Throttle updates to animation frames \u2014 either i"}];
+  const esc = (s) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+  const code = (s) => esc(s).replace(/`([^`]+)`/g, "<code>$1</code>");
+
+  function render(list, el) {
+    el.innerHTML = list.map((f, i) => `
+      <details class="finding sev-${f.sev}" data-sev="${f.sev}" data-dim="${f.dim}">
+        <summary>
+          <span class="stripe" aria-hidden="true"></span>
+          <span class="badges">
+            <span class="chip sev-${f.sev}">${f.sev}</span>
+            <span class="chip dim">${f.dim}</span>
+          </span>
+          <span class="fmain">
+            <span class="ftitle">${esc(f.title)}</span>
+            <span class="floc">${esc(f.file)}${f.line ? ":" + f.line : ""}</span>
+          </span>
+          <span class="status ${f.status}"><span class="dot"></span>${f.status}</span>
+        </summary>
+        <div class="detail">
+          <div class="row"><div class="k">What's wrong</div><div class="v">${code(f.detail)}…</div></div>
+          <div class="row"><div class="k">${f.status === "fixed" ? "Fix applied" : "Recommended fix"}</div><div class="v">${code(f.fix)}…</div></div>
+        </div>
+      </details>`).join("");
+  }
+
+  const fixed = DATA.filter((f) => f.status === "fixed");
+  const defer = DATA.filter((f) => f.status === "deferred");
+  render(fixed, document.getElementById("fixed-list"));
+  render(defer, document.getElementById("defer-list"));
+  document.getElementById("fixed-count").textContent = fixed.length;
+  document.getElementById("defer-count").textContent = defer.length;
+
+  let sevFilter = "all";
+  let dimFilter = null;
+  function apply() {
+    document.querySelectorAll(".finding").forEach((el) => {
+      const okSev = sevFilter === "all" || el.dataset.sev === sevFilter;
+      const okDim = !dimFilter || el.dataset.dim === dimFilter;
+      el.hidden = !(okSev && okDim);
+    });
+  }
+  document.querySelectorAll('[data-dim="sev"] .filter').forEach((b) => {
+    b.addEventListener("click", () => {
+      document.querySelectorAll('[data-dim="sev"] .filter').forEach((x) => x.setAttribute("aria-pressed", "false"));
+      b.setAttribute("aria-pressed", "true");
+      sevFilter = b.dataset.f;
+      apply();
+    });
+  });
+  document.querySelectorAll('[data-dim="dim"] .filter').forEach((b) => {
+    b.addEventListener("click", () => {
+      const was = b.getAttribute("aria-pressed") === "true";
+      document.querySelectorAll('[data-dim="dim"] .filter').forEach((x) => x.setAttribute("aria-pressed", "false"));
+      b.setAttribute("aria-pressed", was ? "false" : "true");
+      dimFilter = was ? null : b.dataset.d;
+      apply();
+    });
+  });
+</script>

--- a/drizzle/0001_shocking_green_goblin.sql
+++ b/drizzle/0001_shocking_green_goblin.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "uq_runs_active_per_project" ON "generation_runs" USING btree ("project_id") WHERE status in ('queued','running','awaiting_input') and kind <> 'export';

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1744 @@
+{
+  "id": "01bdc3d6-3532-4b51-8e9d-ec171bd089de",
+  "prevId": "696d9152-1841-4078-b9c5-a7e2a56d6544",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthly_limit_usd": {
+          "name": "monthly_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20.00'"
+        },
+        "hard_limit": {
+          "name": "hard_limit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "alert_threshold_pct": {
+          "name": "alert_threshold_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_bible": {
+      "name": "character_bible",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facts": {
+          "name": "facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_by_chapter": {
+          "name": "updated_by_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_character_name": {
+          "name": "uq_character_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_bible_book_id_books_id_fk": {
+          "name": "character_bible_book_id_books_id_fk",
+          "tableFrom": "character_bible",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1785188220553,
       "tag": "0000_harsh_black_queen",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1785209284778,
+      "tag": "0001_shocking_green_goblin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/agents/chapter-writer.ts
+++ b/src/ai/agents/chapter-writer.ts
@@ -217,10 +217,12 @@ export async function writeChapter(ctx: ChapterWriterCtx): Promise<ChapterResult
   );
 
   const revised = applyReplacements(draft, revision.output.replacements);
+  // Only credit the revision bump when at least one replacement actually landed.
+  const qualityScore = revised === draft ? verdict.score : Math.min(1, verdict.score + 0.1);
   return {
     content: revised,
     wordCount: countWords(revised),
-    qualityScore: Math.min(1, verdict.score + 0.1),
+    qualityScore,
     critique: verdict,
   };
 }

--- a/src/ai/agents/editor.ts
+++ b/src/ai/agents/editor.ts
@@ -17,6 +17,8 @@ export type EditChapterInput = {
   content: string;
   styleGuide?: string;
   chapterOutline?: unknown;
+  /** Continuity issues the edit must address; kept out of the chapter body. */
+  revisionNotes?: string;
 };
 
 export type EditChapterResult = {
@@ -85,6 +87,9 @@ function editPrompt(input: EditChapterInput, metricsNote: string): string {
       styleGuide: input.styleGuide,
       chapterOutline: outlineToText(input.chapterOutline),
     }),
+    input.revisionNotes
+      ? `## Continuity issues to address (fix via replacements)\n${input.revisionNotes}`
+      : "",
     `## Measured heuristics (free analysis)\n${metricsNote}`,
     [
       `## Output format (this overrides the response format in your instructions)`,
@@ -93,7 +98,9 @@ function editPrompt(input: EditChapterInput, metricsNote: string): string {
       `Respect the author's voice: light touch — refinement, not rewriting. Leave everything you do not flag untouched.`,
       `Put overall observations in "notes" as short strings.`,
     ].join("\n"),
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 // Same contract as chapter-writer's applyReplacements: exact-match spans only,

--- a/src/ai/agents/outline.ts
+++ b/src/ai/agents/outline.ts
@@ -230,11 +230,17 @@ function selfCheckPrompt(
     .join("\n\n");
 }
 
-function normalizeOutline(outline: BookOutline, structureId: string): BookOutline {
+function normalizeOutline(
+  outline: BookOutline,
+  structureId: string,
+  chapterCount: number,
+): BookOutline {
+  // Clamp to the configured chapter count so an over-long outline cannot
+  // draft (and bill) more chapters than the author budgeted for.
   return {
     ...outline,
     plotStructure: getPlotTemplate(structureId) ? structureId : outline.plotStructure,
-    chapters: outline.chapters.map((c, i) => ({ ...c, number: i + 1 })),
+    chapters: outline.chapters.slice(0, chapterCount).map((c, i) => ({ ...c, number: i + 1 })),
   };
 }
 
@@ -276,9 +282,9 @@ export async function generateOutline(input: OutlineInput): Promise<BookOutline>
 
   if (input.tier !== "draft") {
     const issues = codeCheckIssues(outline, input.chapterCount, plan.acts, template);
-    // Cheap code checks first; the LLM pass only runs for premium and only
-    // when the checks found something it needs to fix.
-    if (issues.length > 0 && input.tier === "premium") {
+    // Cheap code checks first; the LLM pass only runs when the checks found
+    // something it needs to fix.
+    if (issues.length > 0) {
       const checked = await metered(
         input.meter,
         { role: "outliner", operation: "outliner.selfCheck", model },
@@ -295,7 +301,7 @@ export async function generateOutline(input: OutlineInput): Promise<BookOutline>
     }
   }
 
-  return normalizeOutline(outline, structureId);
+  return normalizeOutline(outline, structureId, input.chapterCount);
 }
 
 /**

--- a/src/ai/agents/summarizer.ts
+++ b/src/ai/agents/summarizer.ts
@@ -1,5 +1,5 @@
 import { generateText, Output } from "ai";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
@@ -49,34 +49,25 @@ export async function summarizeChapter(input: {
       ),
     );
 
+  // Atomic upsert: concurrent chapter steps in a wave append facts without
+  // lost updates or racing the uq_character_name unique index.
   for (const entry of summary.newFacts) {
-    const [existing] = await db
-      .select()
-      .from(schema.characterBible)
-      .where(
-        and(
-          eq(schema.characterBible.bookId, input.bookId),
-          eq(schema.characterBible.name, entry.character),
-        ),
-      )
-      .limit(1);
-    if (existing) {
-      await db
-        .update(schema.characterBible)
-        .set({
-          facts: { ...existing.facts, facts: [...(existing.facts.facts ?? []), ...entry.facts] },
-          updatedByChapter: input.chapterNumber,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.characterBible.id, existing.id));
-    } else {
-      await db.insert(schema.characterBible).values({
+    await db
+      .insert(schema.characterBible)
+      .values({
         bookId: input.bookId,
         name: entry.character,
         facts: { facts: entry.facts, firstAppearance: input.chapterNumber },
         updatedByChapter: input.chapterNumber,
+      })
+      .onConflictDoUpdate({
+        target: [schema.characterBible.bookId, schema.characterBible.name],
+        set: {
+          facts: sql`jsonb_set(${schema.characterBible.facts}, '{facts}', coalesce(${schema.characterBible.facts}->'facts', '[]'::jsonb) || (excluded.facts->'facts'))`,
+          updatedByChapter: input.chapterNumber,
+          updatedAt: new Date(),
+        },
       });
-    }
   }
 
   return summary;

--- a/src/ai/content-tools/image.ts
+++ b/src/ai/content-tools/image.ts
@@ -33,7 +33,7 @@ export const imageTool: ContentTool = {
   description: "Generate an illustration for the selected passage",
   icon: "image",
   appliesTo: "selection",
-  estUsd: 0.05,
+  estUsd: 0.08,
   async run(ctx, input) {
     const promptModel = MODELS[ctx.tier].lineEdit;
     const promptResult = await metered(

--- a/src/ai/metering.ts
+++ b/src/ai/metering.ts
@@ -47,6 +47,11 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
   await checkBudget(ctx.userId);
   const startedAt = Date.now();
   const result = await fn();
+  // Image models bill per generated image, not per token — count returned image files.
+  const imageCount =
+    (result as { files?: Array<{ mediaType?: string }> }).files?.filter((f) =>
+      f.mediaType?.startsWith("image/"),
+    ).length ?? 0;
   await recordLlmCall({
     userId: ctx.userId,
     projectId: ctx.projectId,
@@ -60,6 +65,7 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
       cachedInputTokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
       cacheWriteTokens: result.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
       reasoningTokens: result.usage.outputTokenDetails?.reasoningTokens ?? 0,
+      imageCount,
     },
     latencyMs: Date.now() - startedAt,
   });

--- a/src/ai/schemas/index.ts
+++ b/src/ai/schemas/index.ts
@@ -51,7 +51,7 @@ export const bookOutlineSchema = z.object({
   synopsis: z.string(),
   themes: z.array(z.string()).max(6),
   plotStructure: z.string(),
-  chapters: z.array(chapterOutlineSchema).min(3),
+  chapters: z.array(chapterOutlineSchema).min(3).max(60),
 });
 export type BookOutline = z.infer<typeof bookOutlineSchema>;
 

--- a/src/ai/tools/index.ts
+++ b/src/ai/tools/index.ts
@@ -52,34 +52,24 @@ function characterBibleUpdate(ctx: ToolCtx) {
     }),
     execute: async ({ name, facts }) => {
       const db = getDb();
-      const [existing] = await db
-        .select()
-        .from(schema.characterBible)
-        .where(
-          and(eq(schema.characterBible.bookId, ctx.bookId), eq(schema.characterBible.name, name)),
-        )
-        .limit(1);
-      if (existing) {
-        const merged = {
-          ...existing.facts,
-          facts: [...(existing.facts.facts ?? []), ...facts],
-        };
-        await db
-          .update(schema.characterBible)
-          .set({
-            facts: merged,
-            updatedByChapter: ctx.chapterNumber,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.characterBible.id, existing.id));
-      } else {
-        await db.insert(schema.characterBible).values({
+      // Atomic upsert: concurrent chapter steps in a wave append facts without
+      // lost updates or racing the uq_character_name unique index.
+      await db
+        .insert(schema.characterBible)
+        .values({
           bookId: ctx.bookId,
           name,
           facts: { facts, firstAppearance: ctx.chapterNumber },
           updatedByChapter: ctx.chapterNumber,
+        })
+        .onConflictDoUpdate({
+          target: [schema.characterBible.bookId, schema.characterBible.name],
+          set: {
+            facts: sql`jsonb_set(${schema.characterBible.facts}, '{facts}', coalesce(${schema.characterBible.facts}->'facts', '[]'::jsonb) || (excluded.facts->'facts'))`,
+            updatedByChapter: ctx.chapterNumber,
+            updatedAt: new Date(),
+          },
         });
-      }
       return { recorded: true, name, factCount: facts.length };
     },
   });

--- a/src/app/api/chapters/[chapterId]/edits/[suggestionId]/route.ts
+++ b/src/app/api/chapters/[chapterId]/edits/[suggestionId]/route.ts
@@ -76,15 +76,24 @@ export async function POST(
   const { anchor } = suggestion;
   let start: number;
   let end: number;
-  if (
-    chapter.version === suggestion.chapterVersion &&
-    chapter.content.slice(anchor.start, anchor.end) === anchor.originalText
-  ) {
+  if (chapter.content.slice(anchor.start, anchor.end) === anchor.originalText) {
+    // The quoted passage still sits at its recorded offsets — use them even
+    // when the version moved (typing elsewhere doesn't shift this passage).
     start = anchor.start;
     end = anchor.end;
   } else {
-    const found = resolveAnchor(chapter.content, anchor.originalText);
+    // Re-anchor near the recorded position so duplicate passages resolve to
+    // the intended occurrence, not the first.
+    const found = resolveAnchor(chapter.content, anchor.originalText, anchor.start);
     if (!found) {
+      // The quote is gone for good — retire the suggestion so it doesn't
+      // reappear as pending on reload.
+      await db
+        .update(schema.suggestions)
+        .set({ status: "rejected" })
+        .where(
+          and(eq(schema.suggestions.id, suggestionId), eq(schema.suggestions.status, "pending")),
+        );
       return Response.json(
         {
           error: "The chapter has changed and this suggestion no longer matches",

--- a/src/app/api/chapters/[chapterId]/edits/route.ts
+++ b/src/app/api/chapters/[chapterId]/edits/route.ts
@@ -126,6 +126,19 @@ export async function POST(req: Request, ctx: { params: Promise<{ chapterId: str
     throw error;
   }
 
+  // Ordinal of this passage among identical matches (0 = first), so the
+  // client can highlight/apply the right duplicate. Counts match starts
+  // before the selection in the full content, mirroring findTextRange's
+  // every-start enumeration.
+  let occurrence = 0;
+  for (
+    let idx = chapter.content.indexOf(selection.text);
+    idx !== -1 && idx < selection.start;
+    idx = chapter.content.indexOf(selection.text, idx + 1)
+  ) {
+    occurrence += 1;
+  }
+
   const [row] = await db
     .insert(schema.suggestions)
     .values({
@@ -134,7 +147,12 @@ export async function POST(req: Request, ctx: { params: Promise<{ chapterId: str
       passType: "selection",
       suggestionType: "selection",
       severity: "info",
-      anchor: { start: selection.start, end: selection.end, originalText: selection.text },
+      anchor: {
+        start: selection.start,
+        end: selection.end,
+        originalText: selection.text,
+        occurrence,
+      },
       suggestedText: output.replacement,
       explanation: output.rationale,
       status: "pending",

--- a/src/app/api/exports/[assetId]/route.ts
+++ b/src/app/api/exports/[assetId]/route.ts
@@ -6,8 +6,8 @@ import { requireUser, UnauthorizedError } from "@/lib/auth";
 const paramsSchema = z.object({ assetId: z.uuid() });
 
 /**
- * Ownership-checked download: 302 to the blob URL (with ?download=1 so the
- * browser saves the file), keeping raw blob URLs out of the UI.
+ * Ownership-checked download: proxies the blob bytes instead of redirecting,
+ * so the raw blob URL never reaches the browser (history, referrers, UI).
  */
 export async function GET(_req: Request, ctx: { params: Promise<{ assetId: string }> }) {
   let userId: string;
@@ -26,12 +26,27 @@ export async function GET(_req: Request, ctx: { params: Promise<{ assetId: strin
 
   const db = getDb();
   const [asset] = await db
-    .select({ blobUrl: schema.assets.blobUrl })
+    .select({
+      blobUrl: schema.assets.blobUrl,
+      contentType: schema.assets.contentType,
+      meta: schema.assets.meta,
+    })
     .from(schema.assets)
     .innerJoin(schema.projects, eq(schema.assets.projectId, schema.projects.id))
     .where(and(eq(schema.assets.id, parsed.data.assetId), eq(schema.projects.userId, userId)))
     .limit(1);
   if (!asset) return Response.json({ error: "Asset not found" }, { status: 404 });
 
-  return Response.redirect(`${asset.blobUrl}?download=1`, 302);
+  const meta = asset.meta as { filename?: string };
+  const res = await fetch(asset.blobUrl);
+  if (!res.ok || !res.body) {
+    return Response.json({ error: "Asset not found" }, { status: 404 });
+  }
+  return new Response(res.body, {
+    headers: {
+      "Content-Type": asset.contentType,
+      "Content-Disposition": `attachment; filename="${meta.filename ?? "book"}"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
 }

--- a/src/app/api/projects/[projectId]/export/route.ts
+++ b/src/app/api/projects/[projectId]/export/route.ts
@@ -24,6 +24,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
     throw error;
   }
   const { projectId } = await ctx.params;
+  if (!z.uuid().safeParse(projectId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
   if (!parsed.success) {
     return Response.json({ error: parsed.error.flatten() }, { status: 400 });
@@ -90,6 +93,9 @@ export async function GET(req: Request, ctx: { params: Promise<{ projectId: stri
     throw error;
   }
   const { projectId } = await ctx.params;
+  if (!z.uuid().safeParse(projectId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const url = new URL(req.url);
   const parsed = querySchema.safeParse({ runId: url.searchParams.get("runId") });
   if (!parsed.success) {

--- a/src/app/api/projects/[projectId]/generate/route.ts
+++ b/src/app/api/projects/[projectId]/generate/route.ts
@@ -14,6 +14,14 @@ const bodySchema = z.object({
   requireOutlineApproval: z.boolean().default(false),
 });
 
+/** Postgres unique violation on uq_runs_active_per_project, possibly wrapped by the driver. */
+function isActiveRunConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const { code, message, cause } = error as { code?: string; message?: string; cause?: unknown };
+  if (code === "23505" || message?.includes("uq_runs_active_per_project")) return true;
+  return cause !== undefined && isActiveRunConflict(cause);
+}
+
 export async function POST(req: Request, ctx: { params: Promise<{ projectId: string }> }) {
   let userId: string;
   try {
@@ -25,6 +33,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
     throw error;
   }
   const { projectId } = await ctx.params;
+  if (!z.uuid().safeParse(projectId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
   if (!parsed.success) {
     return Response.json({ error: parsed.error.flatten() }, { status: 400 });
@@ -63,16 +74,36 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
     waveSize: 4,
   };
 
-  const [run] = await db
-    .insert(schema.generationRuns)
-    .values({
-      projectId,
-      userId,
-      kind: "full_book",
-      status: "queued",
-      config,
-    })
-    .returning({ id: schema.generationRuns.id });
+  let run: { id: string };
+  try {
+    [run] = await db
+      .insert(schema.generationRuns)
+      .values({
+        projectId,
+        userId,
+        kind: "full_book",
+        status: "queued",
+        config,
+      })
+      .returning({ id: schema.generationRuns.id });
+  } catch (error) {
+    // The partial unique index is the race-proof backstop behind the pre-check above.
+    if (!isActiveRunConflict(error)) throw error;
+    const [raced] = await db
+      .select({ id: schema.generationRuns.id })
+      .from(schema.generationRuns)
+      .where(
+        and(
+          eq(schema.generationRuns.projectId, projectId),
+          inArray(schema.generationRuns.status, ["queued", "running", "awaiting_input"]),
+        ),
+      )
+      .limit(1);
+    return Response.json(
+      { error: "A generation run is already in progress", runId: raced?.id },
+      { status: 409 },
+    );
+  }
 
   const workflowRun = await start(generateBook, [run.id, projectId, userId, config]);
   await db
@@ -94,6 +125,9 @@ export async function DELETE(_req: Request, ctx: { params: Promise<{ projectId: 
     throw error;
   }
   const { projectId } = await ctx.params;
+  if (!z.uuid().safeParse(projectId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const db = getDb();
   const [run] = await db
     .select()

--- a/src/app/api/runs/[runId]/input/route.ts
+++ b/src/app/api/runs/[runId]/input/route.ts
@@ -22,6 +22,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ runId: string 
     throw error;
   }
   const { runId } = await ctx.params;
+  if (!z.uuid().safeParse(runId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const parsed = bodySchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
     return Response.json({ error: parsed.error.flatten() }, { status: 400 });

--- a/src/app/api/runs/[runId]/route.ts
+++ b/src/app/api/runs/[runId]/route.ts
@@ -1,4 +1,5 @@
 import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 import { getDb, schema } from "@/db";
 import { requireUser, UnauthorizedError } from "@/lib/auth";
 
@@ -14,6 +15,9 @@ export async function GET(_req: Request, ctx: { params: Promise<{ runId: string 
     throw error;
   }
   const { runId } = await ctx.params;
+  if (!z.uuid().safeParse(runId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const db = getDb();
   const [run] = await db
     .select()

--- a/src/app/api/runs/[runId]/stream/route.ts
+++ b/src/app/api/runs/[runId]/stream/route.ts
@@ -1,5 +1,6 @@
 import { getRun } from "workflow/api";
 import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 import { getDb, schema } from "@/db";
 import { requireUser, UnauthorizedError } from "@/lib/auth";
 import { PROGRESS_NS } from "@/lib/run-events";
@@ -21,6 +22,9 @@ export async function GET(req: Request, ctx: { params: Promise<{ runId: string }
     throw error;
   }
   const { runId } = await ctx.params;
+  if (!z.uuid().safeParse(runId).success) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   const url = new URL(req.url);
   const namespace = url.searchParams.get("ns") ?? PROGRESS_NS;
   const startIndex = Number(url.searchParams.get("startIndex") ?? "0");

--- a/src/components/editor/editor-shell.tsx
+++ b/src/components/editor/editor-shell.tsx
@@ -403,6 +403,9 @@ export function EditorShell({
       const ed = editorRef.current;
       if (!ed || ed.isDestroyed) return;
       setBusy("apply");
+      // Freeze typing for the round-trip: a keystroke landing between the
+      // flush-serialize and applyServerChapter's setContent would be discarded.
+      ed.setEditable(false);
       try {
         if (!(await autosaveRef.current.flush())) {
           toast.error("Couldn't save the chapter first — resolve the conflict.");
@@ -439,6 +442,7 @@ export function EditorShell({
           toast.error("Couldn't apply the suggestion — try again.");
         }
       } finally {
+        if (!ed.isDestroyed) ed.setEditable(true);
         setBusy(null);
       }
     },
@@ -448,7 +452,10 @@ export function EditorShell({
   const acceptAll = useCallback(async () => {
     const ids = suggestions.map((s) => s.id);
     if (ids.length === 0) return;
+    const ed = editorRef.current;
     setBusy("apply");
+    // Freeze typing for the round-trips (see acceptSuggestion).
+    ed?.setEditable(false);
     try {
       if (!(await autosaveRef.current.flush())) {
         toast.error("Couldn't save the chapter first — resolve the conflict.");
@@ -478,6 +485,7 @@ export function EditorShell({
         toast.success(`Applied ${applied} suggestion${applied === 1 ? "" : "s"}.`);
       }
     } finally {
+      if (ed && !ed.isDestroyed) ed.setEditable(true);
       setBusy(null);
     }
   }, [applyServerChapter, chapterId, suggestions]);

--- a/src/components/editor/suggestion-plugin.ts
+++ b/src/components/editor/suggestion-plugin.ts
@@ -91,7 +91,11 @@ function createSuggestionPlugin(onActivate?: (id: string | null) => void): Plugi
         if (meta?.type === "set") {
           items = meta.suggestions.map((suggestion) => ({
             suggestion,
-            range: findAnchorRangeInDoc(newState.doc, suggestion.anchor.originalText),
+            range: findAnchorRangeInDoc(
+              newState.doc,
+              suggestion.anchor.originalText,
+              suggestion.anchor.occurrence ?? 0,
+            ),
           }));
           if (activeId && !items.some((i) => i.suggestion.id === activeId)) activeId = null;
           if (hoverId && !items.some((i) => i.suggestion.id === hoverId)) hoverId = null;

--- a/src/components/editor/use-autosave.ts
+++ b/src/components/editor/use-autosave.ts
@@ -42,8 +42,13 @@ export function useAutosave(options: {
   });
 
   const save = useCallback(
-    (force = false): Promise<boolean> => {
-      if (inflightRef.current) return inflightRef.current;
+    function save(force = false): Promise<boolean> {
+      // A stale in-flight save may not contain the latest keystrokes; once it
+      // settles (its .finally has nulled inflightRef), chain a fresh save if
+      // the editor is still dirty so callers see the *latest* content's fate.
+      if (inflightRef.current) {
+        return inflightRef.current.then((ok) => (ok && dirtyRef.current ? save(force) : ok));
+      }
       if (!dirtyRef.current && !force) return Promise.resolve(true);
       // After a conflict, only an explicit resolution ("keep mine") may write.
       if (conflictRef.current && !force) return Promise.resolve(false);
@@ -146,8 +151,14 @@ export function useAutosave(options: {
   useEffect(
     () => () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      // Unmount (e.g. client-side navigation) with a pending debounce: fire
+      // and forget a final save so those keystrokes aren't silently lost.
+      if (dirtyRef.current && !conflictRef.current && !inflightRef.current) {
+        const content = optionsRef.current.getContent();
+        if (content != null) void saveChapter(chapterId, content, versionRef.current);
+      }
     },
-    [],
+    [chapterId],
   );
 
   return {

--- a/src/db/queries/books.ts
+++ b/src/db/queries/books.ts
@@ -1,24 +1,25 @@
+import { cache } from "react";
 import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 
-/** Project + its book row (book may be null before first generation). */
-export async function getProjectWithBook(userId: string, projectId: string) {
+/**
+ * Project + its book row (book may be null before first generation).
+ * Single LEFT JOIN (uq_books_project guarantees at most one book) and
+ * per-request deduped so layout/metadata/page share one execution.
+ */
+export const getProjectWithBook = cache(async (userId: string, projectId: string) => {
   const db = getDb();
-  const [project] = await db
-    .select()
+  const [row] = await db
+    .select({ project: schema.projects, book: schema.books })
     .from(schema.projects)
+    .leftJoin(schema.books, eq(schema.books.projectId, schema.projects.id))
     .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
     .limit(1);
-  if (!project) return null;
-  const [book] = await db
-    .select()
-    .from(schema.books)
-    .where(eq(schema.books.projectId, projectId))
-    .limit(1);
-  return { project, book: book ?? null };
-}
+  if (!row) return null;
+  return { project: row.project, book: row.book ?? null };
+});
 
-export async function getChapterList(bookId: string) {
+export const getChapterList = cache(async (bookId: string) => {
   const db = getDb();
   return db
     .select({
@@ -35,9 +36,9 @@ export async function getChapterList(bookId: string) {
     .from(schema.chapters)
     .where(eq(schema.chapters.bookId, bookId))
     .orderBy(schema.chapters.chapterNumber);
-}
+});
 
-export async function getChapterWithContent(bookId: string, chapterNumber: number) {
+export const getChapterWithContent = cache(async (bookId: string, chapterNumber: number) => {
   const db = getDb();
   const [chapter] = await db
     .select()
@@ -47,7 +48,7 @@ export async function getChapterWithContent(bookId: string, chapterNumber: numbe
     )
     .limit(1);
   return chapter ?? null;
-}
+});
 
 export async function getChapterById(chapterId: string) {
   const db = getDb();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -193,6 +193,11 @@ export const generationRuns = pgTable(
   (t) => [
     index("idx_runs_project").on(t.projectId, t.createdAt),
     index("idx_runs_status").on(t.status),
+    // Race-proof backstop for the "one active generation per project" rule.
+    // Export runs are excluded so exports stay independent of generation.
+    uniqueIndex("uq_runs_active_per_project")
+      .on(t.projectId)
+      .where(sql`status in ('queued','running','awaiting_input') and kind <> 'export'`),
   ],
 );
 
@@ -255,6 +260,8 @@ export type SuggestionAnchor = {
   start: number;
   end: number;
   originalText: string;
+  /** Ordinal among identical matches of originalText (0 = first). Absent on legacy/review rows. */
+  occurrence?: number;
 };
 
 export const suggestions = pgTable(

--- a/src/lib/actions/chapters.ts
+++ b/src/lib/actions/chapters.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 
 import { getDb, schema } from "@/db";
 import { getChapterOwnership } from "@/db/queries/books";
@@ -33,6 +34,7 @@ export async function saveChapter(
   opts?: { force?: boolean },
 ): Promise<SaveChapterResult> {
   const { userId } = await requireUser();
+  if (!z.uuid().safeParse(chapterId).success) return { ok: false, error: "not_found" };
   if (
     typeof content !== "string" ||
     content.length > MAX_CONTENT_CHARS ||

--- a/src/lib/actions/projects.ts
+++ b/src/lib/actions/projects.ts
@@ -48,6 +48,14 @@ const startBookSchema = z.object({
   settings: projectSettingsSchema.default({}),
 });
 
+/** Postgres unique violation on uq_runs_active_per_project, possibly wrapped by the driver. */
+function isActiveRunConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const { code, message, cause } = error as { code?: string; message?: string; cause?: unknown };
+  if (code === "23505" || message?.includes("uq_runs_active_per_project")) return true;
+  return cause !== undefined && isActiveRunConflict(cause);
+}
+
 /**
  * Shared run-start logic — the server-side equivalent of
  * POST /api/projects/[projectId]/generate, factored out so server actions
@@ -74,16 +82,23 @@ async function startGenerationRun(
 
   await getOrCreateBook(project.id, project.title);
 
-  const [run] = await db
-    .insert(schema.generationRuns)
-    .values({
-      projectId: project.id,
-      userId,
-      kind: "full_book",
-      status: "queued",
-      config,
-    })
-    .returning({ id: schema.generationRuns.id });
+  let run: { id: string };
+  try {
+    [run] = await db
+      .insert(schema.generationRuns)
+      .values({
+        projectId: project.id,
+        userId,
+        kind: "full_book",
+        status: "queued",
+        config,
+      })
+      .returning({ id: schema.generationRuns.id });
+  } catch (error) {
+    // The partial unique index is the race-proof backstop behind the pre-check above.
+    if (!isActiveRunConflict(error)) throw error;
+    throw new Error("A generation run is already in progress");
+  }
 
   const workflowRun = await start(generateBook, [run.id, project.id, userId, config]);
   await db

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/db";
-import { clerkEnabled } from "@/lib/clerk";
+import { clerkEnabled, devAuthAllowed } from "@/lib/clerk";
 
 export class UnauthorizedError extends Error {
   constructor() {
@@ -23,12 +23,20 @@ async function devFallbackUser(): Promise<{ userId: string }> {
 
 /**
  * Resolves the signed-in Clerk user and lazily upserts the users row so the
- * Clerk webhook is reconciliation, not a critical path. Until the Clerk
- * integration is provisioned, every visitor shares a single dev identity so
- * previews stay fully usable; this path is dead code once keys exist.
+ * Clerk webhook is reconciliation, not a critical path. Without Clerk keys the
+ * shared dev identity is used only when explicitly allowed (development or
+ * ALLOW_DEV_AUTH=1); otherwise missing keys fail closed with a loud error.
  */
 export async function requireUser(): Promise<{ userId: string }> {
-  if (!clerkEnabled) return devFallbackUser();
+  if (!clerkEnabled) {
+    if (devAuthAllowed) {
+      console.warn(
+        "[auth] Clerk keys absent — serving shared dev fallback identity (dev/ALLOW_DEV_AUTH opt-in)",
+      );
+      return devFallbackUser();
+    }
+    throw new Error("Auth misconfigured: Clerk keys absent in a non-dev environment");
+  }
 
   const { userId } = await auth();
   if (!userId) throw new UnauthorizedError();

--- a/src/lib/billing/pricing.test.ts
+++ b/src/lib/billing/pricing.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { calculateUsd, MODEL_PRICING } from "./pricing";
+
+describe("calculateUsd", () => {
+  it("charges token models on tokens only", () => {
+    const usd = calculateUsd("anthropic/claude-sonnet-5", {
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+    });
+    expect(usd).toBeCloseTo(MODEL_PRICING["anthropic/claude-sonnet-5"].inputPerMTok, 5);
+  });
+
+  it("prices cached-read input at the cheaper rate", () => {
+    const p = MODEL_PRICING["anthropic/claude-sonnet-5"];
+    const usd = calculateUsd("anthropic/claude-sonnet-5", {
+      inputTokens: 1_000_000,
+      cachedInputTokens: 1_000_000,
+      outputTokens: 0,
+    });
+    expect(usd).toBeCloseTo(p.cachedInputPerMTok, 5);
+  });
+
+  it("bills image models per generated image, not just tokens", () => {
+    const model = "google/gemini-3.1-flash-image";
+    const perImage = MODEL_PRICING[model].perImageUsd!;
+    // A single image with a small token footprint (~1,300 output tokens).
+    const usd = calculateUsd(model, { inputTokens: 200, outputTokens: 1_300, imageCount: 1 });
+    // The per-image charge must dominate — this is the budget-bypass regression.
+    expect(usd).toBeGreaterThan(perImage);
+    expect(usd - perImage).toBeLessThan(0.01);
+    // Three images cost roughly triple.
+    const three = calculateUsd(model, { inputTokens: 200, outputTokens: 1_300, imageCount: 3 });
+    expect(three).toBeGreaterThan(3 * perImage);
+  });
+
+  it("defaults an unknown image model to the conservative fallback per-image price", () => {
+    const usd = calculateUsd("unknown/some-image-model", {
+      inputTokens: 0,
+      outputTokens: 0,
+      imageCount: 1,
+    });
+    expect(usd).toBeGreaterThan(0.1);
+  });
+});

--- a/src/lib/billing/pricing.ts
+++ b/src/lib/billing/pricing.ts
@@ -6,6 +6,8 @@ export type ModelPricing = {
   outputPerMTok: number;
   cachedInputPerMTok: number;
   cacheWritePerMTok: number;
+  /** Flat USD per generated image (image models bill per image, not per token). */
+  perImageUsd?: number;
 };
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
@@ -38,6 +40,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     outputPerMTok: 3,
     cachedInputPerMTok: 0.05,
     cacheWritePerMTok: 0.5,
+    perImageUsd: 0.067,
   },
 };
 
@@ -46,6 +49,7 @@ const FALLBACK_PRICING: ModelPricing = {
   outputPerMTok: 25,
   cachedInputPerMTok: 0.5,
   cacheWritePerMTok: 6.25,
+  perImageUsd: 0.15,
 };
 
 export type UsageTokens = {
@@ -53,6 +57,7 @@ export type UsageTokens = {
   outputTokens: number;
   cachedInputTokens?: number;
   cacheWriteTokens?: number;
+  imageCount?: number;
 };
 
 export function calculateUsd(model: string, usage: UsageTokens): number {
@@ -65,6 +70,7 @@ export function calculateUsd(model: string, usage: UsageTokens): number {
       cachedRead * pricing.cachedInputPerMTok +
       cacheWrite * pricing.cacheWritePerMTok +
       usage.outputTokens * pricing.outputPerMTok) /
-    1_000_000;
+      1_000_000 +
+    (usage.imageCount ?? 0) * (pricing.perImageUsd ?? 0);
   return Math.round(usd * 1_000_000) / 1_000_000;
 }

--- a/src/lib/clerk.ts
+++ b/src/lib/clerk.ts
@@ -1,3 +1,9 @@
 // Clerk activates once the Marketplace integration provisions keys.
 // Until then the app runs unauthenticated so previews stay reviewable.
 export const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+
+// Without Clerk keys, the shared dev identity is only allowed as an explicit
+// opt-in: local development, or ALLOW_DEV_AUTH=1 (server-only, never NEXT_PUBLIC_).
+// Everywhere else, missing keys must fail closed.
+export const devAuthAllowed =
+  process.env.NODE_ENV === "development" || process.env.ALLOW_DEV_AUTH === "1";

--- a/src/lib/editor/anchors.ts
+++ b/src/lib/editor/anchors.ts
@@ -6,12 +6,26 @@
 
 export type AnchorRange = { start: number; end: number };
 
-/** First-occurrence resolution of an anchor quote inside chapter content. */
-export function resolveAnchor(content: string, anchorText: string): AnchorRange | null {
+/**
+ * Resolve an anchor quote inside chapter content. With `hintStart`, the
+ * occurrence whose start is closest to the hint wins (so duplicate passages
+ * resolve to the intended one); without it, the first occurrence.
+ */
+export function resolveAnchor(
+  content: string,
+  anchorText: string,
+  hintStart?: number,
+): AnchorRange | null {
   if (!anchorText) return null;
-  const start = content.indexOf(anchorText);
-  if (start === -1) return null;
-  return { start, end: start + anchorText.length };
+  const first = content.indexOf(anchorText);
+  if (first === -1) return null;
+  let best = first;
+  if (hintStart !== undefined) {
+    for (let idx = first; idx !== -1; idx = content.indexOf(anchorText, idx + 1)) {
+      if (Math.abs(idx - hintStart) < Math.abs(best - hintStart)) best = idx;
+    }
+  }
+  return { start: best, end: best + anchorText.length };
 }
 
 /** Word count matching the drafting pipeline's convention. */

--- a/src/lib/editor/doc-text.ts
+++ b/src/lib/editor/doc-text.ts
@@ -77,22 +77,39 @@ const MAX_FUZZY_ANCHOR = 600;
 /**
  * Find `needle` in `haystack`, exact first, then tolerating differing
  * whitespace runs (markdown "\n\n" vs doc-text separators, wrapped lines).
+ * `occurrence` selects the nth match (0-based, enumerated at every start
+ * position); falls back to the first match when absent or out of range.
  */
 export function findTextRange(
   haystack: string,
   needle: string,
+  occurrence = 0,
 ): { start: number; end: number } | null {
   if (!needle) return null;
-  const exact = haystack.indexOf(needle);
-  if (exact !== -1) return { start: exact, end: exact + needle.length };
+  const exact: number[] = [];
+  for (let idx = haystack.indexOf(needle); idx !== -1; idx = haystack.indexOf(needle, idx + 1)) {
+    exact.push(idx);
+    if (exact.length > occurrence) break;
+  }
+  if (exact.length > 0) {
+    const start = exact[occurrence] ?? exact[0];
+    return { start, end: start + needle.length };
+  }
 
   if (needle.length > MAX_FUZZY_ANCHOR) return null;
   const tokens = needle.split(/\s+/).filter(Boolean);
   if (tokens.length === 0) return null;
   const pattern = tokens.map(escapeRegExp).join("\\s+");
-  const match = new RegExp(pattern).exec(haystack);
-  if (!match) return null;
-  return { start: match.index, end: match.index + match[0].length };
+  const re = new RegExp(pattern, "g");
+  const fuzzy: RegExpExecArray[] = [];
+  for (let match = re.exec(haystack); match; match = re.exec(haystack)) {
+    fuzzy.push(match);
+    if (fuzzy.length > occurrence) break;
+    re.lastIndex = match.index + 1;
+  }
+  const chosen = fuzzy[occurrence] ?? fuzzy[0];
+  if (!chosen) return null;
+  return { start: chosen.index, end: chosen.index + chosen[0].length };
 }
 
 /**
@@ -103,9 +120,10 @@ export function findTextRange(
 export function findAnchorRangeInDoc(
   doc: PMNode,
   originalText: string,
+  occurrence = 0,
 ): { from: number; to: number } | null {
   const index = indexDocText(doc);
-  const range = findTextRange(index.text, originalText);
+  const range = findTextRange(index.text, originalText, occurrence);
   if (!range) return null;
   return index.toPmRange(range.start, range.end);
 }

--- a/src/lib/editor/markdown-offsets.ts
+++ b/src/lib/editor/markdown-offsets.ts
@@ -43,6 +43,11 @@ export function markdownSelection(
     return null;
   }
 
+  // A document that already contains a sentinel character makes the offsets
+  // ambiguous (we'd find its sentinel, not ours) — bail so the caller shows
+  // the reselect hint instead of silently truncating.
+  if (clean.includes(SENTINEL_START) || clean.includes(SENTINEL_END)) return null;
+
   const startIdx = withSentinels.indexOf(SENTINEL_START);
   const endIdx = withSentinels.indexOf(SENTINEL_END);
   if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import type { NextRequest } from "next/server";
+import { devAuthAllowed } from "@/lib/clerk";
 
 const isProtected = createRouteMatcher([
   "/studio(.*)",
@@ -12,12 +14,17 @@ const isProtected = createRouteMatcher([
 
 const hasClerkKeys = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
-// Until the Clerk integration is provisioned, pass requests through so previews stay usable.
+// Without Clerk keys: pass through only when dev auth is explicitly allowed
+// (development or ALLOW_DEV_AUTH=1); otherwise fail closed on protected routes.
 export default hasClerkKeys
   ? clerkMiddleware(async (auth, req) => {
       if (isProtected(req)) await auth.protect();
     })
-  : function proxy() {};
+  : devAuthAllowed
+    ? function proxy() {}
+    : function proxy(req: NextRequest) {
+        if (isProtected(req)) return new Response("Auth misconfigured", { status: 503 });
+      };
 
 export const config = {
   matcher: [

--- a/src/workflows/export.ts
+++ b/src/workflows/export.ts
@@ -59,6 +59,15 @@ async function emitExportProgress(ref: RunRef, event: RunEvent) {
 }
 
 /**
+ * Minted in its own step so retries of the upload step reuse the same token
+ * (and thus the same blob pathname) instead of re-rolling it.
+ */
+async function mintExportToken(): Promise<string> {
+  "use step";
+  return crypto.randomUUID();
+}
+
+/**
  * Assemble + render + upload in a single step: the rendered buffer must never
  * cross a step boundary as an argument, so the whole byte-producing path lives
  * here and only small identifiers leave.
@@ -66,6 +75,7 @@ async function emitExportProgress(ref: RunRef, event: RunEvent) {
 async function assembleAndUploadStep(
   ref: RunRef,
   format: ExportFormat,
+  token: string,
 ): Promise<{ assetId: string; filename: string }> {
   "use step";
   const manuscript = await loadManuscript(ref.userId, ref.projectId);
@@ -78,7 +88,7 @@ async function assembleAndUploadStep(
   const meta = FORMAT_META[format];
 
   const blob = await put(
-    `exports/${ref.projectId}/${ref.dbRunId}.${meta.extension}`,
+    `exports/${ref.projectId}/${token}.${meta.extension}`,
     Buffer.from(result.buffer),
     {
       access: "public",
@@ -122,7 +132,8 @@ export async function exportBook(
       detail: `Assembling the ${FORMAT_META[format].label} edition`,
     });
 
-    const { assetId, filename } = await assembleAndUploadStep(ref, format);
+    const token = await mintExportToken();
+    const { assetId, filename } = await assembleAndUploadStep(ref, format, token);
 
     await markExportStatus(ref, "completed");
     await emitExportProgress(ref, { type: "stage", stage: "done", pct: 100, detail: filename });

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -85,7 +85,9 @@ function toWorkflowError(error: unknown): never {
     }
     throw new FatalError(message);
   }
-  throw new FatalError(error instanceof Error ? error.message : String(error));
+  throw new RetryableError(error instanceof Error ? error.message : String(error), {
+    retryAfter: "30s",
+  });
 }
 
 async function loadRunContext(ref: RunRef) {
@@ -152,6 +154,10 @@ export async function checkBudgetStep(ref: RunRef, config: GenerationConfig) {
 export async function conceptStep(ref: RunRef, config: GenerationConfig): Promise<BookConcept> {
   "use step";
   const { project, book, meter } = await loadRunContext(ref);
+  // Resume: a retry run reuses the concept a prior run already persisted.
+  if (book.concept && typeof book.concept === "object" && Object.keys(book.concept).length > 0) {
+    return book.concept as BookConcept;
+  }
   const tools: ToolCtx = { userId: ref.userId, projectId: ref.projectId, bookId: book.id };
   try {
     const concept = await generateConcept({
@@ -176,6 +182,18 @@ export async function outlineStep(
 ): Promise<BookOutline> {
   "use step";
   const { project, book, meter } = await loadRunContext(ref);
+  // Resume: without in-run revision notes, a retry reuses the persisted
+  // outline instead of regenerating it and clobbering chapter summaries.
+  if (revisionNotes === undefined) {
+    const db = getDb();
+    const [existing] = await db
+      .select({ content: schema.outlines.content })
+      .from(schema.outlines)
+      .where(eq(schema.outlines.bookId, book.id))
+      .orderBy(sql`${schema.outlines.version} desc`)
+      .limit(1);
+    if (existing) return existing.content as BookOutline;
+  }
   const tools: ToolCtx = { userId: ref.userId, projectId: ref.projectId, bookId: book.id };
   try {
     const outline = await generateOutline({
@@ -209,7 +227,9 @@ export async function writeChapterStep(
   const [existing] = await db
     .select({
       status: schema.chapters.status,
+      title: schema.chapters.title,
       content: schema.chapters.content,
+      summary: schema.chapters.summary,
       wordCount: schema.chapters.wordCount,
       qualityScore: schema.chapters.qualityScore,
     })
@@ -219,6 +239,22 @@ export async function writeChapterStep(
     )
     .limit(1);
   if (isChapterComplete(existing)) {
+    // Backfill: a retry after persistChapter succeeded but summarizeChapter
+    // failed must still write the summary and character-bible facts.
+    if (existing.summary == null) {
+      try {
+        await summarizeChapter({
+          meter,
+          bookId: book.id,
+          chapterNumber,
+          chapterTitle: existing.title,
+          content: existing.content,
+          tier: config.tier,
+        });
+      } catch (error) {
+        toWorkflowError(error);
+      }
+    }
     await writeEvent(PROGRESS_NS, {
       type: "chapter",
       chapterNumber,
@@ -354,9 +390,8 @@ export async function editChapterStep(
       tools: { userId: ref.userId, projectId: ref.projectId, bookId: book.id, chapterNumber },
       tier: config.tier,
       chapterNumber,
-      content: issueNotes
-        ? `${chapter.content}\n\n<!-- CONTINUITY NOTES TO ADDRESS -->\n${issueNotes}`
-        : chapter.content,
+      content: chapter.content,
+      revisionNotes: issueNotes,
       styleGuide: project.styleGuide ?? undefined,
     });
     if (edited.changed) {


### PR DESCRIPTION
## What

Applies the fixes from a full adversarially-verified code review (36 confirmed findings; the 21 highest-value contained ones fixed here). Report: `doc/review-report.html`.

### Security (all high/medium fixed)
- **Per-image billing** — the gateway bills image generation ~$0.067/image but it was metered on tokens (~$0.004), so a user at their hard cap could loop illustrations for real dollars. Now metered per image; regression test added.
- **Fail closed on missing Clerk keys** — a prod/preview deploy missing the key silently served a shared unauthenticated identity. `requireUser`/`proxy` now require an explicit dev opt-in and error loudly otherwise.
- **Export blob privacy** — tokenized (unguessable, retry-stable) paths + the download route proxies bytes instead of leaking the public URL via 302.

### Correctness (7 high + medium)
- Continuity revision notes no longer leak into the exported manuscript.
- Retry runs reuse the persisted concept/outline instead of clobbering real chapter summaries.
- `character_bible` writes are a single atomic jsonb upsert — fixes lost updates and a run-crashing unique violation under wave parallelism. **A `||`/`->` operator-precedence bug in the upsert was caught by live concurrent testing and fixed before shipping.**
- Transient DB errors are retryable, not fatal; zero-effect revisions don't dodge the edit gate; outline chapter count is bounded + clamped; standard-tier outline validation enforced.
- Editor: flush autosave on unmount, fix stale-flush reporting, freeze input during accept round-trips, anchor to the correct duplicate occurrence, sentinel guard, mark stale suggestions rejected, validate UUIDs.

### Concurrency / performance
- Partial unique index + 409 mapping closes the TOCTOU that let two concurrent POSTs start two paid workflows on one book (migration `0001`).
- `getProjectWithBook` → one LEFT JOIN + React.cache on hot readers (up to 6 sequential round trips per page → 1).

## Verification
272 unit tests + 12 E2E green; typecheck/lint/build clean; migration applied to Neon and index verified; atomic upsert (4 concurrent writers) and anchor-hint resolution live-verified against the database.

## Deferred (tracked in the report, not this PR)
12 lower-severity items needing a redesign or careful staging — per-substep summarizer checkpointing, live-stream reconnection edge cases, event-seq atomicity, minor tool query pushdowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)