### PR TITLE
Entity tracker: a story bible for characters, places, objects, organizations and events

### DIFF
--- a/drizzle/0002_loose_mephisto.sql
+++ b/drizzle/0002_loose_mephisto.sql
@@ -1,0 +1,61 @@
+CREATE TABLE "entities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"book_id" uuid NOT NULL,
+	"kind" text NOT NULL,
+	"name" text NOT NULL,
+	"aliases" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"attrs" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"portrait_asset_id" uuid,
+	"first_appearance_chapter" integer,
+	"last_updated_chapter" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "entity_relationships" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"book_id" uuid NOT NULL,
+	"from_entity_id" uuid NOT NULL,
+	"to_entity_id" uuid NOT NULL,
+	"type" text NOT NULL,
+	"description" text,
+	"established_chapter" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "entities" ADD CONSTRAINT "entities_book_id_books_id_fk" FOREIGN KEY ("book_id") REFERENCES "public"."books"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "entity_relationships" ADD CONSTRAINT "entity_relationships_book_id_books_id_fk" FOREIGN KEY ("book_id") REFERENCES "public"."books"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "entity_relationships" ADD CONSTRAINT "entity_relationships_from_entity_id_entities_id_fk" FOREIGN KEY ("from_entity_id") REFERENCES "public"."entities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "entity_relationships" ADD CONSTRAINT "entity_relationships_to_entity_id_entities_id_fk" FOREIGN KEY ("to_entity_id") REFERENCES "public"."entities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_entity_name" ON "entities" USING btree ("book_id","kind","name");--> statement-breakpoint
+CREATE INDEX "idx_entities_book" ON "entities" USING btree ("book_id","kind");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_entity_relationship" ON "entity_relationships" USING btree ("from_entity_id","to_entity_id","type");--> statement-breakpoint
+CREATE INDEX "idx_relationships_book" ON "entity_relationships" USING btree ("book_id");--> statement-breakpoint
+-- Backfill: every character_bible row becomes a kind='character' entity.
+-- The old `facts` jsonb held {role, appearance, personality, relationships,
+-- facts[], firstAppearance}; role and facts[] map directly, the rest is
+-- preserved under the same keys since the character attrs schema is a superset.
+INSERT INTO "entities" ("book_id", "kind", "name", "aliases", "attrs", "first_appearance_chapter", "last_updated_chapter", "created_at", "updated_at")
+SELECT
+  cb."book_id",
+  'character',
+  cb."name",
+  '[]'::jsonb,
+  jsonb_strip_nulls(
+    jsonb_build_object(
+      'role', cb."facts"->>'role',
+      'appearance', CASE
+        WHEN jsonb_typeof(cb."facts"->'appearance') = 'object'
+          THEN (SELECT string_agg(value, ', ') FROM jsonb_each_text(cb."facts"->'appearance'))
+        ELSE cb."facts"->>'appearance'
+      END,
+      'personality', CASE WHEN jsonb_typeof(cb."facts"->'personality') = 'array' THEN cb."facts"->'personality' ELSE '[]'::jsonb END,
+      'facts', CASE WHEN jsonb_typeof(cb."facts"->'facts') = 'array' THEN cb."facts"->'facts' ELSE '[]'::jsonb END
+    )
+  ),
+  NULLIF(cb."facts"->>'firstAppearance', '')::integer,
+  cb."updated_by_chapter",
+  cb."created_at",
+  cb."updated_at"
+FROM "character_bible" cb
+ON CONFLICT ("book_id", "kind", "name") DO NOTHING;

--- a/drizzle/0003_lyrical_shiver_man.sql
+++ b/drizzle/0003_lyrical_shiver_man.sql
@@ -1,0 +1,1 @@
+DROP TABLE "character_bible" CASCADE;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2037 @@
+{
+  "id": "fa28046f-7e37-455c-9460-a71af9fae45d",
+  "prevId": "01bdc3d6-3532-4b51-8e9d-ec171bd089de",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthly_limit_usd": {
+          "name": "monthly_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20.00'"
+        },
+        "hard_limit": {
+          "name": "hard_limit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "alert_threshold_pct": {
+          "name": "alert_threshold_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_bible": {
+      "name": "character_bible",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facts": {
+          "name": "facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_by_chapter": {
+          "name": "updated_by_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_character_name": {
+          "name": "uq_character_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_bible_book_id_books_id_fk": {
+          "name": "character_bible_book_id_books_id_fk",
+          "tableFrom": "character_bible",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "portrait_asset_id": {
+          "name": "portrait_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_appearance_chapter": {
+          "name": "first_appearance_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_chapter": {
+          "name": "last_updated_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_name": {
+          "name": "uq_entity_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_book": {
+          "name": "idx_entities_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_book_id_books_id_fk": {
+          "name": "entities_book_id_books_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationships": {
+      "name": "entity_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_chapter": {
+          "name": "established_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_relationship": {
+          "name": "uq_entity_relationship",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationships_book": {
+          "name": "idx_relationships_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_relationships_book_id_books_id_fk": {
+          "name": "entity_relationships_book_id_books_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_from_entity_id_entities_id_fk": {
+          "name": "entity_relationships_from_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_to_entity_id_entities_id_fk": {
+          "name": "entity_relationships_to_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1942 @@
+{
+  "id": "6d0ea05c-5619-4d4c-a71c-c546da9b7337",
+  "prevId": "fa28046f-7e37-455c-9460-a71af9fae45d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthly_limit_usd": {
+          "name": "monthly_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20.00'"
+        },
+        "hard_limit": {
+          "name": "hard_limit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "alert_threshold_pct": {
+          "name": "alert_threshold_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "portrait_asset_id": {
+          "name": "portrait_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_appearance_chapter": {
+          "name": "first_appearance_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_chapter": {
+          "name": "last_updated_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_name": {
+          "name": "uq_entity_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_book": {
+          "name": "idx_entities_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_book_id_books_id_fk": {
+          "name": "entities_book_id_books_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationships": {
+      "name": "entity_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_chapter": {
+          "name": "established_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_relationship": {
+          "name": "uq_entity_relationship",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationships_book": {
+          "name": "idx_relationships_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_relationships_book_id_books_id_fk": {
+          "name": "entity_relationships_book_id_books_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_from_entity_id_entities_id_fk": {
+          "name": "entity_relationships_from_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_to_entity_id_entities_id_fk": {
+          "name": "entity_relationships_to_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1785209284778,
       "tag": "0001_shocking_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785275441890,
+      "tag": "0002_loose_mephisto",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785275458792,
+      "tag": "0003_lyrical_shiver_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/agents/chapter-writer.ts
+++ b/src/ai/agents/chapter-writer.ts
@@ -80,7 +80,8 @@ function draftPrompt(ctx: ChapterWriterCtx, plan: ScenePlan): string {
     `Target length: about ${ctx.targetWords} words. Output plain markdown prose only — no JSON, no notes, no headings other than scene breaks if the style calls for them.`,
     `## Scene plan\n${JSON.stringify(plan, null, 2)}`,
     `## Working method`,
-    `Before writing a scene involving a character, call characterBibleGet for them. When you need an earlier event's details, call storySoFarSearch instead of inventing them. After you finish the draft, call characterBibleUpdate for any character you established new canonical facts about, then stop.`,
+    `Before writing anything involving a person, place, object, organization or event, call entityGet for it — the story bible is canon and you must not contradict it. If you are unsure whether something already exists, call entitySearch before inventing it, so you do not create a near-duplicate under a slightly different name. When you need an earlier event's details, call storySoFarSearch instead of inventing them.`,
+    `If you must introduce something new, derive its name from the entities it relates to: family members share surnames, and heritage governs naming. After you finish the draft, call entityUpsert for anything you established that later chapters must honor, entityRelate for any new relationship, then stop.`,
     `Open with: ${ctx.chapterOutline.openingHook}`,
     `Close with: ${ctx.chapterOutline.closingHook}`,
   ].join("\n\n");

--- a/src/ai/agents/concept.ts
+++ b/src/ai/agents/concept.ts
@@ -1,6 +1,7 @@
 import { generateText, isStepCount, Output } from "ai";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/db";
+import { seedEntities } from "@/db/queries/entities";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
 import { buildToolset, type ToolCtx } from "@/ai/tools";
@@ -79,10 +80,9 @@ export async function generateConcept(input: ConceptCtx): Promise<BookConcept> {
 }
 
 /**
- * Persists the concept onto the book row and seeds the character bible from
- * the concept's cast. Existing bible entries win (onConflictDoNothing on the
- * uq_character_name (bookId, name) index) so re-running never clobbers facts
- * later chapters added.
+ * Persists the concept onto the book row and seeds the story bible from the
+ * concept's cast. Existing entities win (onConflictDoNothing on
+ * uq_entity_name) so re-running never clobbers canon later chapters added.
  */
 export async function persistConcept(bookId: string, concept: BookConcept): Promise<void> {
   const db = getDb();
@@ -96,21 +96,12 @@ export async function persistConcept(bookId: string, concept: BookConcept): Prom
     })
     .where(eq(schema.books.id, bookId));
 
-  if (concept.characters.length > 0) {
-    await db
-      .insert(schema.characterBible)
-      .values(
-        concept.characters.map((c) => ({
-          bookId,
-          name: c.name,
-          facts: {
-            role: c.role,
-            facts: [c.description, `Arc: ${c.arc}`],
-          },
-        })),
-      )
-      .onConflictDoNothing({
-        target: [schema.characterBible.bookId, schema.characterBible.name],
-      });
-  }
+  await seedEntities(
+    bookId,
+    concept.characters.map((c) => ({
+      kind: "character" as const,
+      name: c.name,
+      attrs: { role: c.role, facts: [c.description, `Arc: ${c.arc}`] },
+    })),
+  );
 }

--- a/src/ai/agents/entity-bible.ts
+++ b/src/ai/agents/entity-bible.ts
@@ -1,0 +1,135 @@
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
+import { MODELS, type QualityTier } from "@/ai/models";
+import { ENTITY_KINDS, RELATIONSHIP_TYPES } from "@/ai/schemas/entities";
+import type { BookConcept, BookOutline } from "@/ai/schemas";
+import { applyEntityDeltas, seedEntities, type EntitySeed } from "@/db/queries/entities";
+
+/**
+ * Builds the story bible before drafting starts.
+ *
+ * The problem this solves: without a canon established up front, chapter 9
+ * invents a surname for a sister that chapter 2 never gave, or gives the hero's
+ * sword a jewel it never had. So every entity is interrogated once — who are
+ * they to the story, what do they do, what do they look like, what heritage do
+ * they come from — and, crucially, names are *derived* from the entities they
+ * are related to rather than picked in isolation.
+ */
+
+const bibleSchema = z.object({
+  entities: z
+    .array(
+      z.object({
+        kind: z.enum(ENTITY_KINDS),
+        name: z.string(),
+        aliases: z.array(z.string()).max(4).default([]),
+        attrs: z.record(z.string(), z.unknown()).default({}),
+      }),
+    )
+    .max(60),
+  relationships: z
+    .array(
+      z.object({
+        from: z.string(),
+        to: z.string(),
+        type: z.enum(RELATIONSHIP_TYPES),
+        description: z.string().max(300).optional(),
+      }),
+    )
+    .max(60)
+    .default([]),
+});
+
+function bibleInstructions(): string {
+  return [
+    `You are a story bible editor. Before a word of prose is written you establish the canon that every chapter must honor.`,
+    ``,
+    `For each entity, answer the questions that keep a long book consistent:`,
+    `- character: what are they to the story (protagonist, foil, obstacle)? what is their occupation? what would a reader picture when they appear? what cultural or regional heritage do they come from? how do they speak? what do they want, and what are they hiding?`,
+    `- location: what kind of place is it, what does it physically contain, who owns it, how does it feel to be in?`,
+    `- object: what does it look like in specific terms, where did it come from, who holds it, why does it matter?`,
+    `- organization: what is it for, how is it structured, who belongs, how is it regarded?`,
+    `- event: when does it occur, who takes part, what is the outcome?`,
+    ``,
+    `Naming is not decoration. Derive every name from the entity's heritage and from the names of entities it is related to — siblings and parents share surnames, a household's servants may carry regional names, a ship and its owner may echo each other. Record the reasoning in nameRationale. Never assign a name that contradicts an established family tie.`,
+    ``,
+    `Record relationships explicitly, especially family ties, ownership, and membership.`,
+    `Be specific. "Tall and dark-haired" is useless; "a head taller than everyone in the room, with the family's heavy black brows" is canon.`,
+  ].join("\n");
+}
+
+/**
+ * Derives the initial cast and world. Runs once, after the outline, before any
+ * chapter is drafted.
+ */
+export async function buildEntityBible(input: {
+  meter: MeterCtx;
+  bookId: string;
+  tier: QualityTier;
+  concept: BookConcept;
+  outline: BookOutline;
+  genre?: string;
+  existingNames?: string[];
+}): Promise<{ entityCount: number; relationshipCount: number }> {
+  const model = MODELS[input.tier].summarizer;
+
+  const chapterDigest = input.outline.chapters
+    .map((c) => `${c.number}. ${c.title} — ${c.summary} [${c.charactersPresent.join(", ")}]`)
+    .join("\n");
+
+  const result = await metered(
+    input.meter,
+    { role: "entity-bible", operation: "entity.bible", model },
+    () =>
+      generateText({
+        model,
+        instructions: bibleInstructions(),
+        prompt: [
+          `## Book`,
+          `${input.concept.title} — ${input.concept.logline}`,
+          input.genre ? `Genre: ${input.genre}` : "",
+          `Setting: ${input.concept.setting}`,
+          `Central conflict: ${input.concept.centralConflict}`,
+          ``,
+          `## Cast from the concept`,
+          input.concept.characters
+            .map((c) => `- ${c.name} (${c.role}): ${c.description} Arc: ${c.arc}`)
+            .join("\n"),
+          ``,
+          `## Chapter outline`,
+          chapterDigest,
+          ``,
+          input.existingNames?.length
+            ? `## Already in the bible — do not duplicate, and derive new names consistently with these\n${input.existingNames.join(", ")}`
+            : "",
+          ``,
+          `Produce the story bible: every character named in the outline, every location the story visits, every object that carries weight, plus any organizations and named events. Then the relationships between them.`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        output: Output.object({ schema: bibleSchema }),
+        providerOptions: gatewayOptions(input.meter, "entity-bible"),
+      }),
+  );
+
+  const bible = result.output;
+
+  const seeds: EntitySeed[] = bible.entities.map((e) => ({
+    kind: e.kind,
+    name: e.name,
+    aliases: e.aliases,
+    attrs: e.attrs,
+  }));
+  await seedEntities(input.bookId, seeds);
+
+  // Relationships are applied after the entities exist so both endpoints resolve.
+  await applyEntityDeltas({
+    bookId: input.bookId,
+    newFacts: [],
+    relationships: bible.relationships.map((r) => ({ from: r.from, to: r.to, type: r.type })),
+  });
+
+  return { entityCount: seeds.length, relationshipCount: bible.relationships.length };
+}

--- a/src/ai/agents/summarizer.ts
+++ b/src/ai/agents/summarizer.ts
@@ -1,14 +1,19 @@
 import { generateText, Output } from "ai";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
 import { chapterSummarySchema, type ChapterSummary } from "@/ai/schemas";
+import { applyEntityDeltas } from "@/db/queries/entities";
 
 /**
- * Writes the rolling ~250-token summary + character-bible facts delta after a
- * chapter is drafted. This is what makes later chapters cheap: successors read
- * summaries and query the bible instead of ingesting full prior chapters.
+ * Writes the rolling ~250-token summary + the story-bible delta after a chapter
+ * is drafted. This is what makes later chapters cheap: successors read summaries
+ * and query the bible instead of ingesting full prior chapters.
+ *
+ * Entity upkeep deliberately rides on this existing call rather than adding a
+ * per-chapter request of its own — the marginal cost is a few hundred output
+ * tokens.
  */
 export async function summarizeChapter(input: {
   meter: MeterCtx;
@@ -29,7 +34,8 @@ export async function summarizeChapter(input: {
           "You maintain a book's story memory. Summarize tightly and extract only facts future chapters must honor.",
         prompt: [
           `Summarize chapter ${input.chapterNumber} ("${input.chapterTitle ?? "untitled"}") in at most 200 words, covering plot events, character developments, and any objects/promises/injuries that matter later.`,
-          `Then list new canonical facts per character introduced in this chapter (only durable facts — appearance, relationships, possessions, wounds, secrets, commitments).`,
+          `Then list new canonical facts per entity this chapter established — not only characters but also locations (what a place contains), objects (who holds it, what it does), organizations and named events. Record only durable facts a later chapter must honor: appearance, heritage, possessions, wounds, secrets, commitments, contents, ownership.`,
+          `Also list any relationships the chapter established between named entities (family ties especially — they govern surnames).`,
           `## Chapter text\n${input.content}`,
         ].join("\n\n"),
         output: Output.object({ schema: chapterSummarySchema }),
@@ -49,26 +55,12 @@ export async function summarizeChapter(input: {
       ),
     );
 
-  // Atomic upsert: concurrent chapter steps in a wave append facts without
-  // lost updates or racing the uq_character_name unique index.
-  for (const entry of summary.newFacts) {
-    await db
-      .insert(schema.characterBible)
-      .values({
-        bookId: input.bookId,
-        name: entry.character,
-        facts: { facts: entry.facts, firstAppearance: input.chapterNumber },
-        updatedByChapter: input.chapterNumber,
-      })
-      .onConflictDoUpdate({
-        target: [schema.characterBible.bookId, schema.characterBible.name],
-        set: {
-          facts: sql`jsonb_set(${schema.characterBible.facts}, '{facts}', coalesce(${schema.characterBible.facts}->'facts', '[]'::jsonb) || (excluded.facts->'facts'))`,
-          updatedByChapter: input.chapterNumber,
-          updatedAt: new Date(),
-        },
-      });
-  }
+  await applyEntityDeltas({
+    bookId: input.bookId,
+    chapterNumber: input.chapterNumber,
+    newFacts: summary.newFacts,
+    relationships: summary.relationships,
+  });
 
   return summary;
 }

--- a/src/ai/schemas/entities.ts
+++ b/src/ai/schemas/entities.ts
@@ -1,0 +1,156 @@
+import { z } from "zod";
+
+/**
+ * The story bible's entity model.
+ *
+ * Consistency drift in long books is rarely about plot — it is about details:
+ * a character's eyes changing colour, a sword gaining a jewel it never had, a
+ * house growing a room. Each kind therefore gets a purpose-built attribute
+ * schema rather than a bag of free text, so the writer can be asked for
+ * specific facts and the continuity pass has something concrete to check.
+ *
+ * Every kind carries `facts`, an append-only list. That shared channel is what
+ * makes the atomic jsonb merge in `entityUpsert` possible across a wave of
+ * concurrently drafting chapters.
+ */
+
+export const ENTITY_KINDS = ["character", "location", "object", "organization", "event"] as const;
+export type EntityKind = (typeof ENTITY_KINDS)[number];
+
+/** Accreted canon: short declarative statements later chapters must honour. */
+const facts = z.array(z.string()).default([]);
+
+export const characterAttrs = z.object({
+  role: z.string().optional().describe("Role in the story — protagonist, foil, antagonist, etc."),
+  occupation: z.string().optional().describe("What they do for a living"),
+  appearance: z.string().optional().describe("Physical description a reader would picture"),
+  heritage: z
+    .string()
+    .optional()
+    .describe("Cultural, ethnic or regional background informing name and speech"),
+  age: z.string().optional(),
+  speech: z.string().optional().describe("How they talk — register, verbal tics, dialect"),
+  personality: z.array(z.string()).default([]),
+  goals: z.array(z.string()).default([]),
+  secrets: z.array(z.string()).default([]),
+  nameRationale: z
+    .string()
+    .optional()
+    .describe("Why this name — family ties, heritage, naming conventions it follows"),
+  facts,
+});
+
+export const locationAttrs = z.object({
+  locationType: z.string().optional().describe("House, tavern, city, ship, forest…"),
+  description: z.string().optional(),
+  features: z.array(z.string()).default([]).describe("Fixed, memorable characteristics"),
+  contents: z
+    .array(z.string())
+    .default([])
+    .describe("Notable things inside it — furniture, objects, rooms"),
+  atmosphere: z.string().optional().describe("How the place feels to be in"),
+  owner: z.string().optional().describe("Character or organization it belongs to"),
+  facts,
+});
+
+export const objectAttrs = z.object({
+  description: z.string().optional().describe("What it looks like, in specific terms"),
+  significance: z.string().optional().describe("Why it matters to the story"),
+  provenance: z.string().optional().describe("Where it came from, who made it"),
+  holder: z.string().optional().describe("Who currently has it"),
+  capabilities: z.array(z.string()).default([]).describe("What it can do, if anything"),
+  facts,
+});
+
+export const organizationAttrs = z.object({
+  purpose: z.string().optional(),
+  structure: z.string().optional().describe("How it is organized and led"),
+  members: z.array(z.string()).default([]),
+  reputation: z.string().optional().describe("How outsiders regard it"),
+  facts,
+});
+
+export const eventAttrs = z.object({
+  when: z.string().optional().describe("When it happens relative to the story"),
+  participants: z.array(z.string()).default([]),
+  outcome: z.string().optional(),
+  significance: z.string().optional(),
+  facts,
+});
+
+export const ENTITY_ATTRS = {
+  character: characterAttrs,
+  location: locationAttrs,
+  object: objectAttrs,
+  organization: organizationAttrs,
+  event: eventAttrs,
+} as const;
+
+export type EntityAttrs =
+  | z.infer<typeof characterAttrs>
+  | z.infer<typeof locationAttrs>
+  | z.infer<typeof objectAttrs>
+  | z.infer<typeof organizationAttrs>
+  | z.infer<typeof eventAttrs>;
+
+export function attrsSchemaFor(kind: EntityKind) {
+  return ENTITY_ATTRS[kind];
+}
+
+/** Parses attrs for a kind, dropping unknown keys rather than throwing. */
+export function parseAttrs(kind: EntityKind, value: unknown): EntityAttrs {
+  const result = attrsSchemaFor(kind).safeParse(value ?? {});
+  return result.success ? result.data : (attrsSchemaFor(kind).parse({}) as EntityAttrs);
+}
+
+/**
+ * Scalar attributes worth guarding. A change to one of these is a likely
+ * continuity error (eyes changing colour); list-valued fields such as `facts`
+ * or `personality` only ever accumulate and are never treated as conflicts.
+ */
+export const GUARDED_ATTRS: Record<EntityKind, string[]> = {
+  character: ["appearance", "heritage", "age", "occupation"],
+  location: ["locationType", "owner"],
+  object: ["description", "provenance"],
+  organization: ["purpose", "structure"],
+  event: ["when", "outcome"],
+};
+
+export const RELATIONSHIP_TYPES = [
+  "parent",
+  "child",
+  "sibling",
+  "spouse",
+  "friend",
+  "rival",
+  "enemy",
+  "mentor",
+  "employer",
+  "member-of",
+  "owns",
+  "located-in",
+  "created",
+  "participated-in",
+  "other",
+] as const;
+export type RelationshipType = (typeof RELATIONSHIP_TYPES)[number];
+
+/** Relationship kinds that imply a shared family name. Drives name derivation. */
+export const FAMILY_RELATIONSHIPS: RelationshipType[] = ["parent", "child", "sibling", "spouse"];
+
+/** Maps an entity kind onto the continuity_issues category vocabulary. */
+export const KIND_TO_ISSUE_CATEGORY: Record<EntityKind, "character" | "setting" | "plot"> = {
+  character: "character",
+  location: "setting",
+  object: "plot",
+  organization: "setting",
+  event: "plot",
+};
+
+export const entityInputSchema = z.object({
+  kind: z.enum(ENTITY_KINDS),
+  name: z.string().min(1).max(120),
+  aliases: z.array(z.string()).default([]),
+  attrs: z.record(z.string(), z.unknown()).default({}),
+});
+export type EntityInput = z.infer<typeof entityInputSchema>;

--- a/src/ai/schemas/index.ts
+++ b/src/ai/schemas/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ENTITY_KINDS } from "./entities";
 
 export const conceptSchema = z.object({
   title: z.string(),
@@ -103,14 +104,30 @@ export type Revision = z.infer<typeof revisionSchema>;
 
 export const chapterSummarySchema = z.object({
   summary: z.string().max(2_000),
+  /**
+   * Entity deltas ride along on the summarizer call that already runs after
+   * every chapter, so per-chapter bible upkeep costs a few hundred output
+   * tokens rather than a second request per chapter.
+   */
   newFacts: z
     .array(
       z.object({
-        character: z.string(),
+        kind: z.enum(ENTITY_KINDS).default("character"),
+        name: z.string(),
         facts: z.array(z.string()).max(8),
       }),
     )
-    .max(10),
+    .max(16),
+  relationships: z
+    .array(
+      z.object({
+        from: z.string(),
+        to: z.string(),
+        type: z.string(),
+      }),
+    )
+    .max(10)
+    .default([]),
   timelineNote: z.string().optional(),
 });
 export type ChapterSummary = z.infer<typeof chapterSummarySchema>;

--- a/src/ai/tools/entities.test.ts
+++ b/src/ai/tools/entities.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { findConflicts } from "./entities";
+import {
+  GUARDED_ATTRS,
+  KIND_TO_ISSUE_CATEGORY,
+  attrsSchemaFor,
+  parseAttrs,
+  ENTITY_KINDS,
+} from "@/ai/schemas/entities";
+
+describe("per-kind attribute schemas", () => {
+  it("gives every kind a schema", () => {
+    for (const kind of ENTITY_KINDS) {
+      expect(attrsSchemaFor(kind)).toBeDefined();
+    }
+  });
+
+  it("defaults list fields so the jsonb merge always has an array to concat", () => {
+    for (const kind of ENTITY_KINDS) {
+      const parsed = parseAttrs(kind, {}) as { facts?: string[] };
+      expect(Array.isArray(parsed.facts)).toBe(true);
+    }
+  });
+
+  it("keeps the kind-specific fields the bible depends on", () => {
+    const character = parseAttrs("character", {
+      heritage: "Coastal Averrin",
+      nameRationale: "Shares the Vantry surname with her mother",
+      appearance: "tide-weathered, rope-scarred hands",
+      bogus: "dropped",
+    }) as Record<string, unknown>;
+    expect(character.heritage).toBe("Coastal Averrin");
+    expect(character.nameRationale).toContain("Vantry");
+    expect(character.bogus).toBeUndefined();
+  });
+
+  it("records what a location contains — the television-in-the-den case", () => {
+    const location = parseAttrs("location", {
+      locationType: "family home",
+      contents: ["a television in the den", "her father's charts"],
+    }) as Record<string, unknown>;
+    expect(location.contents).toEqual(["a television in the den", "her father's charts"]);
+  });
+
+  it("drops malformed attrs rather than throwing mid-generation", () => {
+    const parsed = parseAttrs("object", { capabilities: "not-an-array" }) as {
+      capabilities?: string[];
+    };
+    expect(Array.isArray(parsed.capabilities)).toBe(true);
+  });
+});
+
+describe("findConflicts", () => {
+  it("flags a guarded scalar changing — the drift we care about", () => {
+    const conflicts = findConflicts(
+      "character",
+      { appearance: "grey eyes", facts: ["a"] },
+      { appearance: "green eyes", facts: ["b"] },
+    );
+    expect(conflicts).toEqual([{ field: "appearance", from: "grey eyes", to: "green eyes" }]);
+  });
+
+  it("ignores case and surrounding whitespace", () => {
+    expect(
+      findConflicts("character", { appearance: "Grey eyes" }, { appearance: " grey eyes " }),
+    ).toEqual([]);
+  });
+
+  it("does not treat first-time establishment as a conflict", () => {
+    expect(findConflicts("character", {}, { appearance: "grey eyes" })).toEqual([]);
+  });
+
+  it("does not treat an omitted field as a conflict", () => {
+    expect(findConflicts("character", { appearance: "grey eyes" }, {})).toEqual([]);
+  });
+
+  it("never flags list fields — facts only ever accumulate", () => {
+    const conflicts = findConflicts(
+      "character",
+      { facts: ["was in Averrin"], personality: ["blunt"] },
+      { facts: ["left Averrin"], personality: ["warm"] },
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  it("guards object provenance so a sword cannot change origin", () => {
+    const conflicts = findConflicts(
+      "object",
+      { provenance: "forged by her mother" },
+      { provenance: "bought in the market" },
+    );
+    expect(conflicts.map((c) => c.field)).toEqual(["provenance"]);
+  });
+
+  it("guards a field for every kind", () => {
+    for (const kind of ENTITY_KINDS) {
+      expect(GUARDED_ATTRS[kind].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("KIND_TO_ISSUE_CATEGORY", () => {
+  it("maps every kind onto the continuity_issues vocabulary", () => {
+    const allowed = new Set(["character", "timeline", "setting", "plot", "factual"]);
+    for (const kind of ENTITY_KINDS) {
+      expect(allowed.has(KIND_TO_ISSUE_CATEGORY[kind])).toBe(true);
+    }
+  });
+});

--- a/src/ai/tools/entities.ts
+++ b/src/ai/tools/entities.ts
@@ -1,0 +1,292 @@
+import { tool } from "ai";
+import { and, eq, ilike, or, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import {
+  ENTITY_KINDS,
+  GUARDED_ATTRS,
+  KIND_TO_ISSUE_CATEGORY,
+  RELATIONSHIP_TYPES,
+  parseAttrs,
+  type EntityKind,
+} from "@/ai/schemas/entities";
+
+/**
+ * Story-bible tools. These are the agents' only authoritative source for who
+ * someone is, what a place contains, or what an object can do — the point being
+ * that a chapter written in wave 3 asks rather than invents.
+ */
+
+export type EntityToolCtx = {
+  bookId: string;
+  chapterNumber?: number;
+};
+
+/** Scalar attrs that already have a different value — the drift we care about. */
+export function findConflicts(
+  kind: EntityKind,
+  existing: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): { field: string; from: string; to: string }[] {
+  const conflicts: { field: string; from: string; to: string }[] = [];
+  for (const field of GUARDED_ATTRS[kind]) {
+    const before = existing[field];
+    const after = incoming[field];
+    if (typeof before !== "string" || typeof after !== "string") continue;
+    if (!before.trim() || !after.trim()) continue;
+    if (before.trim().toLowerCase() !== after.trim().toLowerCase()) {
+      conflicts.push({ field, from: before, to: after });
+    }
+  }
+  return conflicts;
+}
+
+export function entityGet(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Look up canonical facts about people, places, objects, organizations or events in this book. Consult before writing anything involving one — never invent a detail that might already be established.",
+    inputSchema: z.object({
+      names: z.array(z.string()).min(1).max(8).describe("Entity names to look up"),
+      kind: z.enum(ENTITY_KINDS).optional().describe("Narrow the lookup to one kind"),
+    }),
+    execute: async ({ names, kind }) => {
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(schema.entities)
+        .where(
+          kind
+            ? and(eq(schema.entities.bookId, ctx.bookId), eq(schema.entities.kind, kind))
+            : eq(schema.entities.bookId, ctx.bookId),
+        );
+
+      const wanted = new Set(names.map((n) => n.toLowerCase()));
+      const matches = (row: (typeof rows)[number]) =>
+        wanted.has(row.name.toLowerCase()) ||
+        row.aliases.some((alias) => wanted.has(alias.toLowerCase()));
+
+      const found = rows.filter(matches);
+      const ids = found.map((r) => r.id);
+
+      // Relationships give the writer the family/ownership context that keeps
+      // names and possessions consistent.
+      const relationships = ids.length
+        ? await db
+            .select({
+              from: schema.entityRelationships.fromEntityId,
+              to: schema.entityRelationships.toEntityId,
+              type: schema.entityRelationships.type,
+              description: schema.entityRelationships.description,
+            })
+            .from(schema.entityRelationships)
+            .where(eq(schema.entityRelationships.bookId, ctx.bookId))
+        : [];
+
+      const nameById = new Map(rows.map((r) => [r.id, r.name]));
+
+      return {
+        entities: found.map((r) => ({
+          kind: r.kind,
+          name: r.name,
+          aliases: r.aliases,
+          attrs: r.attrs,
+          firstAppearanceChapter: r.firstAppearanceChapter,
+          relationships: relationships
+            .filter((rel) => rel.from === r.id || rel.to === r.id)
+            .map((rel) => ({
+              type: rel.type,
+              other: nameById.get(rel.from === r.id ? rel.to : rel.from) ?? "unknown",
+              direction: rel.from === r.id ? "outgoing" : "incoming",
+              description: rel.description,
+            })),
+        })),
+        missing: names.filter(
+          (n) =>
+            !found.some(
+              (r) =>
+                r.name.toLowerCase() === n.toLowerCase() ||
+                r.aliases.some((a) => a.toLowerCase() === n.toLowerCase()),
+            ),
+        ),
+      };
+    },
+  });
+}
+
+export function entitySearch(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Search the story bible by partial name or kind when you do not know the exact name. Use before inventing a new entity, to avoid creating a duplicate under a slightly different name.",
+    inputSchema: z.object({
+      query: z.string().min(1).max(80).optional(),
+      kind: z.enum(ENTITY_KINDS).optional(),
+      limit: z.number().int().min(1).max(50).default(20),
+    }),
+    execute: async ({ query, kind, limit }) => {
+      const db = getDb();
+      const filters = [eq(schema.entities.bookId, ctx.bookId)];
+      if (kind) filters.push(eq(schema.entities.kind, kind));
+      if (query) {
+        const like = `%${query}%`;
+        filters.push(
+          or(
+            ilike(schema.entities.name, like),
+            sql`${schema.entities.aliases}::text ilike ${like}`,
+          )!,
+        );
+      }
+      const rows = await db
+        .select({
+          kind: schema.entities.kind,
+          name: schema.entities.name,
+          aliases: schema.entities.aliases,
+          firstAppearanceChapter: schema.entities.firstAppearanceChapter,
+        })
+        .from(schema.entities)
+        .where(and(...filters))
+        .limit(limit);
+      return { results: rows };
+    },
+  });
+}
+
+export function entityUpsert(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Create or update an entity in the story bible. Call after drafting for anything you established that later chapters must honor — a character's appearance, what a room contains, who holds an object. Contradicting an existing detail is recorded as a continuity issue rather than silently overwriting canon.",
+    inputSchema: z.object({
+      kind: z.enum(ENTITY_KINDS),
+      name: z.string().min(1).max(120),
+      aliases: z.array(z.string()).max(8).default([]),
+      attrs: z
+        .record(z.string(), z.unknown())
+        .default({})
+        .describe("Kind-appropriate attributes. Include `facts` for new canonical statements."),
+    }),
+    execute: async ({ kind, name, aliases, attrs }) => {
+      const db = getDb();
+      const parsed = parseAttrs(kind, attrs) as Record<string, unknown>;
+
+      const [existing] = await db
+        .select({ id: schema.entities.id, attrs: schema.entities.attrs })
+        .from(schema.entities)
+        .where(
+          and(
+            eq(schema.entities.bookId, ctx.bookId),
+            eq(schema.entities.kind, kind),
+            eq(schema.entities.name, name),
+          ),
+        )
+        .limit(1);
+
+      const conflicts = existing ? findConflicts(kind, existing.attrs, parsed) : [];
+      if (conflicts.length > 0) {
+        await db.insert(schema.continuityIssues).values(
+          conflicts.map((c) => ({
+            bookId: ctx.bookId,
+            chapters: ctx.chapterNumber ? [ctx.chapterNumber] : [],
+            category: KIND_TO_ISSUE_CATEGORY[kind],
+            severity: "major" as const,
+            description: `${kind} "${name}": ${c.field} was established as "${c.from}" but chapter ${ctx.chapterNumber ?? "?"} says "${c.to}".`,
+            suggestedFix: `Keep the established "${c.from}" unless the change is deliberate and explained in the prose.`,
+          })),
+        );
+      }
+
+      // Guarded scalars stay as first established; everything else may refine.
+      const conflicted = new Set(conflicts.map((c) => c.field));
+      const safeAttrs = Object.fromEntries(
+        Object.entries(parsed).filter(([key]) => !conflicted.has(key)),
+      );
+      const { facts: incomingFacts = [], ...scalars } = safeAttrs as {
+        facts?: string[];
+        [key: string]: unknown;
+      };
+
+      // Atomic: chapters draft four at a time, so merge in one statement rather
+      // than read-modify-write. The parens around (excluded.attrs->'facts') are
+      // load-bearing — `||` and `->` are equal precedence and left-associative,
+      // so without them this parses as (attrs || excluded.attrs)->'facts'.
+      await db
+        .insert(schema.entities)
+        .values({
+          bookId: ctx.bookId,
+          kind,
+          name,
+          aliases,
+          attrs: { ...scalars, facts: incomingFacts },
+          firstAppearanceChapter: ctx.chapterNumber,
+          lastUpdatedChapter: ctx.chapterNumber,
+        })
+        .onConflictDoUpdate({
+          target: [schema.entities.bookId, schema.entities.kind, schema.entities.name],
+          set: {
+            attrs: sql`jsonb_set(
+              ${schema.entities.attrs} || (${JSON.stringify(scalars)}::jsonb),
+              '{facts}',
+              coalesce(${schema.entities.attrs}->'facts', '[]'::jsonb) || (excluded.attrs->'facts')
+            )`,
+            aliases: sql`(
+              select coalesce(jsonb_agg(distinct value), '[]'::jsonb)
+              from jsonb_array_elements(${schema.entities.aliases} || excluded.aliases)
+            )`,
+            lastUpdatedChapter: ctx.chapterNumber,
+            updatedAt: new Date(),
+          },
+        });
+
+      return {
+        recorded: true,
+        kind,
+        name,
+        conflicts: conflicts.map((c) => `${c.field}: "${c.from}" vs "${c.to}"`),
+      };
+    },
+  });
+}
+
+export function entityRelate(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Record a relationship between two entities — siblings, an owner and a possession, a member and their organization. Family relationships are what let later chapters derive consistent surnames.",
+    inputSchema: z.object({
+      from: z.string().min(1).describe("Name of the entity the relationship starts at"),
+      to: z.string().min(1).describe("Name of the related entity"),
+      type: z.enum(RELATIONSHIP_TYPES),
+      description: z.string().max(400).optional(),
+    }),
+    execute: async ({ from, to, type, description }) => {
+      const db = getDb();
+      const rows = await db
+        .select({ id: schema.entities.id, name: schema.entities.name })
+        .from(schema.entities)
+        .where(eq(schema.entities.bookId, ctx.bookId));
+
+      const lookup = (name: string) =>
+        rows.find((r) => r.name.toLowerCase() === name.toLowerCase());
+      const fromRow = lookup(from);
+      const toRow = lookup(to);
+      if (!fromRow || !toRow) {
+        return {
+          recorded: false,
+          reason: `Unknown entity: ${!fromRow ? from : to}. Create it with entityUpsert first.`,
+        };
+      }
+
+      await db
+        .insert(schema.entityRelationships)
+        .values({
+          bookId: ctx.bookId,
+          fromEntityId: fromRow.id,
+          toEntityId: toRow.id,
+          type,
+          description,
+          establishedChapter: ctx.chapterNumber,
+        })
+        .onConflictDoNothing();
+
+      return { recorded: true, from: fromRow.name, to: toRow.name, type };
+    },
+  });
+}

--- a/src/ai/tools/index.ts
+++ b/src/ai/tools/index.ts
@@ -2,6 +2,7 @@ import { tool, type ToolSet } from "ai";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "@/db";
+import { entityGet, entityRelate, entitySearch, entityUpsert } from "@/ai/tools/entities";
 import { analyzeQuality, getQualityRecommendations } from "@/ai/analysis/quality-metrics";
 import { analyzePacing } from "@/ai/analysis/pacing";
 import { getGenreTemplate, chapterPromptForGenre, genreAvoidList } from "@/ai/knowledge/genres";
@@ -15,65 +16,6 @@ export type ToolCtx = {
 };
 
 export type AgentRole = "writer" | "outliner" | "editor" | "continuity" | "concept";
-
-function characterBibleGet(ctx: ToolCtx) {
-  return tool({
-    description:
-      "Look up canonical facts about characters (appearance, personality, relationships, established facts). Always consult before writing a scene involving a character.",
-    inputSchema: z.object({
-      names: z.array(z.string()).min(1).max(8).describe("Character names to look up"),
-    }),
-    execute: async ({ names }) => {
-      const db = getDb();
-      const rows = await db
-        .select()
-        .from(schema.characterBible)
-        .where(eq(schema.characterBible.bookId, ctx.bookId));
-      const wanted = new Set(names.map((n) => n.toLowerCase()));
-      const found = rows.filter((r) => wanted.has(r.name.toLowerCase()));
-      const missing = names.filter(
-        (n) => !found.some((r) => r.name.toLowerCase() === n.toLowerCase()),
-      );
-      return {
-        characters: found.map((r) => ({ name: r.name, facts: r.facts })),
-        missing,
-      };
-    },
-  });
-}
-
-function characterBibleUpdate(ctx: ToolCtx) {
-  return tool({
-    description:
-      "Record new canonical facts you introduced for a character (names, injuries, promises, object locations, relationship changes). Call after drafting when you established something future chapters must honor.",
-    inputSchema: z.object({
-      name: z.string(),
-      facts: z.array(z.string()).min(1).max(8).describe("New canonical facts, one per entry"),
-    }),
-    execute: async ({ name, facts }) => {
-      const db = getDb();
-      // Atomic upsert: concurrent chapter steps in a wave append facts without
-      // lost updates or racing the uq_character_name unique index.
-      await db
-        .insert(schema.characterBible)
-        .values({
-          bookId: ctx.bookId,
-          name,
-          facts: { facts, firstAppearance: ctx.chapterNumber },
-          updatedByChapter: ctx.chapterNumber,
-        })
-        .onConflictDoUpdate({
-          target: [schema.characterBible.bookId, schema.characterBible.name],
-          set: {
-            facts: sql`jsonb_set(${schema.characterBible.facts}, '{facts}', coalesce(${schema.characterBible.facts}->'facts', '[]'::jsonb) || (excluded.facts->'facts'))`,
-            updatedByChapter: ctx.chapterNumber,
-            updatedAt: new Date(),
-          },
-        });
-      return { recorded: true, name, factCount: facts.length };
-    },
-  });
-}
 
 function storySoFarSearch(ctx: ToolCtx) {
   return tool({
@@ -306,8 +248,10 @@ export function buildToolset(role: AgentRole, ctx: ToolCtx): ToolSet {
   switch (role) {
     case "writer":
       return {
-        characterBibleGet: characterBibleGet(ctx),
-        characterBibleUpdate: characterBibleUpdate(ctx),
+        entityGet: entityGet(ctx),
+        entitySearch: entitySearch(ctx),
+        entityUpsert: entityUpsert(ctx),
+        entityRelate: entityRelate(ctx),
         storySoFarSearch: storySoFarSearch(ctx),
         storySoFarRecent: storySoFarRecent(ctx),
         outlineGetChapter: outlineGetChapter(ctx),
@@ -317,19 +261,21 @@ export function buildToolset(role: AgentRole, ctx: ToolCtx): ToolSet {
       return {
         knowledgePlotStructure,
         knowledgeGenre,
-        characterBibleGet: characterBibleGet(ctx),
+        entityGet: entityGet(ctx),
+        entitySearch: entitySearch(ctx),
       };
     case "editor":
       return {
         qualityAnalyze,
         outlineGetChapter: outlineGetChapter(ctx),
-        characterBibleGet: characterBibleGet(ctx),
+        entityGet: entityGet(ctx),
       };
     case "continuity":
       return {
         chaptersGetText: chaptersGetText(ctx),
         storySoFarSearch: storySoFarSearch(ctx),
-        characterBibleGet: characterBibleGet(ctx),
+        entityGet: entityGet(ctx),
+        entitySearch: entitySearch(ctx),
         outlineGetStructure: outlineGetStructure(ctx),
         continuityRecordIssue: continuityRecordIssue(ctx),
       };

--- a/src/app/(studio)/projects/[projectId]/bible/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/bible/page.tsx
@@ -1,0 +1,94 @@
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { EntityCard } from "@/components/bible/entity-card";
+import { requireUser } from "@/lib/auth";
+import { getProjectWithBook } from "@/db/queries/books";
+import { listEntities, openContradictions } from "@/db/queries/entities";
+import { ENTITY_KINDS, type EntityKind } from "@/ai/schemas/entities";
+
+const KIND_LABELS: Record<EntityKind, string> = {
+  character: "Characters",
+  location: "Locations",
+  object: "Objects",
+  organization: "Organizations",
+  event: "Events",
+};
+
+export default async function BiblePage({ params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params;
+  const { userId } = await requireUser();
+  const data = await getProjectWithBook(userId, projectId);
+  if (!data) notFound();
+  const { book } = data;
+
+  const [entities, contradictions] = await Promise.all([
+    book ? listEntities(book.id) : Promise.resolve([]),
+    book ? openContradictions(book.id) : Promise.resolve([]),
+  ]);
+
+  if (entities.length === 0) {
+    return (
+      <div className="space-y-4">
+        <h2 className="font-display text-xl font-semibold tracking-tight">Story bible</h2>
+        <div className="paper-surface flex flex-col items-center gap-3 px-6 py-16 text-center">
+          <p aria-hidden="true" className="text-2xl text-paper-muted">
+            ⁂
+          </p>
+          <h3 className="font-display text-lg font-semibold text-paper-foreground">
+            Nothing recorded yet
+          </h3>
+          <p className="max-w-md font-serif text-paper-muted italic">
+            The bible fills in as your book is written — the cast and world are established before
+            drafting, then every chapter adds what it establishes.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  /** Contradictions are per-book; match them to entities by name mention. */
+  const contradictionsFor = (name: string) =>
+    contradictions.filter((issue) => issue.description.toLowerCase().includes(name.toLowerCase()));
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h2 className="font-display text-xl font-semibold tracking-tight">Story bible</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Canon every chapter must honor. {entities.length}{" "}
+            {entities.length === 1 ? "entry" : "entries"}.
+          </p>
+        </div>
+        {contradictions.length > 0 ? (
+          <Badge variant="destructive">
+            {contradictions.length} open {contradictions.length === 1 ? "conflict" : "conflicts"}
+          </Badge>
+        ) : null}
+      </header>
+
+      {ENTITY_KINDS.map((kind) => {
+        const group = entities.filter((e) => e.kind === kind);
+        if (group.length === 0) return null;
+        return (
+          <section key={kind} aria-labelledby={`bible-${kind}`} className="space-y-3">
+            <h3
+              id={`bible-${kind}`}
+              className="font-mono text-xs tracking-[0.16em] text-muted-foreground uppercase"
+            >
+              {KIND_LABELS[kind]} · {group.length}
+            </h3>
+            <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {group.map((entity) => (
+                <li key={entity.id}>
+                  <EntityCard entity={entity} conflicts={contradictionsFor(entity.name)} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/api/assets/diagram/route 2.ts
+++ b/src/app/api/assets/diagram/route 2.ts
@@ -1,0 +1,119 @@
+import { put } from "@vercel/blob";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import { getChapterOwnership } from "@/db/queries/books";
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { diagramSourceHash } from "@/lib/export/figures";
+
+/**
+ * Caches a client-rendered Mermaid diagram so server-side surfaces (reading
+ * view, EPUB, PDF, DOCX) can show the diagram instead of its source. Mermaid
+ * needs a DOM, so the editor renders it and posts the result here.
+ *
+ * Idempotent: keyed by a hash of the diagram source, so re-opening a chapter
+ * re-posts the same payload and no-ops. Costs one round trip, no LLM call.
+ */
+
+export const maxDuration = 60;
+
+const MAX_SVG_CHARS = 512_000;
+const MAX_PNG_BYTES = 4_000_000;
+
+const bodySchema = z.object({
+  chapterId: z.uuid(),
+  source: z.string().min(1).max(20_000),
+  svg: z.string().min(1).max(MAX_SVG_CHARS),
+  /** PNG rasterization as a bare base64 payload (no data: prefix). */
+  pngBase64: z.string().min(1).max(MAX_PNG_BYTES),
+  alt: z.string().max(500).optional(),
+});
+
+export async function POST(req: Request) {
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  const { chapterId, source, svg, pngBase64, alt } = parsed.data;
+
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) {
+    return Response.json({ error: "Chapter not found" }, { status: 404 });
+  }
+
+  const sourceHash = diagramSourceHash(source);
+  const db = getDb();
+
+  // Already cached for this project — nothing to do.
+  const existing = await db
+    .select({ id: schema.assets.id })
+    .from(schema.assets)
+    .where(
+      and(
+        eq(schema.assets.projectId, ownership.projectId),
+        eq(schema.assets.kind, "diagram"),
+        sql`${schema.assets.meta}->>'sourceHash' = ${sourceHash}`,
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) {
+    return Response.json({ cached: true, sourceHash });
+  }
+
+  const png = Buffer.from(pngBase64, "base64");
+  if (png.length === 0) {
+    return Response.json({ error: "Invalid PNG payload" }, { status: 400 });
+  }
+
+  const meta = { sourceHash, alt: alt || "Diagram" };
+  const base = `diagrams/${ownership.projectId}/${sourceHash}`;
+
+  const [svgBlob, pngBlob] = await Promise.all([
+    put(`${base}.svg`, svg, {
+      access: "public",
+      contentType: "image/svg+xml",
+      addRandomSuffix: false,
+    }),
+    put(`${base}.png`, png, {
+      access: "public",
+      contentType: "image/png",
+      addRandomSuffix: false,
+    }),
+  ]);
+
+  await db.insert(schema.assets).values([
+    {
+      projectId: ownership.projectId,
+      chapterId,
+      kind: "diagram" as const,
+      blobUrl: svgBlob.url,
+      blobPathname: svgBlob.pathname,
+      contentType: "image/svg+xml",
+      sizeBytes: Buffer.byteLength(svg),
+      meta,
+    },
+    {
+      projectId: ownership.projectId,
+      chapterId,
+      kind: "diagram" as const,
+      blobUrl: pngBlob.url,
+      blobPathname: pngBlob.pathname,
+      contentType: "image/png",
+      sizeBytes: png.length,
+      meta,
+    },
+  ]);
+
+  return Response.json({ cached: false, sourceHash });
+}

--- a/src/app/api/entities/[entityId]/portrait/route.ts
+++ b/src/app/api/entities/[entityId]/portrait/route.ts
@@ -1,0 +1,120 @@
+import { put } from "@vercel/blob";
+import { generateText } from "ai";
+import { eq } from "drizzle-orm";
+
+import { gatewayOptions, metered } from "@/ai/metering";
+import { MODELS, type QualityTier } from "@/ai/models";
+import { getDb, schema } from "@/db";
+import { getEntityForPortrait } from "@/db/queries/entities";
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { BudgetExceededError, checkBudget } from "@/lib/billing/meter";
+import { PORTRAIT_KINDS, PORTRAIT_USD, portraitPrompt } from "@/lib/bible/portraits";
+import type { EntityKind } from "@/ai/schemas/entities";
+
+/**
+ * Generates one entity portrait on demand. Never called automatically — the
+ * image model bills per image and a whole cast would materially change a book's
+ * unit economics, so this is always an explicit choice with the price shown.
+ *
+ * Goes through `metered()` like every other model call, so it lands in
+ * `llm_calls` and counts against the user's budget.
+ */
+
+export const maxDuration = 120;
+
+export async function POST(_req: Request, ctx: { params: Promise<{ entityId: string }> }) {
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const { entityId } = await ctx.params;
+  const entity = await getEntityForPortrait(entityId);
+  if (!entity || entity.userId !== userId) {
+    return Response.json({ error: "Entity not found" }, { status: 404 });
+  }
+
+  const kind = entity.kind as EntityKind;
+  if (!PORTRAIT_KINDS.includes(kind)) {
+    return Response.json({ error: `Portraits are not generated for ${kind}s` }, { status: 400 });
+  }
+
+  const db = getDb();
+  const [project] = await db
+    .select({ settings: schema.projects.settings })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, entity.projectId))
+    .limit(1);
+  const tier: QualityTier = project?.settings.qualityTier ?? "standard";
+
+  try {
+    await checkBudget(userId, PORTRAIT_USD);
+
+    const model = MODELS[tier].image;
+    const prompt = portraitPrompt({
+      kind,
+      name: entity.name,
+      attrs: entity.attrs,
+      genre: entity.genre,
+    });
+
+    const meter = {
+      userId,
+      projectId: entity.projectId,
+      tier,
+    } as Parameters<typeof metered>[0];
+
+    const result = await metered(
+      meter,
+      { role: "content-tool", operation: "entity.portrait", model },
+      () =>
+        generateText({
+          model,
+          prompt,
+          providerOptions: gatewayOptions(meter, "content-tool"),
+        }),
+    );
+
+    const file = result.files.find((f) => f.mediaType?.startsWith("image/"));
+    if (!file) {
+      return Response.json({ error: "The image model returned no image" }, { status: 502 });
+    }
+
+    const contentType = file.mediaType ?? "image/png";
+    const blob = await put(
+      `portraits/${entity.projectId}/${entityId}-${crypto.randomUUID()}.png`,
+      Buffer.from(file.uint8Array),
+      { access: "public", contentType },
+    );
+
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        projectId: entity.projectId,
+        kind: "portrait",
+        blobUrl: blob.url,
+        blobPathname: blob.pathname,
+        contentType,
+        sizeBytes: file.uint8Array.byteLength,
+        meta: { entityId, prompt },
+      })
+      .returning({ id: schema.assets.id });
+
+    await db
+      .update(schema.entities)
+      .set({ portraitAssetId: asset.id, updatedAt: new Date() })
+      .where(eq(schema.entities.id, entityId));
+
+    return Response.json({ url: blob.url });
+  } catch (error) {
+    if (error instanceof BudgetExceededError) {
+      return Response.json({ error: "Monthly budget reached" }, { status: 402 });
+    }
+    throw error;
+  }
+}

--- a/src/components/bible/entity-card.tsx
+++ b/src/components/bible/entity-card.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { ImagePlus, Loader2, TriangleAlert } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { BibleEntity } from "@/db/queries/entities";
+import { PORTRAIT_USD, PORTRAIT_KINDS } from "@/lib/bible/portraits";
+import { cn } from "@/lib/utils";
+
+type Conflict = { id: string; severity: string; description: string };
+
+/** Attribute keys rendered as prose lines, in the order a reader wants them. */
+const FIELD_ORDER = [
+  "role",
+  "occupation",
+  "age",
+  "heritage",
+  "appearance",
+  "speech",
+  "locationType",
+  "description",
+  "owner",
+  "atmosphere",
+  "significance",
+  "provenance",
+  "holder",
+  "purpose",
+  "structure",
+  "reputation",
+  "when",
+  "outcome",
+  "nameRationale",
+];
+
+const FIELD_LABELS: Record<string, string> = {
+  role: "Role",
+  occupation: "Occupation",
+  age: "Age",
+  heritage: "Heritage",
+  appearance: "Appearance",
+  speech: "Speech",
+  locationType: "Type",
+  description: "Description",
+  owner: "Owner",
+  atmosphere: "Atmosphere",
+  significance: "Significance",
+  provenance: "Provenance",
+  holder: "Held by",
+  purpose: "Purpose",
+  structure: "Structure",
+  reputation: "Reputation",
+  when: "When",
+  outcome: "Outcome",
+  nameRationale: "Why this name",
+};
+
+const LIST_FIELDS = [
+  "personality",
+  "goals",
+  "secrets",
+  "features",
+  "contents",
+  "capabilities",
+  "members",
+  "participants",
+];
+
+function asText(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return null;
+}
+
+function asList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+export function EntityCard({ entity, conflicts }: { entity: BibleEntity; conflicts: Conflict[] }) {
+  const [portraitUrl, setPortraitUrl] = useState(entity.portraitUrl);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const attrs = entity.attrs as Record<string, unknown>;
+  const facts = asList(attrs.facts);
+  const canHavePortrait = PORTRAIT_KINDS.includes(entity.kind);
+
+  async function generatePortrait() {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/entities/${entity.id}/portrait`, { method: "POST" });
+      const body = (await response.json()) as { url?: string; error?: string };
+      if (!response.ok || !body.url) {
+        setError(body.error ?? "Could not generate a portrait");
+        return;
+      }
+      setPortraitUrl(body.url);
+    } catch {
+      setError("Could not generate a portrait");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <article className="flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        {portraitUrl ? (
+          <Image
+            src={portraitUrl}
+            alt={`Impression of ${entity.name}`}
+            width={64}
+            height={64}
+            className="size-16 shrink-0 rounded-md object-cover"
+          />
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <h4 className="font-sans font-semibold break-words">{entity.name}</h4>
+          {entity.aliases.length > 0 ? (
+            <p className="text-xs text-muted-foreground">also {entity.aliases.join(", ")}</p>
+          ) : null}
+          {entity.firstAppearanceChapter ? (
+            <p className="mt-0.5 font-mono text-[0.68rem] text-muted-foreground">
+              first appears ch. {entity.firstAppearanceChapter}
+            </p>
+          ) : null}
+        </div>
+        {conflicts.length > 0 ? (
+          <Badge variant="destructive" className="shrink-0 gap-1">
+            <TriangleAlert aria-hidden="true" className="size-3" />
+            {conflicts.length}
+          </Badge>
+        ) : null}
+      </div>
+
+      <dl className="space-y-1 text-sm">
+        {FIELD_ORDER.map((field) => {
+          const value = asText(attrs[field]);
+          if (!value) return null;
+          return (
+            <div key={field} className="flex gap-2">
+              <dt className="shrink-0 text-xs text-muted-foreground">{FIELD_LABELS[field]}</dt>
+              <dd className="min-w-0 text-pretty">{value}</dd>
+            </div>
+          );
+        })}
+        {LIST_FIELDS.map((field) => {
+          const values = asList(attrs[field]);
+          if (values.length === 0) return null;
+          return (
+            <div key={field} className="flex gap-2">
+              <dt className="shrink-0 text-xs text-muted-foreground capitalize">{field}</dt>
+              <dd className="min-w-0 text-pretty">{values.join(", ")}</dd>
+            </div>
+          );
+        })}
+      </dl>
+
+      {entity.relationships.length > 0 ? (
+        <ul className="flex flex-wrap gap-1.5">
+          {entity.relationships.map((rel, i) => (
+            <li key={`${rel.type}-${rel.other}-${i}`}>
+              <Badge variant="secondary" className="font-normal">
+                {rel.type.replace(/-/g, " ")} {rel.other}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {facts.length > 0 ? (
+        <details className="text-sm">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+            {facts.length} established {facts.length === 1 ? "fact" : "facts"}
+          </summary>
+          <ul className="mt-2 list-disc space-y-1 pl-4 text-pretty">
+            {facts.map((fact, i) => (
+              <li key={i}>{fact}</li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+
+      {conflicts.length > 0 ? (
+        <ul className="space-y-1 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+          {conflicts.map((c) => (
+            <li key={c.id}>{c.description}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      {canHavePortrait && !portraitUrl ? (
+        <div className="mt-auto">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={generatePortrait}
+            disabled={busy}
+            className="w-full"
+          >
+            {busy ? (
+              <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+            ) : (
+              <ImagePlus aria-hidden="true" className="size-3.5" />
+            )}
+            {busy ? "Generating…" : `Generate portrait · $${PORTRAIT_USD.toFixed(3)}`}
+          </Button>
+          {error ? (
+            <p role="alert" className={cn("mt-1 text-xs text-destructive")}>
+              {error}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/generation/agent-feed.tsx
+++ b/src/components/generation/agent-feed.tsx
@@ -6,6 +6,7 @@ import type { AgentFeedItem, AgentName, RunConnection } from "@/hooks/use-run-st
 const AGENT_LABELS: Record<AgentName, string> = {
   concept: "Concept",
   outliner: "Outliner",
+  "entity-bible": "Story bible",
   writer: "Writer",
   editor: "Editor",
   continuity: "Continuity",

--- a/src/components/studio/stage-nav.tsx
+++ b/src/components/studio/stage-nav.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 const stages = [
   { slug: "brief", label: "Brief" },
   { slug: "outline", label: "Outline" },
+  { slug: "bible", label: "Bible" },
   { slug: "write", label: "Write" },
   { slug: "editor", label: "Editor" },
   { slug: "manuscript", label: "Manuscript" },

--- a/src/db/queries/entities.ts
+++ b/src/db/queries/entities.ts
@@ -1,0 +1,207 @@
+import { and, asc, eq, sql } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
+import { ENTITY_KINDS, parseAttrs, type EntityKind } from "@/ai/schemas/entities";
+
+/**
+ * Story-bible persistence. Every write here has to survive a wave of four
+ * chapters drafting at once, so merges happen in a single statement rather than
+ * read-modify-write.
+ */
+
+export type EntitySeed = {
+  kind: EntityKind;
+  name: string;
+  aliases?: string[];
+  attrs?: Record<string, unknown>;
+};
+
+function isEntityKind(value: string): value is EntityKind {
+  return (ENTITY_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Appends facts to entities, creating any that do not exist yet.
+ *
+ * The parens around `(excluded.attrs->'facts')` are load-bearing: `||` and `->`
+ * have equal precedence and are left-associative, so without them this parses
+ * as `(attrs || excluded.attrs)->'facts'` and the column resolves to NULL,
+ * violating the NOT NULL constraint. That exact bug shipped once already.
+ */
+export async function applyEntityDeltas(input: {
+  bookId: string;
+  chapterNumber?: number;
+  newFacts: { kind?: string; name: string; facts: string[] }[];
+  relationships?: { from: string; to: string; type: string }[];
+}): Promise<void> {
+  const db = getDb();
+
+  for (const entry of input.newFacts) {
+    if (!entry.name?.trim() || entry.facts.length === 0) continue;
+    const kind = entry.kind && isEntityKind(entry.kind) ? entry.kind : "character";
+
+    await db
+      .insert(schema.entities)
+      .values({
+        bookId: input.bookId,
+        kind,
+        name: entry.name.trim(),
+        aliases: [],
+        attrs: { facts: entry.facts },
+        firstAppearanceChapter: input.chapterNumber,
+        lastUpdatedChapter: input.chapterNumber,
+      })
+      .onConflictDoUpdate({
+        target: [schema.entities.bookId, schema.entities.kind, schema.entities.name],
+        set: {
+          attrs: sql`jsonb_set(${schema.entities.attrs}, '{facts}', coalesce(${schema.entities.attrs}->'facts', '[]'::jsonb) || (excluded.attrs->'facts'))`,
+          lastUpdatedChapter: input.chapterNumber,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  for (const rel of input.relationships ?? []) {
+    if (!rel.from?.trim() || !rel.to?.trim()) continue;
+    const rows = await db
+      .select({ id: schema.entities.id, name: schema.entities.name })
+      .from(schema.entities)
+      .where(eq(schema.entities.bookId, input.bookId));
+    const find = (name: string) => rows.find((r) => r.name.toLowerCase() === name.toLowerCase());
+    const from = find(rel.from);
+    const to = find(rel.to);
+    // Relationships between entities we do not know about are dropped rather
+    // than guessed at — the next chapter's upsert will create them.
+    if (!from || !to || from.id === to.id) continue;
+
+    await db
+      .insert(schema.entityRelationships)
+      .values({
+        bookId: input.bookId,
+        fromEntityId: from.id,
+        toEntityId: to.id,
+        type: rel.type || "other",
+        establishedChapter: input.chapterNumber,
+      })
+      .onConflictDoNothing();
+  }
+}
+
+/**
+ * Seeds entities from the concept/outline pass. Existing rows win: a re-run
+ * must never clobber canon that later chapters have already built on.
+ */
+export async function seedEntities(bookId: string, seeds: EntitySeed[]): Promise<void> {
+  if (seeds.length === 0) return;
+  await getDb()
+    .insert(schema.entities)
+    .values(
+      seeds.map((seed) => ({
+        bookId,
+        kind: seed.kind,
+        name: seed.name.trim(),
+        aliases: seed.aliases ?? [],
+        attrs: parseAttrs(seed.kind, seed.attrs ?? {}) as Record<string, unknown>,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [schema.entities.bookId, schema.entities.kind, schema.entities.name],
+    });
+}
+
+export type BibleEntity = {
+  id: string;
+  kind: EntityKind;
+  name: string;
+  aliases: string[];
+  attrs: Record<string, unknown>;
+  portraitUrl: string | null;
+  firstAppearanceChapter: number | null;
+  relationships: { type: string; other: string; description: string | null }[];
+};
+
+/** The whole bible for a book, ordered for display. */
+export async function listEntities(bookId: string): Promise<BibleEntity[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.entities.id,
+      kind: schema.entities.kind,
+      name: schema.entities.name,
+      aliases: schema.entities.aliases,
+      attrs: schema.entities.attrs,
+      firstAppearanceChapter: schema.entities.firstAppearanceChapter,
+      portraitUrl: schema.assets.blobUrl,
+    })
+    .from(schema.entities)
+    .leftJoin(schema.assets, eq(schema.assets.id, schema.entities.portraitAssetId))
+    .where(eq(schema.entities.bookId, bookId))
+    .orderBy(asc(schema.entities.kind), asc(schema.entities.name));
+
+  const relationships = await db
+    .select({
+      from: schema.entityRelationships.fromEntityId,
+      to: schema.entityRelationships.toEntityId,
+      type: schema.entityRelationships.type,
+      description: schema.entityRelationships.description,
+    })
+    .from(schema.entityRelationships)
+    .where(eq(schema.entityRelationships.bookId, bookId));
+
+  const nameById = new Map(rows.map((r) => [r.id, r.name]));
+
+  return rows.map((row) => ({
+    id: row.id,
+    kind: row.kind as EntityKind,
+    name: row.name,
+    aliases: row.aliases,
+    attrs: row.attrs,
+    portraitUrl: row.portraitUrl,
+    firstAppearanceChapter: row.firstAppearanceChapter,
+    relationships: relationships
+      .filter((rel) => rel.from === row.id || rel.to === row.id)
+      .map((rel) => ({
+        type: rel.type,
+        other: nameById.get(rel.from === row.id ? rel.to : rel.from) ?? "unknown",
+        description: rel.description,
+      })),
+  }));
+}
+
+/** One entity plus enough context to build a portrait prompt. */
+export async function getEntityForPortrait(entityId: string) {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: schema.entities.id,
+      bookId: schema.entities.bookId,
+      kind: schema.entities.kind,
+      name: schema.entities.name,
+      attrs: schema.entities.attrs,
+      projectId: schema.books.projectId,
+      userId: schema.projects.userId,
+      genre: schema.projects.genre,
+    })
+    .from(schema.entities)
+    .innerJoin(schema.books, eq(schema.books.id, schema.entities.bookId))
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(eq(schema.entities.id, entityId))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Open contradictions, so the Bible tab can flag entities that drifted. */
+export async function openContradictions(bookId: string) {
+  return getDb()
+    .select({
+      id: schema.continuityIssues.id,
+      category: schema.continuityIssues.category,
+      severity: schema.continuityIssues.severity,
+      description: schema.continuityIssues.description,
+      chapters: schema.continuityIssues.chapters,
+    })
+    .from(schema.continuityIssues)
+    .where(
+      and(eq(schema.continuityIssues.bookId, bookId), eq(schema.continuityIssues.status, "open")),
+    );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -141,28 +141,63 @@ export const chapterRevisions = pgTable(
   (t) => [index("idx_revisions_chapter").on(t.chapterId, t.createdAt)],
 );
 
-export type CharacterFacts = {
-  role?: string;
-  appearance?: Record<string, string>;
-  personality?: string[];
-  relationships?: Record<string, string>;
-  facts?: string[];
-  firstAppearance?: number;
-};
-
-export const characterBible = pgTable(
-  "character_bible",
+/**
+ * The story bible. Supersedes the character-only `character_bible`: characters
+ * drift, but so do objects (a sword that grows a jewel) and places (a house
+ * that grows a room), and `continuity_issues` already reasoned about setting
+ * and plot categories this model could not represent.
+ *
+ * `attrs` is validated per kind by `src/ai/schemas/entities.ts`. Its `facts`
+ * array is append-only, which is what lets a wave of concurrently drafting
+ * chapters merge into one row without lost updates.
+ */
+export const entities = pgTable(
+  "entities",
   {
     id: uuid("id").primaryKey().defaultRandom(),
     bookId: uuid("book_id")
       .notNull()
       .references(() => books.id, { onDelete: "cascade" }),
+    kind: text("kind", {
+      enum: ["character", "location", "object", "organization", "event"],
+    }).notNull(),
     name: text("name").notNull(),
-    facts: jsonb("facts").$type<CharacterFacts>().default({}).notNull(),
-    updatedByChapter: integer("updated_by_chapter"),
+    aliases: jsonb("aliases").$type<string[]>().default([]).notNull(),
+    attrs: jsonb("attrs").$type<Record<string, unknown>>().default({}).notNull(),
+    portraitAssetId: uuid("portrait_asset_id"),
+    firstAppearanceChapter: integer("first_appearance_chapter"),
+    lastUpdatedChapter: integer("last_updated_chapter"),
     ...timestamps,
   },
-  (t) => [uniqueIndex("uq_character_name").on(t.bookId, t.name)],
+  (t) => [
+    uniqueIndex("uq_entity_name").on(t.bookId, t.kind, t.name),
+    index("idx_entities_book").on(t.bookId, t.kind),
+  ],
+);
+
+/** The entity-relationship graph — siblings, owners, members, locations. */
+export const entityRelationships = pgTable(
+  "entity_relationships",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    bookId: uuid("book_id")
+      .notNull()
+      .references(() => books.id, { onDelete: "cascade" }),
+    fromEntityId: uuid("from_entity_id")
+      .notNull()
+      .references(() => entities.id, { onDelete: "cascade" }),
+    toEntityId: uuid("to_entity_id")
+      .notNull()
+      .references(() => entities.id, { onDelete: "cascade" }),
+    type: text("type").notNull(),
+    description: text("description"),
+    establishedChapter: integer("established_chapter"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => [
+    uniqueIndex("uq_entity_relationship").on(t.fromEntityId, t.toEntityId, t.type),
+    index("idx_relationships_book").on(t.bookId),
+  ],
 );
 
 export const generationRuns = pgTable(
@@ -347,6 +382,7 @@ export const assets = pgTable(
         "cover",
         "illustration",
         "diagram",
+        "portrait",
         "export_epub",
         "export_pdf",
         "export_docx",

--- a/src/lib/bible/portraits.ts
+++ b/src/lib/bible/portraits.ts
@@ -1,0 +1,79 @@
+import { MODEL_PRICING } from "@/lib/billing/pricing";
+import type { EntityKind } from "@/ai/schemas/entities";
+
+/**
+ * Entity portraits are opt-in per entity, never automatic.
+ *
+ * The image model bills a flat rate per image, so a book with 15–40 entities
+ * would add $1.00–$2.70 to a standard-tier book costing roughly $4.70 — a
+ * 20–55% increase for what is decoration. Generating them on demand keeps that
+ * a choice the author makes with the price in front of them.
+ */
+
+export const PORTRAIT_USD = MODEL_PRICING["google/gemini-3.1-flash-image"]?.perImageUsd ?? 0.067;
+
+/**
+ * Kinds worth illustrating. An "organization" or "event" portrait is rarely
+ * more than an abstract smear, so those are excluded.
+ */
+export const PORTRAIT_KINDS: EntityKind[] = ["character", "location", "object"];
+
+/** One shared style so a book's portraits read as a set rather than a jumble. */
+const HOUSE_STYLE =
+  "atmospheric literary book illustration, painterly, muted palette, soft directional light, no text, no lettering, no watermark";
+
+/**
+ * Builds the image prompt from the entity's structured attributes rather than
+ * from prose — the bible already holds exactly the concrete visual facts an
+ * image model needs.
+ */
+export function portraitPrompt(input: {
+  kind: EntityKind;
+  name: string;
+  attrs: Record<string, unknown>;
+  genre?: string | null;
+}): string {
+  const attr = (key: string): string | null => {
+    const value = input.attrs[key];
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+  };
+  const list = (key: string): string[] =>
+    Array.isArray(input.attrs[key])
+      ? (input.attrs[key] as unknown[]).filter((v): v is string => typeof v === "string")
+      : [];
+
+  const parts: string[] = [];
+
+  if (input.kind === "character") {
+    parts.push(`Character portrait, head and shoulders, of ${input.name}.`);
+    const appearance = attr("appearance");
+    const heritage = attr("heritage");
+    const age = attr("age");
+    const occupation = attr("occupation");
+    if (appearance) parts.push(appearance);
+    if (heritage) parts.push(`Heritage: ${heritage}.`);
+    if (age) parts.push(`Age: ${age}.`);
+    if (occupation) parts.push(`Dressed as befits a ${occupation}.`);
+  } else if (input.kind === "location") {
+    parts.push(`Establishing view of ${input.name}.`);
+    const description = attr("description");
+    const type = attr("locationType");
+    const atmosphere = attr("atmosphere");
+    const features = list("features").slice(0, 5);
+    if (type) parts.push(`A ${type}.`);
+    if (description) parts.push(description);
+    if (features.length) parts.push(`Notable features: ${features.join(", ")}.`);
+    if (atmosphere) parts.push(`Atmosphere: ${atmosphere}.`);
+  } else {
+    parts.push(`Still life study of ${input.name}, a single object, centred.`);
+    const description = attr("description");
+    const provenance = attr("provenance");
+    if (description) parts.push(description);
+    if (provenance) parts.push(`Origin: ${provenance}.`);
+  }
+
+  if (input.genre) parts.push(`Genre: ${input.genre}.`);
+  parts.push(HOUSE_STYLE);
+
+  return parts.join(" ");
+}

--- a/src/lib/export/figures 2.ts
+++ b/src/lib/export/figures 2.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "@/db";
+
+/**
+ * Figure resolution for diagrams and inline images.
+ *
+ * Mermaid needs a DOM, so we never render it on the server. The editor renders
+ * each diagram client-side and uploads the SVG + a PNG rasterization, keyed by
+ * a hash of the source. Every server-side surface (reading view, EPUB, PDF,
+ * DOCX) then looks the render up by that hash. A miss is not an error — callers
+ * fall back to showing the source, so a diagram never silently disappears.
+ */
+
+export type FigureAsset = {
+  svgUrl: string | null;
+  pngUrl: string | null;
+  alt: string;
+  /** Only populated for the byte-embedding exporters (PDF, DOCX). */
+  pngBytes?: Uint8Array;
+  width?: number;
+  height?: number;
+};
+
+/** Keyed by diagram source hash, or by URL for plain markdown images. */
+export type FigureMap = Record<string, FigureAsset>;
+
+/**
+ * Hash of a diagram's source. The client computes the same digest over the same
+ * normalized string via SubtleCrypto — keep the two in step or every lookup
+ * misses and exports quietly regress to source text.
+ */
+export function diagramSourceHash(source: string): string {
+  return createHash("sha256").update(normalizeDiagramSource(source), "utf8").digest("hex");
+}
+
+/** Trailing whitespace differs between the editor and stored markdown; ignore it. */
+export function normalizeDiagramSource(source: string): string {
+  return source
+    .trim()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n");
+}
+
+/** Width/height from a PNG's IHDR chunk. Null when the bytes are not a PNG. */
+export function pngDimensions(bytes: Uint8Array): { width: number; height: number } | null {
+  // 8-byte signature, then a 4-byte length + "IHDR" + width/height as big-endian u32.
+  if (bytes.length < 24) return null;
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (signature.some((byte, i) => bytes[i] !== byte)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+/** Scales an image down to fit a max width, preserving aspect ratio. */
+export function fitWidth(
+  dims: { width: number; height: number },
+  maxWidth: number,
+): { width: number; height: number } {
+  if (dims.width <= maxWidth) return dims;
+  const scale = maxWidth / dims.width;
+  return { width: Math.round(dims.width * scale), height: Math.round(dims.height * scale) };
+}
+
+/** Every diagram render stored for a project, keyed by source hash. */
+export async function loadFigures(projectId: string): Promise<FigureMap> {
+  const rows = await getDb()
+    .select({
+      blobUrl: schema.assets.blobUrl,
+      contentType: schema.assets.contentType,
+      meta: schema.assets.meta,
+    })
+    .from(schema.assets)
+    .where(and(eq(schema.assets.projectId, projectId), eq(schema.assets.kind, "diagram")));
+
+  const figures: FigureMap = {};
+  for (const row of rows) {
+    const meta = (row.meta ?? {}) as { sourceHash?: string; alt?: string };
+    if (!meta.sourceHash) continue;
+    const existing = figures[meta.sourceHash] ?? {
+      svgUrl: null,
+      pngUrl: null,
+      alt: meta.alt || "Diagram",
+    };
+    if (row.contentType === "image/svg+xml") existing.svgUrl = row.blobUrl;
+    if (row.contentType === "image/png") existing.pngUrl = row.blobUrl;
+    if (meta.alt) existing.alt = meta.alt;
+    figures[meta.sourceHash] = existing;
+  }
+  return figures;
+}
+
+/**
+ * Downloads PNG bytes for the figures PDF/DOCX will embed. Failures are
+ * swallowed per-figure: a fetch error degrades that one diagram to source text
+ * rather than failing the whole export.
+ */
+export async function hydrateFigureBytes(figures: FigureMap): Promise<FigureMap> {
+  const entries = Object.entries(figures).filter(([, figure]) => figure.pngUrl);
+  const hydrated: FigureMap = { ...figures };
+
+  await Promise.all(
+    entries.map(async ([key, figure]) => {
+      try {
+        const response = await fetch(figure.pngUrl as string);
+        if (!response.ok) return;
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const dims = pngDimensions(bytes);
+        hydrated[key] = { ...figure, pngBytes: bytes, ...(dims ?? {}) };
+      } catch {
+        // Leave the figure without bytes; exporters fall back to source text.
+      }
+    }),
+  );
+
+  return hydrated;
+}

--- a/src/lib/run-events.ts
+++ b/src/lib/run-events.ts
@@ -36,7 +36,15 @@ export const runEventSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("agent"),
-    agent: z.enum(["concept", "outliner", "writer", "editor", "continuity", "summarizer"]),
+    agent: z.enum([
+      "concept",
+      "outliner",
+      "entity-bible",
+      "writer",
+      "editor",
+      "continuity",
+      "summarizer",
+    ]),
     message: z.string(),
     chapterNumber: z.number().int().optional(),
   }),

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -9,6 +9,7 @@ import {
   continuityPhaseStep,
   editChapterStep,
   emitCost,
+  entityBibleStep,
   emitProgress,
   finalizeStep,
   markRunStatus,
@@ -67,6 +68,21 @@ export async function generateBook(
         outline = await outlineStep(ref, config, concept, approval.notes);
       }
     }
+
+    // Canon before prose: chapters draft four at a time, so the bible has to
+    // exist before any of them can consult it.
+    await emitProgress(ref, {
+      type: "agent",
+      agent: "entity-bible",
+      message: "Building the story bible",
+    });
+    const bible = await entityBibleStep(ref, config, concept, outline);
+    await emitProgress(ref, {
+      type: "agent",
+      agent: "entity-bible",
+      message: `${bible.entityCount} entities, ${bible.relationshipCount} relationships`,
+    });
+    await emitCost(ref);
 
     const chapterNumbers = outline.chapters.map((c) => c.number);
     const total = chapterNumbers.length;

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -6,6 +6,7 @@ import { generateConcept, persistConcept } from "@/ai/agents/concept";
 import { generateOutline, persistOutline } from "@/ai/agents/outline";
 import { writeChapter, persistChapter } from "@/ai/agents/chapter-writer";
 import { summarizeChapter } from "@/ai/agents/summarizer";
+import { buildEntityBible } from "@/ai/agents/entity-bible";
 import { editChapter } from "@/ai/agents/editor";
 import {
   aggregateContinuityOutcomes,
@@ -18,6 +19,7 @@ import type { ReviewPhaseKey } from "@/ai/prompts/review-rubric";
 import { BudgetExceededError, checkBudget } from "@/lib/billing/meter";
 import { estimateBookCost } from "@/ai/estimate";
 import { getOrCreateBook } from "@/db/queries/projects";
+import { listEntities } from "@/db/queries/entities";
 import { chapterNs, PROGRESS_NS, type GenerationConfig, type RunEvent } from "@/lib/run-events";
 import { isChapterComplete } from "./resume";
 import type { BookConcept, BookOutline, ChapterOutlinePlan } from "@/ai/schemas";
@@ -209,6 +211,35 @@ export async function outlineStep(
     });
     await persistOutline(book.id, outline);
     return outline;
+  } catch (error) {
+    toWorkflowError(error);
+  }
+}
+
+/**
+ * Builds the story bible from the concept + outline before any chapter drafts.
+ * Idempotent: seeding uses onConflictDoNothing, so a retry re-derives without
+ * clobbering canon that chapters have already added.
+ */
+export async function entityBibleStep(
+  ref: RunRef,
+  config: GenerationConfig,
+  concept: BookConcept,
+  outline: BookOutline,
+): Promise<{ entityCount: number; relationshipCount: number }> {
+  "use step";
+  const { project, book, meter } = await loadRunContext(ref);
+  try {
+    const existing = await listEntities(book.id);
+    return await buildEntityBible({
+      meter,
+      bookId: book.id,
+      tier: config.tier,
+      concept,
+      outline,
+      genre: project.genre ?? undefined,
+      existingNames: existing.map((e) => e.name),
+    });
   } catch (error) {
     toWorkflowError(error);
   }


### PR DESCRIPTION
## The problem

Long books drift on details. A character's eyes change colour between chapters, a sword gains a jewel it never had, a sister acquires a surname chapter 2 never gave her.

The old `character_bible` was `(bookId, name, facts jsonb)` — characters only, with append-only free text. Meanwhile `continuity_issues` already classified findings as character/timeline/setting/plot/factual, so **detection was reasoning about categories the data model couldn't represent**. There was nowhere to record that the family home has a television in the den, or who forged the hero's sword.

## What this adds

`entities` + `entity_relationships` across five kinds — character, location, object, organization, event — each with a purpose-built attribute schema rather than a bag of text. Characters carry heritage, speech and `nameRationale`; locations carry `contents`; objects carry provenance and current holder.

**Canon is established before prose.** A new `entityBibleStep` runs after the outline and interrogates each entity: what are they to the story, what do they do, what would a reader picture, what heritage do they come from. Crucially it *derives* names from related entities rather than picking them in isolation — siblings share surnames, heritage governs naming — and records the reasoning.

**Per-chapter accretion is free.** Entity deltas ride on the summarizer call that already runs after every chapter, so the marginal cost is a few hundred output tokens rather than a new request per chapter.

**Contradictions are recorded, not applied.** `entityUpsert` compares incoming guarded scalars against stored ones and writes a `continuity_issues` row instead of silently overwriting canon.

## Two things that could have gone wrong

**The jsonb merge.** Chapters draft four at a time, so the merge is a single atomic statement. The parens around `(excluded.attrs->'facts')` are load-bearing — `||` and `->` are equal precedence and left-associative. Verified directly against Postgres:

```
parenthesized (ours): {"facts":["established in ch1","added in ch7"],"appearance":"grey eyes"}
precedence probe    : null
```

That `null` is exactly the NOT NULL violation that shipped once before.

**Prompt caching.** Entity context is chapter-varying, so it goes in the per-chapter user message and never in `anthropicCachedSystem`'s prefix. Getting this wrong would silently destroy the ~50–60% cache-read rate.

## Bible tab

Entities grouped by kind with relationships, accrued facts and open conflicts. Read-only apart from portraits; editing is a deliberate follow-up.

## Portraits — on demand, never automatic

The image model bills **$0.067 flat per image**. A book with 15–40 entities would add **$1.00–$2.70** to a standard-tier book costing ~$4.70 — a 20–55% increase for decoration, against a product built around cost optimization. So it's a per-entity button showing the price, routed through `metered()` like every other model call. Organizations and events are excluded, since a "portrait" of an event is rarely more than a smear.

## Migration

`0002` creates the tables and backfills from `character_bible` — the jsonb projection was dry-run against all 30 live rows and preserves role and facts. `0003` drops the old table.

## Verification

299 unit tests (up from 286): per-kind schemas, conflict detection across every guarded field, case/whitespace insensitivity, first-establishment and omission not counting as conflicts, list fields never conflicting, and the kind→category mapping staying inside the `continuity_issues` vocabulary. Typecheck, lint, format and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Schema migration plus drop of character_bible is irreversible without care; concurrent chapter merges and backfill SQL must run cleanly in production.
> 
> **Overview**
> Replaces the character-only **`character_bible`** table with **`entities`** and **`entity_relationships`**, covering characters, locations, objects, organizations, and events with per-kind **`attrs`**. Migration **`0002`** backfills characters from the old table; **`0003`** drops **`character_bible`**.
> 
> Generation now runs **`entityBibleStep`** after the outline (before chapter waves) to seed canon and relationships, and agents use **`entityGet` / `entitySearch` / `entityUpsert` / `entityRelate`** instead of character bible tools. Chapter summaries and the summarizer feed **`applyEntityDeltas`**; guarded scalar changes from **`entityUpsert`** open **`continuity_issues`** instead of overwriting canon.
> 
> Authors get a **Bible** studio tab (grouped entities, conflicts, optional paid portraits) plus diagram cache API and export figure helpers bundled in the same PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192ea3f98b167f5e009a5bbe8c4ad731fbc0cbc2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->