### PR TITLE
Prepaid credits with Stripe, priced from measured production data

### DIFF
--- a/doc/PRICING.md
+++ b/doc/PRICING.md
@@ -1,0 +1,104 @@
+# Pricing and unit economics
+
+Derived from production data, not estimates. Every LLM call is metered into
+`llm_calls`; the figures below come from two complete books.
+
+## Measured cost of a book
+
+| Tier | Chapters | Words | Generation | + light editing (+50%) | Per 1k words |
+|---|---|---|---|---|---|
+| standard | 12 | 36,588 | $6.39 | **$9.58** | $0.262 |
+| premium | 10 | 36,816 | $8.61 | **$12.91** | $0.351 |
+| draft *(derived)* | — | — | $4.95 | **$7.43** | ~$0.203 |
+
+Draft has never run in production — its figure is derived by removing the editor
+pass and most continuity phases from the standard book. Re-derive it after the
+first real draft-tier run.
+
+Largest cost line in both books is the writer (54% / 56%). The second-largest
+differs entirely by tier: continuity on standard, editor on premium.
+
+## Why the original price list was withdrawn
+
+The rebuild plan assumed draft ≈ $2.60, standard ≈ $4.70, premium ≈ $10.70 and
+priced for 74–79% margins. Measured against real COGS:
+
+| Tier | Old price | Real COGS | Margin |
+|---|---|---|---|
+| draft | $9.99 | $7.43 | **19.2%** |
+| standard | $19.99 | $9.58 | **47.2%** |
+| premium | $49.99 | $12.91 | 70.2% |
+
+The structural fault is compression: COGS spans $5.48 while the price list spans
+$40. The tiers were priced as if they differed five-fold in cost; they differ by
+less than two-fold.
+
+## The model: prepaid credits at 2.75× metered cost
+
+One credit is one dollar of retail value. Work is debited at
+`CREDIT_MARKUP` (`src/lib/billing/credits.ts`) times its metered cost.
+
+A multiplier rather than a fixed per-book price because:
+
+- **Editing becomes revenue.** The +50% editing uplift is real metered usage.
+  Under a fixed price it erodes margin; under credits the author pays for it.
+- **Runaway generations stop being losses.** Three revision passes debit three
+  revision passes.
+- **Provider price changes pass through**, so margin holds as rates move.
+
+| Tier | Generate | Light edit | Finished book |
+|---|---|---|---|
+| draft | 14 cr | 7 cr | 21 cr |
+| standard | 18 cr | 9 cr | 27 cr |
+| premium | 24 cr | 12 cr | 36 cr |
+
+### Packs
+
+| Pack | Price | Credits | Bonus | Worst-case margin |
+|---|---|---|---|---|
+| Starter | $25 | 25 | — | 59.0% |
+| Author | $60 | 66 | 10% | 56.1% |
+| Studio | $120 | 138 | 15% | 54.5% |
+| Press | $300 | 360 | 20% | 52.9% |
+
+Worst case assumes every credit is spent. Unspent credits are pure margin.
+`credits.test.ts` asserts every pack stays above 50% at current rates and above
+35% if model prices rose 25%.
+
+## Operating costs
+
+| Line | Monthly |
+|---|---|
+| Vercel Pro | $20 + ~$0.10/book |
+| Neon | $0 → $19 |
+| Clerk | $0 below 10k MAU |
+| Blob | ~$3 |
+| Domain (.ai) | ~$7.50 |
+| Tooling | ~$15 |
+| **Fixed total** | **$45.50** |
+
+AI Gateway is passthrough at list price with zero markup — it is COGS, already
+counted per book. Sales tax/VAT is handled by Stripe Tax at ~0.5% of volume;
+income tax should be reserved at 21–30% of net.
+
+Break-even is **3 books/month** for fixed costs, **33 books/month** with $500 of
+marketing.
+
+## Two open cost levers
+
+1. **Prompt cache is at 31.7%**, against a 50–60% design target — 1.37M cached
+   against 2.95M billed input tokens. The writer role, the largest cost line,
+   shows 310k cached against 638k billed.
+2. **Continuity variance is unexplained**: $1.95 on one book versus $0.54 on a
+   comparable one, the expensive run consuming 1.06M input tokens. If continuity
+   reads full prose rather than summaries on some paths, that is recoverable.
+
+At 2.75× markup every dollar saved in COGS is $2.75 of headroom.
+
+## Caveats
+
+- Both measured books are ~36k-word novellas. Nothing here is validated for
+  full-length novels.
+- Draft-tier COGS is derived, not measured.
+- The Stripe resource is provisioned as a **sandbox** (test mode). Claim it with
+  `vercel integration resource claim sopher-payments` before taking real money.

--- a/drizzle/0004_furry_machine_man.sql
+++ b/drizzle/0004_furry_machine_man.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "credit_ledger" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"amount" numeric(12, 4) NOT NULL,
+	"kind" text NOT NULL,
+	"description" text NOT NULL,
+	"project_id" uuid,
+	"run_id" uuid,
+	"external_ref" text,
+	"metered_usd" numeric(12, 6),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "credit_ledger" ADD CONSTRAINT "credit_ledger_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "credit_ledger" ADD CONSTRAINT "credit_ledger_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "credit_ledger" ADD CONSTRAINT "credit_ledger_run_id_generation_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."generation_runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ledger_user" ON "credit_ledger" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_ledger_external_ref" ON "credit_ledger" USING btree ("external_ref");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2094 @@
+{
+  "id": "c8d65dbe-f31b-4a13-a71e-14ff5edc8f28",
+  "prevId": "6d0ea05c-5619-4d4c-a71c-c546da9b7337",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthly_limit_usd": {
+          "name": "monthly_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20.00'"
+        },
+        "hard_limit": {
+          "name": "hard_limit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "alert_threshold_pct": {
+          "name": "alert_threshold_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metered_usd": {
+          "name": "metered_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ledger_user": {
+          "name": "idx_ledger_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_ledger_external_ref": {
+          "name": "uq_ledger_external_ref",
+          "columns": [
+            {
+              "expression": "external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_user_id_users_id_fk": {
+          "name": "credit_ledger_user_id_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_project_id_projects_id_fk": {
+          "name": "credit_ledger_project_id_projects_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_run_id_generation_runs_id_fk": {
+          "name": "credit_ledger_run_id_generation_runs_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "portrait_asset_id": {
+          "name": "portrait_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_appearance_chapter": {
+          "name": "first_appearance_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_chapter": {
+          "name": "last_updated_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_name": {
+          "name": "uq_entity_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_book": {
+          "name": "idx_entities_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_book_id_books_id_fk": {
+          "name": "entities_book_id_books_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationships": {
+      "name": "entity_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_chapter": {
+          "name": "established_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_relationship": {
+          "name": "uq_entity_relationship",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationships_book": {
+          "name": "idx_relationships_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_relationships_book_id_books_id_fk": {
+          "name": "entity_relationships_book_id_books_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_from_entity_id_entities_id_fk": {
+          "name": "entity_relationships_from_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_to_entity_id_entities_id_fk": {
+          "name": "entity_relationships_to_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1785275458792,
       "tag": "0003_lyrical_shiver_man",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1785283417132,
+      "tag": "0004_furry_machine_man",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-resizable-panels": "^4.12.2",
     "shadcn": "^4.16.0",
     "sonner": "^2.0.7",
+    "stripe": "^22.3.2",
     "svix": "^1.99.1",
     "tailwind-merge": "^3.6.0",
     "tiptap-markdown": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      stripe:
+        specifier: ^22.3.2
+        version: 22.3.2(@types/node@20.19.43)
       svix:
         specifier: ^1.99.1
         version: 1.99.1
@@ -6091,6 +6094,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@22.3.2:
+    resolution: {integrity: sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -12851,6 +12863,10 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.3.2(@types/node@20.19.43):
+    optionalDependencies:
+      '@types/node': 20.19.43
 
   strtok3@10.3.5:
     dependencies:

--- a/src/ai/agents/entity-bible 2.ts
+++ b/src/ai/agents/entity-bible 2.ts
@@ -1,0 +1,135 @@
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
+import { MODELS, type QualityTier } from "@/ai/models";
+import { ENTITY_KINDS, RELATIONSHIP_TYPES } from "@/ai/schemas/entities";
+import type { BookConcept, BookOutline } from "@/ai/schemas";
+import { applyEntityDeltas, seedEntities, type EntitySeed } from "@/db/queries/entities";
+
+/**
+ * Builds the story bible before drafting starts.
+ *
+ * The problem this solves: without a canon established up front, chapter 9
+ * invents a surname for a sister that chapter 2 never gave, or gives the hero's
+ * sword a jewel it never had. So every entity is interrogated once — who are
+ * they to the story, what do they do, what do they look like, what heritage do
+ * they come from — and, crucially, names are *derived* from the entities they
+ * are related to rather than picked in isolation.
+ */
+
+const bibleSchema = z.object({
+  entities: z
+    .array(
+      z.object({
+        kind: z.enum(ENTITY_KINDS),
+        name: z.string(),
+        aliases: z.array(z.string()).max(4).default([]),
+        attrs: z.record(z.string(), z.unknown()).default({}),
+      }),
+    )
+    .max(60),
+  relationships: z
+    .array(
+      z.object({
+        from: z.string(),
+        to: z.string(),
+        type: z.enum(RELATIONSHIP_TYPES),
+        description: z.string().max(300).optional(),
+      }),
+    )
+    .max(60)
+    .default([]),
+});
+
+function bibleInstructions(): string {
+  return [
+    `You are a story bible editor. Before a word of prose is written you establish the canon that every chapter must honor.`,
+    ``,
+    `For each entity, answer the questions that keep a long book consistent:`,
+    `- character: what are they to the story (protagonist, foil, obstacle)? what is their occupation? what would a reader picture when they appear? what cultural or regional heritage do they come from? how do they speak? what do they want, and what are they hiding?`,
+    `- location: what kind of place is it, what does it physically contain, who owns it, how does it feel to be in?`,
+    `- object: what does it look like in specific terms, where did it come from, who holds it, why does it matter?`,
+    `- organization: what is it for, how is it structured, who belongs, how is it regarded?`,
+    `- event: when does it occur, who takes part, what is the outcome?`,
+    ``,
+    `Naming is not decoration. Derive every name from the entity's heritage and from the names of entities it is related to — siblings and parents share surnames, a household's servants may carry regional names, a ship and its owner may echo each other. Record the reasoning in nameRationale. Never assign a name that contradicts an established family tie.`,
+    ``,
+    `Record relationships explicitly, especially family ties, ownership, and membership.`,
+    `Be specific. "Tall and dark-haired" is useless; "a head taller than everyone in the room, with the family's heavy black brows" is canon.`,
+  ].join("\n");
+}
+
+/**
+ * Derives the initial cast and world. Runs once, after the outline, before any
+ * chapter is drafted.
+ */
+export async function buildEntityBible(input: {
+  meter: MeterCtx;
+  bookId: string;
+  tier: QualityTier;
+  concept: BookConcept;
+  outline: BookOutline;
+  genre?: string;
+  existingNames?: string[];
+}): Promise<{ entityCount: number; relationshipCount: number }> {
+  const model = MODELS[input.tier].summarizer;
+
+  const chapterDigest = input.outline.chapters
+    .map((c) => `${c.number}. ${c.title} — ${c.summary} [${c.charactersPresent.join(", ")}]`)
+    .join("\n");
+
+  const result = await metered(
+    input.meter,
+    { role: "entity-bible", operation: "entity.bible", model },
+    () =>
+      generateText({
+        model,
+        instructions: bibleInstructions(),
+        prompt: [
+          `## Book`,
+          `${input.concept.title} — ${input.concept.logline}`,
+          input.genre ? `Genre: ${input.genre}` : "",
+          `Setting: ${input.concept.setting}`,
+          `Central conflict: ${input.concept.centralConflict}`,
+          ``,
+          `## Cast from the concept`,
+          input.concept.characters
+            .map((c) => `- ${c.name} (${c.role}): ${c.description} Arc: ${c.arc}`)
+            .join("\n"),
+          ``,
+          `## Chapter outline`,
+          chapterDigest,
+          ``,
+          input.existingNames?.length
+            ? `## Already in the bible — do not duplicate, and derive new names consistently with these\n${input.existingNames.join(", ")}`
+            : "",
+          ``,
+          `Produce the story bible: every character named in the outline, every location the story visits, every object that carries weight, plus any organizations and named events. Then the relationships between them.`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        output: Output.object({ schema: bibleSchema }),
+        providerOptions: gatewayOptions(input.meter, "entity-bible"),
+      }),
+  );
+
+  const bible = result.output;
+
+  const seeds: EntitySeed[] = bible.entities.map((e) => ({
+    kind: e.kind,
+    name: e.name,
+    aliases: e.aliases,
+    attrs: e.attrs,
+  }));
+  await seedEntities(input.bookId, seeds);
+
+  // Relationships are applied after the entities exist so both endpoints resolve.
+  await applyEntityDeltas({
+    bookId: input.bookId,
+    newFacts: [],
+    relationships: bible.relationships.map((r) => ({ from: r.from, to: r.to, type: r.type })),
+  });
+
+  return { entityCount: seeds.length, relationshipCount: bible.relationships.length };
+}

--- a/src/ai/metering.ts
+++ b/src/ai/metering.ts
@@ -1,5 +1,6 @@
 import type { JSONValue, LanguageModelUsage } from "ai";
 import { checkBudget, recordLlmCall } from "@/lib/billing/meter";
+import { debitCredits } from "@/lib/billing/credits";
 import { PROSE_FALLBACK_MODELS } from "./models";
 
 export type MeterCtx = {
@@ -52,7 +53,7 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
     (result as { files?: Array<{ mediaType?: string }> }).files?.filter((f) =>
       f.mediaType?.startsWith("image/"),
     ).length ?? 0;
-  await recordLlmCall({
+  const usd = await recordLlmCall({
     userId: ctx.userId,
     projectId: ctx.projectId,
     runId: ctx.runId,
@@ -69,5 +70,16 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
     },
     latencyMs: Date.now() - startedAt,
   });
+
+  // Debit the wallet from the same place the cost is recorded, so the ledger
+  // and llm_calls can never disagree about what was spent.
+  await debitCredits({
+    userId: ctx.userId,
+    meteredUsd: usd,
+    description: info.operation,
+    projectId: ctx.projectId ?? undefined,
+    runId: ctx.runId ?? undefined,
+  });
+
   return result;
 }

--- a/src/ai/schemas/entities 2.ts
+++ b/src/ai/schemas/entities 2.ts
@@ -1,0 +1,156 @@
+import { z } from "zod";
+
+/**
+ * The story bible's entity model.
+ *
+ * Consistency drift in long books is rarely about plot — it is about details:
+ * a character's eyes changing colour, a sword gaining a jewel it never had, a
+ * house growing a room. Each kind therefore gets a purpose-built attribute
+ * schema rather than a bag of free text, so the writer can be asked for
+ * specific facts and the continuity pass has something concrete to check.
+ *
+ * Every kind carries `facts`, an append-only list. That shared channel is what
+ * makes the atomic jsonb merge in `entityUpsert` possible across a wave of
+ * concurrently drafting chapters.
+ */
+
+export const ENTITY_KINDS = ["character", "location", "object", "organization", "event"] as const;
+export type EntityKind = (typeof ENTITY_KINDS)[number];
+
+/** Accreted canon: short declarative statements later chapters must honour. */
+const facts = z.array(z.string()).default([]);
+
+export const characterAttrs = z.object({
+  role: z.string().optional().describe("Role in the story — protagonist, foil, antagonist, etc."),
+  occupation: z.string().optional().describe("What they do for a living"),
+  appearance: z.string().optional().describe("Physical description a reader would picture"),
+  heritage: z
+    .string()
+    .optional()
+    .describe("Cultural, ethnic or regional background informing name and speech"),
+  age: z.string().optional(),
+  speech: z.string().optional().describe("How they talk — register, verbal tics, dialect"),
+  personality: z.array(z.string()).default([]),
+  goals: z.array(z.string()).default([]),
+  secrets: z.array(z.string()).default([]),
+  nameRationale: z
+    .string()
+    .optional()
+    .describe("Why this name — family ties, heritage, naming conventions it follows"),
+  facts,
+});
+
+export const locationAttrs = z.object({
+  locationType: z.string().optional().describe("House, tavern, city, ship, forest…"),
+  description: z.string().optional(),
+  features: z.array(z.string()).default([]).describe("Fixed, memorable characteristics"),
+  contents: z
+    .array(z.string())
+    .default([])
+    .describe("Notable things inside it — furniture, objects, rooms"),
+  atmosphere: z.string().optional().describe("How the place feels to be in"),
+  owner: z.string().optional().describe("Character or organization it belongs to"),
+  facts,
+});
+
+export const objectAttrs = z.object({
+  description: z.string().optional().describe("What it looks like, in specific terms"),
+  significance: z.string().optional().describe("Why it matters to the story"),
+  provenance: z.string().optional().describe("Where it came from, who made it"),
+  holder: z.string().optional().describe("Who currently has it"),
+  capabilities: z.array(z.string()).default([]).describe("What it can do, if anything"),
+  facts,
+});
+
+export const organizationAttrs = z.object({
+  purpose: z.string().optional(),
+  structure: z.string().optional().describe("How it is organized and led"),
+  members: z.array(z.string()).default([]),
+  reputation: z.string().optional().describe("How outsiders regard it"),
+  facts,
+});
+
+export const eventAttrs = z.object({
+  when: z.string().optional().describe("When it happens relative to the story"),
+  participants: z.array(z.string()).default([]),
+  outcome: z.string().optional(),
+  significance: z.string().optional(),
+  facts,
+});
+
+export const ENTITY_ATTRS = {
+  character: characterAttrs,
+  location: locationAttrs,
+  object: objectAttrs,
+  organization: organizationAttrs,
+  event: eventAttrs,
+} as const;
+
+export type EntityAttrs =
+  | z.infer<typeof characterAttrs>
+  | z.infer<typeof locationAttrs>
+  | z.infer<typeof objectAttrs>
+  | z.infer<typeof organizationAttrs>
+  | z.infer<typeof eventAttrs>;
+
+export function attrsSchemaFor(kind: EntityKind) {
+  return ENTITY_ATTRS[kind];
+}
+
+/** Parses attrs for a kind, dropping unknown keys rather than throwing. */
+export function parseAttrs(kind: EntityKind, value: unknown): EntityAttrs {
+  const result = attrsSchemaFor(kind).safeParse(value ?? {});
+  return result.success ? result.data : (attrsSchemaFor(kind).parse({}) as EntityAttrs);
+}
+
+/**
+ * Scalar attributes worth guarding. A change to one of these is a likely
+ * continuity error (eyes changing colour); list-valued fields such as `facts`
+ * or `personality` only ever accumulate and are never treated as conflicts.
+ */
+export const GUARDED_ATTRS: Record<EntityKind, string[]> = {
+  character: ["appearance", "heritage", "age", "occupation"],
+  location: ["locationType", "owner"],
+  object: ["description", "provenance"],
+  organization: ["purpose", "structure"],
+  event: ["when", "outcome"],
+};
+
+export const RELATIONSHIP_TYPES = [
+  "parent",
+  "child",
+  "sibling",
+  "spouse",
+  "friend",
+  "rival",
+  "enemy",
+  "mentor",
+  "employer",
+  "member-of",
+  "owns",
+  "located-in",
+  "created",
+  "participated-in",
+  "other",
+] as const;
+export type RelationshipType = (typeof RELATIONSHIP_TYPES)[number];
+
+/** Relationship kinds that imply a shared family name. Drives name derivation. */
+export const FAMILY_RELATIONSHIPS: RelationshipType[] = ["parent", "child", "sibling", "spouse"];
+
+/** Maps an entity kind onto the continuity_issues category vocabulary. */
+export const KIND_TO_ISSUE_CATEGORY: Record<EntityKind, "character" | "setting" | "plot"> = {
+  character: "character",
+  location: "setting",
+  object: "plot",
+  organization: "setting",
+  event: "plot",
+};
+
+export const entityInputSchema = z.object({
+  kind: z.enum(ENTITY_KINDS),
+  name: z.string().min(1).max(120),
+  aliases: z.array(z.string()).default([]),
+  attrs: z.record(z.string(), z.unknown()).default({}),
+});
+export type EntityInput = z.infer<typeof entityInputSchema>;

--- a/src/ai/tools/entities 2.ts
+++ b/src/ai/tools/entities 2.ts
@@ -1,0 +1,292 @@
+import { tool } from "ai";
+import { and, eq, ilike, or, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import {
+  ENTITY_KINDS,
+  GUARDED_ATTRS,
+  KIND_TO_ISSUE_CATEGORY,
+  RELATIONSHIP_TYPES,
+  parseAttrs,
+  type EntityKind,
+} from "@/ai/schemas/entities";
+
+/**
+ * Story-bible tools. These are the agents' only authoritative source for who
+ * someone is, what a place contains, or what an object can do — the point being
+ * that a chapter written in wave 3 asks rather than invents.
+ */
+
+export type EntityToolCtx = {
+  bookId: string;
+  chapterNumber?: number;
+};
+
+/** Scalar attrs that already have a different value — the drift we care about. */
+export function findConflicts(
+  kind: EntityKind,
+  existing: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): { field: string; from: string; to: string }[] {
+  const conflicts: { field: string; from: string; to: string }[] = [];
+  for (const field of GUARDED_ATTRS[kind]) {
+    const before = existing[field];
+    const after = incoming[field];
+    if (typeof before !== "string" || typeof after !== "string") continue;
+    if (!before.trim() || !after.trim()) continue;
+    if (before.trim().toLowerCase() !== after.trim().toLowerCase()) {
+      conflicts.push({ field, from: before, to: after });
+    }
+  }
+  return conflicts;
+}
+
+export function entityGet(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Look up canonical facts about people, places, objects, organizations or events in this book. Consult before writing anything involving one — never invent a detail that might already be established.",
+    inputSchema: z.object({
+      names: z.array(z.string()).min(1).max(8).describe("Entity names to look up"),
+      kind: z.enum(ENTITY_KINDS).optional().describe("Narrow the lookup to one kind"),
+    }),
+    execute: async ({ names, kind }) => {
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(schema.entities)
+        .where(
+          kind
+            ? and(eq(schema.entities.bookId, ctx.bookId), eq(schema.entities.kind, kind))
+            : eq(schema.entities.bookId, ctx.bookId),
+        );
+
+      const wanted = new Set(names.map((n) => n.toLowerCase()));
+      const matches = (row: (typeof rows)[number]) =>
+        wanted.has(row.name.toLowerCase()) ||
+        row.aliases.some((alias) => wanted.has(alias.toLowerCase()));
+
+      const found = rows.filter(matches);
+      const ids = found.map((r) => r.id);
+
+      // Relationships give the writer the family/ownership context that keeps
+      // names and possessions consistent.
+      const relationships = ids.length
+        ? await db
+            .select({
+              from: schema.entityRelationships.fromEntityId,
+              to: schema.entityRelationships.toEntityId,
+              type: schema.entityRelationships.type,
+              description: schema.entityRelationships.description,
+            })
+            .from(schema.entityRelationships)
+            .where(eq(schema.entityRelationships.bookId, ctx.bookId))
+        : [];
+
+      const nameById = new Map(rows.map((r) => [r.id, r.name]));
+
+      return {
+        entities: found.map((r) => ({
+          kind: r.kind,
+          name: r.name,
+          aliases: r.aliases,
+          attrs: r.attrs,
+          firstAppearanceChapter: r.firstAppearanceChapter,
+          relationships: relationships
+            .filter((rel) => rel.from === r.id || rel.to === r.id)
+            .map((rel) => ({
+              type: rel.type,
+              other: nameById.get(rel.from === r.id ? rel.to : rel.from) ?? "unknown",
+              direction: rel.from === r.id ? "outgoing" : "incoming",
+              description: rel.description,
+            })),
+        })),
+        missing: names.filter(
+          (n) =>
+            !found.some(
+              (r) =>
+                r.name.toLowerCase() === n.toLowerCase() ||
+                r.aliases.some((a) => a.toLowerCase() === n.toLowerCase()),
+            ),
+        ),
+      };
+    },
+  });
+}
+
+export function entitySearch(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Search the story bible by partial name or kind when you do not know the exact name. Use before inventing a new entity, to avoid creating a duplicate under a slightly different name.",
+    inputSchema: z.object({
+      query: z.string().min(1).max(80).optional(),
+      kind: z.enum(ENTITY_KINDS).optional(),
+      limit: z.number().int().min(1).max(50).default(20),
+    }),
+    execute: async ({ query, kind, limit }) => {
+      const db = getDb();
+      const filters = [eq(schema.entities.bookId, ctx.bookId)];
+      if (kind) filters.push(eq(schema.entities.kind, kind));
+      if (query) {
+        const like = `%${query}%`;
+        filters.push(
+          or(
+            ilike(schema.entities.name, like),
+            sql`${schema.entities.aliases}::text ilike ${like}`,
+          )!,
+        );
+      }
+      const rows = await db
+        .select({
+          kind: schema.entities.kind,
+          name: schema.entities.name,
+          aliases: schema.entities.aliases,
+          firstAppearanceChapter: schema.entities.firstAppearanceChapter,
+        })
+        .from(schema.entities)
+        .where(and(...filters))
+        .limit(limit);
+      return { results: rows };
+    },
+  });
+}
+
+export function entityUpsert(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Create or update an entity in the story bible. Call after drafting for anything you established that later chapters must honor — a character's appearance, what a room contains, who holds an object. Contradicting an existing detail is recorded as a continuity issue rather than silently overwriting canon.",
+    inputSchema: z.object({
+      kind: z.enum(ENTITY_KINDS),
+      name: z.string().min(1).max(120),
+      aliases: z.array(z.string()).max(8).default([]),
+      attrs: z
+        .record(z.string(), z.unknown())
+        .default({})
+        .describe("Kind-appropriate attributes. Include `facts` for new canonical statements."),
+    }),
+    execute: async ({ kind, name, aliases, attrs }) => {
+      const db = getDb();
+      const parsed = parseAttrs(kind, attrs) as Record<string, unknown>;
+
+      const [existing] = await db
+        .select({ id: schema.entities.id, attrs: schema.entities.attrs })
+        .from(schema.entities)
+        .where(
+          and(
+            eq(schema.entities.bookId, ctx.bookId),
+            eq(schema.entities.kind, kind),
+            eq(schema.entities.name, name),
+          ),
+        )
+        .limit(1);
+
+      const conflicts = existing ? findConflicts(kind, existing.attrs, parsed) : [];
+      if (conflicts.length > 0) {
+        await db.insert(schema.continuityIssues).values(
+          conflicts.map((c) => ({
+            bookId: ctx.bookId,
+            chapters: ctx.chapterNumber ? [ctx.chapterNumber] : [],
+            category: KIND_TO_ISSUE_CATEGORY[kind],
+            severity: "major" as const,
+            description: `${kind} "${name}": ${c.field} was established as "${c.from}" but chapter ${ctx.chapterNumber ?? "?"} says "${c.to}".`,
+            suggestedFix: `Keep the established "${c.from}" unless the change is deliberate and explained in the prose.`,
+          })),
+        );
+      }
+
+      // Guarded scalars stay as first established; everything else may refine.
+      const conflicted = new Set(conflicts.map((c) => c.field));
+      const safeAttrs = Object.fromEntries(
+        Object.entries(parsed).filter(([key]) => !conflicted.has(key)),
+      );
+      const { facts: incomingFacts = [], ...scalars } = safeAttrs as {
+        facts?: string[];
+        [key: string]: unknown;
+      };
+
+      // Atomic: chapters draft four at a time, so merge in one statement rather
+      // than read-modify-write. The parens around (excluded.attrs->'facts') are
+      // load-bearing — `||` and `->` are equal precedence and left-associative,
+      // so without them this parses as (attrs || excluded.attrs)->'facts'.
+      await db
+        .insert(schema.entities)
+        .values({
+          bookId: ctx.bookId,
+          kind,
+          name,
+          aliases,
+          attrs: { ...scalars, facts: incomingFacts },
+          firstAppearanceChapter: ctx.chapterNumber,
+          lastUpdatedChapter: ctx.chapterNumber,
+        })
+        .onConflictDoUpdate({
+          target: [schema.entities.bookId, schema.entities.kind, schema.entities.name],
+          set: {
+            attrs: sql`jsonb_set(
+              ${schema.entities.attrs} || (${JSON.stringify(scalars)}::jsonb),
+              '{facts}',
+              coalesce(${schema.entities.attrs}->'facts', '[]'::jsonb) || (excluded.attrs->'facts')
+            )`,
+            aliases: sql`(
+              select coalesce(jsonb_agg(distinct value), '[]'::jsonb)
+              from jsonb_array_elements(${schema.entities.aliases} || excluded.aliases)
+            )`,
+            lastUpdatedChapter: ctx.chapterNumber,
+            updatedAt: new Date(),
+          },
+        });
+
+      return {
+        recorded: true,
+        kind,
+        name,
+        conflicts: conflicts.map((c) => `${c.field}: "${c.from}" vs "${c.to}"`),
+      };
+    },
+  });
+}
+
+export function entityRelate(ctx: EntityToolCtx) {
+  return tool({
+    description:
+      "Record a relationship between two entities — siblings, an owner and a possession, a member and their organization. Family relationships are what let later chapters derive consistent surnames.",
+    inputSchema: z.object({
+      from: z.string().min(1).describe("Name of the entity the relationship starts at"),
+      to: z.string().min(1).describe("Name of the related entity"),
+      type: z.enum(RELATIONSHIP_TYPES),
+      description: z.string().max(400).optional(),
+    }),
+    execute: async ({ from, to, type, description }) => {
+      const db = getDb();
+      const rows = await db
+        .select({ id: schema.entities.id, name: schema.entities.name })
+        .from(schema.entities)
+        .where(eq(schema.entities.bookId, ctx.bookId));
+
+      const lookup = (name: string) =>
+        rows.find((r) => r.name.toLowerCase() === name.toLowerCase());
+      const fromRow = lookup(from);
+      const toRow = lookup(to);
+      if (!fromRow || !toRow) {
+        return {
+          recorded: false,
+          reason: `Unknown entity: ${!fromRow ? from : to}. Create it with entityUpsert first.`,
+        };
+      }
+
+      await db
+        .insert(schema.entityRelationships)
+        .values({
+          bookId: ctx.bookId,
+          fromEntityId: fromRow.id,
+          toEntityId: toRow.id,
+          type,
+          description,
+          establishedChapter: ctx.chapterNumber,
+        })
+        .onConflictDoNothing();
+
+      return { recorded: true, from: fromRow.name, to: toRow.name, type };
+    },
+  });
+}

--- a/src/ai/tools/entities.test 2.ts
+++ b/src/ai/tools/entities.test 2.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { findConflicts } from "./entities";
+import {
+  GUARDED_ATTRS,
+  KIND_TO_ISSUE_CATEGORY,
+  attrsSchemaFor,
+  parseAttrs,
+  ENTITY_KINDS,
+} from "@/ai/schemas/entities";
+
+describe("per-kind attribute schemas", () => {
+  it("gives every kind a schema", () => {
+    for (const kind of ENTITY_KINDS) {
+      expect(attrsSchemaFor(kind)).toBeDefined();
+    }
+  });
+
+  it("defaults list fields so the jsonb merge always has an array to concat", () => {
+    for (const kind of ENTITY_KINDS) {
+      const parsed = parseAttrs(kind, {}) as { facts?: string[] };
+      expect(Array.isArray(parsed.facts)).toBe(true);
+    }
+  });
+
+  it("keeps the kind-specific fields the bible depends on", () => {
+    const character = parseAttrs("character", {
+      heritage: "Coastal Averrin",
+      nameRationale: "Shares the Vantry surname with her mother",
+      appearance: "tide-weathered, rope-scarred hands",
+      bogus: "dropped",
+    }) as Record<string, unknown>;
+    expect(character.heritage).toBe("Coastal Averrin");
+    expect(character.nameRationale).toContain("Vantry");
+    expect(character.bogus).toBeUndefined();
+  });
+
+  it("records what a location contains — the television-in-the-den case", () => {
+    const location = parseAttrs("location", {
+      locationType: "family home",
+      contents: ["a television in the den", "her father's charts"],
+    }) as Record<string, unknown>;
+    expect(location.contents).toEqual(["a television in the den", "her father's charts"]);
+  });
+
+  it("drops malformed attrs rather than throwing mid-generation", () => {
+    const parsed = parseAttrs("object", { capabilities: "not-an-array" }) as {
+      capabilities?: string[];
+    };
+    expect(Array.isArray(parsed.capabilities)).toBe(true);
+  });
+});
+
+describe("findConflicts", () => {
+  it("flags a guarded scalar changing — the drift we care about", () => {
+    const conflicts = findConflicts(
+      "character",
+      { appearance: "grey eyes", facts: ["a"] },
+      { appearance: "green eyes", facts: ["b"] },
+    );
+    expect(conflicts).toEqual([{ field: "appearance", from: "grey eyes", to: "green eyes" }]);
+  });
+
+  it("ignores case and surrounding whitespace", () => {
+    expect(
+      findConflicts("character", { appearance: "Grey eyes" }, { appearance: " grey eyes " }),
+    ).toEqual([]);
+  });
+
+  it("does not treat first-time establishment as a conflict", () => {
+    expect(findConflicts("character", {}, { appearance: "grey eyes" })).toEqual([]);
+  });
+
+  it("does not treat an omitted field as a conflict", () => {
+    expect(findConflicts("character", { appearance: "grey eyes" }, {})).toEqual([]);
+  });
+
+  it("never flags list fields — facts only ever accumulate", () => {
+    const conflicts = findConflicts(
+      "character",
+      { facts: ["was in Averrin"], personality: ["blunt"] },
+      { facts: ["left Averrin"], personality: ["warm"] },
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  it("guards object provenance so a sword cannot change origin", () => {
+    const conflicts = findConflicts(
+      "object",
+      { provenance: "forged by her mother" },
+      { provenance: "bought in the market" },
+    );
+    expect(conflicts.map((c) => c.field)).toEqual(["provenance"]);
+  });
+
+  it("guards a field for every kind", () => {
+    for (const kind of ENTITY_KINDS) {
+      expect(GUARDED_ATTRS[kind].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("KIND_TO_ISSUE_CATEGORY", () => {
+  it("maps every kind onto the continuity_issues vocabulary", () => {
+    const allowed = new Set(["character", "timeline", "setting", "plot", "factual"]);
+    for (const kind of ENTITY_KINDS) {
+      expect(allowed.has(KIND_TO_ISSUE_CATEGORY[kind])).toBe(true);
+    }
+  });
+});

--- a/src/app/(studio)/projects/[projectId]/bible/page 2.tsx
+++ b/src/app/(studio)/projects/[projectId]/bible/page 2.tsx
@@ -1,0 +1,94 @@
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { EntityCard } from "@/components/bible/entity-card";
+import { requireUser } from "@/lib/auth";
+import { getProjectWithBook } from "@/db/queries/books";
+import { listEntities, openContradictions } from "@/db/queries/entities";
+import { ENTITY_KINDS, type EntityKind } from "@/ai/schemas/entities";
+
+const KIND_LABELS: Record<EntityKind, string> = {
+  character: "Characters",
+  location: "Locations",
+  object: "Objects",
+  organization: "Organizations",
+  event: "Events",
+};
+
+export default async function BiblePage({ params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params;
+  const { userId } = await requireUser();
+  const data = await getProjectWithBook(userId, projectId);
+  if (!data) notFound();
+  const { book } = data;
+
+  const [entities, contradictions] = await Promise.all([
+    book ? listEntities(book.id) : Promise.resolve([]),
+    book ? openContradictions(book.id) : Promise.resolve([]),
+  ]);
+
+  if (entities.length === 0) {
+    return (
+      <div className="space-y-4">
+        <h2 className="font-display text-xl font-semibold tracking-tight">Story bible</h2>
+        <div className="paper-surface flex flex-col items-center gap-3 px-6 py-16 text-center">
+          <p aria-hidden="true" className="text-2xl text-paper-muted">
+            ⁂
+          </p>
+          <h3 className="font-display text-lg font-semibold text-paper-foreground">
+            Nothing recorded yet
+          </h3>
+          <p className="max-w-md font-serif text-paper-muted italic">
+            The bible fills in as your book is written — the cast and world are established before
+            drafting, then every chapter adds what it establishes.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  /** Contradictions are per-book; match them to entities by name mention. */
+  const contradictionsFor = (name: string) =>
+    contradictions.filter((issue) => issue.description.toLowerCase().includes(name.toLowerCase()));
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h2 className="font-display text-xl font-semibold tracking-tight">Story bible</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Canon every chapter must honor. {entities.length}{" "}
+            {entities.length === 1 ? "entry" : "entries"}.
+          </p>
+        </div>
+        {contradictions.length > 0 ? (
+          <Badge variant="destructive">
+            {contradictions.length} open {contradictions.length === 1 ? "conflict" : "conflicts"}
+          </Badge>
+        ) : null}
+      </header>
+
+      {ENTITY_KINDS.map((kind) => {
+        const group = entities.filter((e) => e.kind === kind);
+        if (group.length === 0) return null;
+        return (
+          <section key={kind} aria-labelledby={`bible-${kind}`} className="space-y-3">
+            <h3
+              id={`bible-${kind}`}
+              className="font-mono text-xs tracking-[0.16em] text-muted-foreground uppercase"
+            >
+              {KIND_LABELS[kind]} · {group.length}
+            </h3>
+            <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {group.map((entity) => (
+                <li key={entity.id}>
+                  <EntityCard entity={entity} conflicts={contradictionsFor(entity.name)} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(studio)/studio/credits/page.tsx
+++ b/src/app/(studio)/studio/credits/page.tsx
@@ -1,0 +1,122 @@
+import { PackButtons } from "@/components/credits/pack-buttons";
+import { RelativeTime } from "@/components/relative-time";
+import { requireUser } from "@/lib/auth";
+import { CREDIT_PACKS, getBalance, listLedger } from "@/lib/billing/credits";
+
+export const metadata = { title: "Credits — sopher.ai" };
+
+const KIND_LABELS: Record<string, string> = {
+  purchase: "Purchase",
+  usage: "Usage",
+  refund: "Refund",
+  grant: "Grant",
+  adjustment: "Adjustment",
+};
+
+export default async function CreditsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ purchase?: string }>;
+}) {
+  const { purchase } = await searchParams;
+  const { userId } = await requireUser();
+  const [balance, ledger] = await Promise.all([getBalance(userId), listLedger(userId)]);
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h2 className="font-display text-xl font-semibold tracking-tight">Credits</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          One credit is one dollar of writing. A finished novella runs about 21–36 credits depending
+          on tier.
+        </p>
+      </header>
+
+      {purchase === "complete" ? (
+        <p
+          role="status"
+          className="rounded-md border border-ai/40 bg-ai-soft px-4 py-3 text-sm text-ai"
+        >
+          Payment received. Credits appear here once Stripe confirms the charge — usually within a
+          few seconds. Refresh if the balance below looks unchanged.
+        </p>
+      ) : null}
+      {purchase === "cancelled" ? (
+        <p role="status" className="rounded-md border border-border px-4 py-3 text-sm">
+          Checkout cancelled. Nothing was charged.
+        </p>
+      ) : null}
+
+      <section aria-labelledby="balance-heading" className="paper-surface px-6 py-6">
+        <h3
+          id="balance-heading"
+          className="font-mono text-xs tracking-[0.16em] text-paper-muted uppercase"
+        >
+          Balance
+        </h3>
+        <p className="mt-1 font-display text-4xl font-semibold tabular-nums text-paper-foreground">
+          {balance.toFixed(2)}
+          <span className="ml-2 font-sans text-base font-normal text-paper-muted">credits</span>
+        </p>
+      </section>
+
+      <section aria-labelledby="packs-heading" className="space-y-4">
+        <h3 id="packs-heading" className="font-sans font-semibold">
+          Add credits
+        </h3>
+        <PackButtons packs={CREDIT_PACKS} />
+      </section>
+
+      <section aria-labelledby="ledger-heading" className="space-y-3">
+        <h3 id="ledger-heading" className="font-sans font-semibold">
+          Activity
+        </h3>
+        {ledger.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Nothing yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <caption className="sr-only">Credit purchases and usage, most recent first</caption>
+              <thead>
+                <tr className="border-b border-border text-left">
+                  <th scope="col" className="py-2 pr-3 font-medium text-muted-foreground">
+                    When
+                  </th>
+                  <th scope="col" className="py-2 pr-3 font-medium text-muted-foreground">
+                    Type
+                  </th>
+                  <th scope="col" className="py-2 pr-3 font-medium text-muted-foreground">
+                    Detail
+                  </th>
+                  <th scope="col" className="py-2 text-right font-medium text-muted-foreground">
+                    Credits
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {ledger.map((entry) => {
+                  const amount = Number(entry.amount);
+                  return (
+                    <tr key={entry.id} className="border-b border-border/60 last:border-0">
+                      <td className="py-2 pr-3 whitespace-nowrap text-muted-foreground">
+                        <RelativeTime iso={entry.createdAt.toISOString()} />
+                      </td>
+                      <td className="py-2 pr-3">{KIND_LABELS[entry.kind] ?? entry.kind}</td>
+                      <td className="py-2 pr-3 text-muted-foreground">{entry.description}</td>
+                      <td
+                        className={`py-2 text-right tabular-nums ${amount < 0 ? "text-muted-foreground" : "text-ai"}`}
+                      >
+                        {amount > 0 ? "+" : ""}
+                        {amount.toFixed(2)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/assets/diagram/route 3.ts
+++ b/src/app/api/assets/diagram/route 3.ts
@@ -1,0 +1,119 @@
+import { put } from "@vercel/blob";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import { getChapterOwnership } from "@/db/queries/books";
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { diagramSourceHash } from "@/lib/export/figures";
+
+/**
+ * Caches a client-rendered Mermaid diagram so server-side surfaces (reading
+ * view, EPUB, PDF, DOCX) can show the diagram instead of its source. Mermaid
+ * needs a DOM, so the editor renders it and posts the result here.
+ *
+ * Idempotent: keyed by a hash of the diagram source, so re-opening a chapter
+ * re-posts the same payload and no-ops. Costs one round trip, no LLM call.
+ */
+
+export const maxDuration = 60;
+
+const MAX_SVG_CHARS = 512_000;
+const MAX_PNG_BYTES = 4_000_000;
+
+const bodySchema = z.object({
+  chapterId: z.uuid(),
+  source: z.string().min(1).max(20_000),
+  svg: z.string().min(1).max(MAX_SVG_CHARS),
+  /** PNG rasterization as a bare base64 payload (no data: prefix). */
+  pngBase64: z.string().min(1).max(MAX_PNG_BYTES),
+  alt: z.string().max(500).optional(),
+});
+
+export async function POST(req: Request) {
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  const { chapterId, source, svg, pngBase64, alt } = parsed.data;
+
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) {
+    return Response.json({ error: "Chapter not found" }, { status: 404 });
+  }
+
+  const sourceHash = diagramSourceHash(source);
+  const db = getDb();
+
+  // Already cached for this project — nothing to do.
+  const existing = await db
+    .select({ id: schema.assets.id })
+    .from(schema.assets)
+    .where(
+      and(
+        eq(schema.assets.projectId, ownership.projectId),
+        eq(schema.assets.kind, "diagram"),
+        sql`${schema.assets.meta}->>'sourceHash' = ${sourceHash}`,
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) {
+    return Response.json({ cached: true, sourceHash });
+  }
+
+  const png = Buffer.from(pngBase64, "base64");
+  if (png.length === 0) {
+    return Response.json({ error: "Invalid PNG payload" }, { status: 400 });
+  }
+
+  const meta = { sourceHash, alt: alt || "Diagram" };
+  const base = `diagrams/${ownership.projectId}/${sourceHash}`;
+
+  const [svgBlob, pngBlob] = await Promise.all([
+    put(`${base}.svg`, svg, {
+      access: "public",
+      contentType: "image/svg+xml",
+      addRandomSuffix: false,
+    }),
+    put(`${base}.png`, png, {
+      access: "public",
+      contentType: "image/png",
+      addRandomSuffix: false,
+    }),
+  ]);
+
+  await db.insert(schema.assets).values([
+    {
+      projectId: ownership.projectId,
+      chapterId,
+      kind: "diagram" as const,
+      blobUrl: svgBlob.url,
+      blobPathname: svgBlob.pathname,
+      contentType: "image/svg+xml",
+      sizeBytes: Buffer.byteLength(svg),
+      meta,
+    },
+    {
+      projectId: ownership.projectId,
+      chapterId,
+      kind: "diagram" as const,
+      blobUrl: pngBlob.url,
+      blobPathname: pngBlob.pathname,
+      contentType: "image/png",
+      sizeBytes: png.length,
+      meta,
+    },
+  ]);
+
+  return Response.json({ cached: false, sourceHash });
+}

--- a/src/app/api/credits/checkout/route.ts
+++ b/src/app/api/credits/checkout/route.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { getPack } from "@/lib/billing/credits";
+import { getStripe, stripeConfigured } from "@/lib/payments/stripe";
+
+/**
+ * Starts a Stripe Checkout session for a credit pack.
+ *
+ * This route never grants credits. It only creates the session; the webhook is
+ * the sole authority on payment, because the browser redirect a user lands on
+ * after paying is trivially forgeable and cannot be trusted to move money.
+ */
+
+export const maxDuration = 60;
+
+const bodySchema = z.object({ packId: z.string().min(1).max(40) });
+
+function originFrom(req: Request): string {
+  const explicit = process.env.NEXT_PUBLIC_APP_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+  // Vercel sets this per-deployment; fall back to the request origin locally.
+  const host = req.headers.get("host");
+  const proto = host?.startsWith("localhost") ? "http" : "https";
+  return host ? `${proto}://${host}` : "https://sopher.ai";
+}
+
+export async function POST(req: Request) {
+  if (!stripeConfigured) {
+    return Response.json({ error: "Payments are not configured" }, { status: 503 });
+  }
+
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  // Price comes from our own catalog, never from the request — otherwise a
+  // caller could name their own price for a pack.
+  const pack = getPack(parsed.data.packId);
+  if (!pack) return Response.json({ error: "Unknown pack" }, { status: 404 });
+
+  const origin = originFrom(req);
+  const session = await getStripe().checkout.sessions.create({
+    mode: "payment",
+    // Reconciled by the webhook; also lets us show the right pack on return.
+    client_reference_id: userId,
+    metadata: { userId, packId: pack.id, credits: String(pack.credits) },
+    line_items: [
+      {
+        quantity: 1,
+        price_data: {
+          currency: "usd",
+          unit_amount: pack.usd * 100,
+          product_data: {
+            name: `${pack.name} — ${pack.credits} credits`,
+            description:
+              pack.bonus > 0
+                ? `${pack.usd} dollars of credit plus ${Math.round(pack.bonus * 100)}% bonus`
+                : `${pack.credits} credits for sopher.ai`,
+          },
+        },
+      },
+    ],
+    success_url: `${origin}/studio/credits?purchase=complete`,
+    cancel_url: `${origin}/studio/credits?purchase=cancelled`,
+  });
+
+  if (!session.url) {
+    return Response.json({ error: "Could not start checkout" }, { status: 502 });
+  }
+  return Response.json({ url: session.url });
+}

--- a/src/app/api/entities/[entityId]/portrait/route 2.ts
+++ b/src/app/api/entities/[entityId]/portrait/route 2.ts
@@ -1,0 +1,120 @@
+import { put } from "@vercel/blob";
+import { generateText } from "ai";
+import { eq } from "drizzle-orm";
+
+import { gatewayOptions, metered } from "@/ai/metering";
+import { MODELS, type QualityTier } from "@/ai/models";
+import { getDb, schema } from "@/db";
+import { getEntityForPortrait } from "@/db/queries/entities";
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { BudgetExceededError, checkBudget } from "@/lib/billing/meter";
+import { PORTRAIT_KINDS, PORTRAIT_USD, portraitPrompt } from "@/lib/bible/portraits";
+import type { EntityKind } from "@/ai/schemas/entities";
+
+/**
+ * Generates one entity portrait on demand. Never called automatically — the
+ * image model bills per image and a whole cast would materially change a book's
+ * unit economics, so this is always an explicit choice with the price shown.
+ *
+ * Goes through `metered()` like every other model call, so it lands in
+ * `llm_calls` and counts against the user's budget.
+ */
+
+export const maxDuration = 120;
+
+export async function POST(_req: Request, ctx: { params: Promise<{ entityId: string }> }) {
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const { entityId } = await ctx.params;
+  const entity = await getEntityForPortrait(entityId);
+  if (!entity || entity.userId !== userId) {
+    return Response.json({ error: "Entity not found" }, { status: 404 });
+  }
+
+  const kind = entity.kind as EntityKind;
+  if (!PORTRAIT_KINDS.includes(kind)) {
+    return Response.json({ error: `Portraits are not generated for ${kind}s` }, { status: 400 });
+  }
+
+  const db = getDb();
+  const [project] = await db
+    .select({ settings: schema.projects.settings })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, entity.projectId))
+    .limit(1);
+  const tier: QualityTier = project?.settings.qualityTier ?? "standard";
+
+  try {
+    await checkBudget(userId, PORTRAIT_USD);
+
+    const model = MODELS[tier].image;
+    const prompt = portraitPrompt({
+      kind,
+      name: entity.name,
+      attrs: entity.attrs,
+      genre: entity.genre,
+    });
+
+    const meter = {
+      userId,
+      projectId: entity.projectId,
+      tier,
+    } as Parameters<typeof metered>[0];
+
+    const result = await metered(
+      meter,
+      { role: "content-tool", operation: "entity.portrait", model },
+      () =>
+        generateText({
+          model,
+          prompt,
+          providerOptions: gatewayOptions(meter, "content-tool"),
+        }),
+    );
+
+    const file = result.files.find((f) => f.mediaType?.startsWith("image/"));
+    if (!file) {
+      return Response.json({ error: "The image model returned no image" }, { status: 502 });
+    }
+
+    const contentType = file.mediaType ?? "image/png";
+    const blob = await put(
+      `portraits/${entity.projectId}/${entityId}-${crypto.randomUUID()}.png`,
+      Buffer.from(file.uint8Array),
+      { access: "public", contentType },
+    );
+
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        projectId: entity.projectId,
+        kind: "portrait",
+        blobUrl: blob.url,
+        blobPathname: blob.pathname,
+        contentType,
+        sizeBytes: file.uint8Array.byteLength,
+        meta: { entityId, prompt },
+      })
+      .returning({ id: schema.assets.id });
+
+    await db
+      .update(schema.entities)
+      .set({ portraitAssetId: asset.id, updatedAt: new Date() })
+      .where(eq(schema.entities.id, entityId));
+
+    return Response.json({ url: blob.url });
+  } catch (error) {
+    if (error instanceof BudgetExceededError) {
+      return Response.json({ error: "Monthly budget reached" }, { status: 402 });
+    }
+    throw error;
+  }
+}

--- a/src/app/api/runs/[runId]/input/route.ts
+++ b/src/app/api/runs/[runId]/input/route.ts
@@ -3,12 +3,18 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "@/db";
 import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { getBalance } from "@/lib/billing/credits";
 
-const bodySchema = z.object({
-  kind: z.literal("outline-approval"),
-  approved: z.boolean(),
-  notes: z.string().max(5_000).optional(),
-});
+const bodySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("outline-approval"),
+    approved: z.boolean(),
+    notes: z.string().max(5_000).optional(),
+  }),
+  // Resumes a run suspended mid-book because the wallet ran short. The balance
+  // is re-checked here so a resume cannot be forced without actually paying.
+  z.object({ kind: z.literal("credits-topup") }),
+]);
 
 /** Resumes a paused run (human-in-the-loop input, e.g. outline approval). */
 export async function POST(req: Request, ctx: { params: Promise<{ runId: string }> }) {
@@ -39,6 +45,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ runId: string 
   if (!run) return Response.json({ error: "Run not found" }, { status: 404 });
   if (run.status !== "awaiting_input") {
     return Response.json({ error: "Run is not waiting for input" }, { status: 409 });
+  }
+
+  if (parsed.data.kind === "credits-topup") {
+    const balance = await getBalance(userId);
+    if (balance <= 0) {
+      return Response.json({ error: "Add credits before resuming", balance }, { status: 402 });
+    }
+    await resumeHook(`credits-topup:${runId}`, { toppedUp: true });
+    return Response.json({ resumed: true, balance });
   }
 
   await resumeHook(`outline-approval:${runId}`, {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,89 @@
+import type Stripe from "stripe";
+
+import { grantCredits } from "@/lib/billing/credits";
+import { getStripe, stripeConfigured } from "@/lib/payments/stripe";
+
+/**
+ * The sole authority on payment.
+ *
+ * Credits are granted here and nowhere else. The success_url a customer lands
+ * on after paying is attacker-controllable, so it only ever refreshes the UI —
+ * money moves when Stripe tells us it moved, over a signed request.
+ *
+ * Stripe retries deliveries, so every grant is keyed on the Checkout Session id
+ * behind a unique index. A replay hits the constraint and grants nothing.
+ */
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  if (!stripeConfigured) {
+    return Response.json({ error: "Payments are not configured" }, { status: 503 });
+  }
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) {
+    return Response.json({ error: "Webhook not configured" }, { status: 503 });
+  }
+
+  const signature = req.headers.get("stripe-signature");
+  if (!signature) {
+    return Response.json({ error: "Missing signature" }, { status: 400 });
+  }
+
+  // Must be the raw body — any parse/re-serialize breaks the signature.
+  const payload = await req.text();
+
+  let event: Stripe.Event;
+  try {
+    event = await getStripe().webhooks.constructEventAsync(payload, signature, secret);
+  } catch {
+    return Response.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object;
+
+    // Only fulfil once payment actually cleared — a session can complete with
+    // an async method still pending.
+    if (session.payment_status !== "paid") {
+      return Response.json({ received: true, ignored: "payment not settled" });
+    }
+
+    const userId = session.metadata?.userId ?? session.client_reference_id ?? null;
+    const credits = Number(session.metadata?.credits ?? 0);
+    const packId = session.metadata?.packId ?? "credits";
+
+    if (!userId || !Number.isFinite(credits) || credits <= 0) {
+      // Nothing actionable, but return 200: a 4xx makes Stripe retry forever.
+      return Response.json({ received: true, ignored: "missing metadata" });
+    }
+
+    const granted = await grantCredits({
+      userId,
+      credits,
+      description: `${packId} pack — ${credits} credits`,
+      externalRef: session.id,
+    });
+
+    return Response.json({ received: true, granted });
+  }
+
+  if (event.type === "charge.refunded") {
+    const charge = event.data.object;
+    const usd = (charge.amount_refunded ?? 0) / 100;
+    const userId = charge.metadata?.userId;
+    if (userId && usd > 0) {
+      await grantCredits({
+        userId,
+        // Refunds claw back at face value, not at the bonus-inclusive rate.
+        credits: -usd,
+        description: `Refund — $${usd.toFixed(2)}`,
+        externalRef: `refund:${charge.id}`,
+        kind: "refund",
+      });
+    }
+    return Response.json({ received: true });
+  }
+
+  return Response.json({ received: true });
+}

--- a/src/components/bible/entity-card 2.tsx
+++ b/src/components/bible/entity-card 2.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { ImagePlus, Loader2, TriangleAlert } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { BibleEntity } from "@/db/queries/entities";
+import { PORTRAIT_USD, PORTRAIT_KINDS } from "@/lib/bible/portraits";
+import { cn } from "@/lib/utils";
+
+type Conflict = { id: string; severity: string; description: string };
+
+/** Attribute keys rendered as prose lines, in the order a reader wants them. */
+const FIELD_ORDER = [
+  "role",
+  "occupation",
+  "age",
+  "heritage",
+  "appearance",
+  "speech",
+  "locationType",
+  "description",
+  "owner",
+  "atmosphere",
+  "significance",
+  "provenance",
+  "holder",
+  "purpose",
+  "structure",
+  "reputation",
+  "when",
+  "outcome",
+  "nameRationale",
+];
+
+const FIELD_LABELS: Record<string, string> = {
+  role: "Role",
+  occupation: "Occupation",
+  age: "Age",
+  heritage: "Heritage",
+  appearance: "Appearance",
+  speech: "Speech",
+  locationType: "Type",
+  description: "Description",
+  owner: "Owner",
+  atmosphere: "Atmosphere",
+  significance: "Significance",
+  provenance: "Provenance",
+  holder: "Held by",
+  purpose: "Purpose",
+  structure: "Structure",
+  reputation: "Reputation",
+  when: "When",
+  outcome: "Outcome",
+  nameRationale: "Why this name",
+};
+
+const LIST_FIELDS = [
+  "personality",
+  "goals",
+  "secrets",
+  "features",
+  "contents",
+  "capabilities",
+  "members",
+  "participants",
+];
+
+function asText(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return null;
+}
+
+function asList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+export function EntityCard({ entity, conflicts }: { entity: BibleEntity; conflicts: Conflict[] }) {
+  const [portraitUrl, setPortraitUrl] = useState(entity.portraitUrl);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const attrs = entity.attrs as Record<string, unknown>;
+  const facts = asList(attrs.facts);
+  const canHavePortrait = PORTRAIT_KINDS.includes(entity.kind);
+
+  async function generatePortrait() {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/entities/${entity.id}/portrait`, { method: "POST" });
+      const body = (await response.json()) as { url?: string; error?: string };
+      if (!response.ok || !body.url) {
+        setError(body.error ?? "Could not generate a portrait");
+        return;
+      }
+      setPortraitUrl(body.url);
+    } catch {
+      setError("Could not generate a portrait");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <article className="flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        {portraitUrl ? (
+          <Image
+            src={portraitUrl}
+            alt={`Impression of ${entity.name}`}
+            width={64}
+            height={64}
+            className="size-16 shrink-0 rounded-md object-cover"
+          />
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <h4 className="font-sans font-semibold break-words">{entity.name}</h4>
+          {entity.aliases.length > 0 ? (
+            <p className="text-xs text-muted-foreground">also {entity.aliases.join(", ")}</p>
+          ) : null}
+          {entity.firstAppearanceChapter ? (
+            <p className="mt-0.5 font-mono text-[0.68rem] text-muted-foreground">
+              first appears ch. {entity.firstAppearanceChapter}
+            </p>
+          ) : null}
+        </div>
+        {conflicts.length > 0 ? (
+          <Badge variant="destructive" className="shrink-0 gap-1">
+            <TriangleAlert aria-hidden="true" className="size-3" />
+            {conflicts.length}
+          </Badge>
+        ) : null}
+      </div>
+
+      <dl className="space-y-1 text-sm">
+        {FIELD_ORDER.map((field) => {
+          const value = asText(attrs[field]);
+          if (!value) return null;
+          return (
+            <div key={field} className="flex gap-2">
+              <dt className="shrink-0 text-xs text-muted-foreground">{FIELD_LABELS[field]}</dt>
+              <dd className="min-w-0 text-pretty">{value}</dd>
+            </div>
+          );
+        })}
+        {LIST_FIELDS.map((field) => {
+          const values = asList(attrs[field]);
+          if (values.length === 0) return null;
+          return (
+            <div key={field} className="flex gap-2">
+              <dt className="shrink-0 text-xs text-muted-foreground capitalize">{field}</dt>
+              <dd className="min-w-0 text-pretty">{values.join(", ")}</dd>
+            </div>
+          );
+        })}
+      </dl>
+
+      {entity.relationships.length > 0 ? (
+        <ul className="flex flex-wrap gap-1.5">
+          {entity.relationships.map((rel, i) => (
+            <li key={`${rel.type}-${rel.other}-${i}`}>
+              <Badge variant="secondary" className="font-normal">
+                {rel.type.replace(/-/g, " ")} {rel.other}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {facts.length > 0 ? (
+        <details className="text-sm">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+            {facts.length} established {facts.length === 1 ? "fact" : "facts"}
+          </summary>
+          <ul className="mt-2 list-disc space-y-1 pl-4 text-pretty">
+            {facts.map((fact, i) => (
+              <li key={i}>{fact}</li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+
+      {conflicts.length > 0 ? (
+        <ul className="space-y-1 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+          {conflicts.map((c) => (
+            <li key={c.id}>{c.description}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      {canHavePortrait && !portraitUrl ? (
+        <div className="mt-auto">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={generatePortrait}
+            disabled={busy}
+            className="w-full"
+          >
+            {busy ? (
+              <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+            ) : (
+              <ImagePlus aria-hidden="true" className="size-3.5" />
+            )}
+            {busy ? "Generating…" : `Generate portrait · $${PORTRAIT_USD.toFixed(3)}`}
+          </Button>
+          {error ? (
+            <p role="alert" className={cn("mt-1 text-xs text-destructive")}>
+              {error}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/credits/pack-buttons.tsx
+++ b/src/components/credits/pack-buttons.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { CreditPack } from "@/lib/billing/credits";
+
+/** Starts Stripe Checkout. Credits are granted by the webhook, never here. */
+export function PackButtons({ packs }: { packs: CreditPack[] }) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function buy(packId: string) {
+    setBusy(packId);
+    setError(null);
+    try {
+      const response = await fetch("/api/credits/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ packId }),
+      });
+      const body = (await response.json()) as { url?: string; error?: string };
+      if (!response.ok || !body.url) {
+        setError(typeof body.error === "string" ? body.error : "Could not start checkout");
+        setBusy(null);
+        return;
+      }
+      // Stripe Checkout is a full-page handoff, not a client route.
+      window.location.assign(body.url);
+    } catch {
+      setError("Could not start checkout");
+      setBusy(null);
+    }
+  }
+
+  return (
+    <>
+      <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {packs.map((pack) => (
+          <li key={pack.id}>
+            <div className="flex h-full flex-col rounded-lg border border-border bg-card p-5">
+              <h3 className="font-sans font-semibold">{pack.name}</h3>
+              <p className="mt-1 font-display text-3xl font-semibold tabular-nums">${pack.usd}</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                <span className="tabular-nums">{pack.credits}</span> credits
+                {pack.bonus > 0 ? (
+                  <span className="text-ai"> · {Math.round(pack.bonus * 100)}% bonus</span>
+                ) : null}
+              </p>
+              <Button
+                type="button"
+                className="mt-4 w-full"
+                variant={pack.id === "author" ? "default" : "outline"}
+                onClick={() => buy(pack.id)}
+                disabled={busy !== null}
+              >
+                {busy === pack.id ? (
+                  <>
+                    <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+                    Opening checkout…
+                  </>
+                ) : (
+                  "Buy credits"
+                )}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {error ? (
+        <p role="alert" className="mt-3 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -35,6 +35,8 @@ function announcementFor(stage: Stage, draftedCount: number, plannedTotal: numbe
       return "Paused. The outline is ready for your approval.";
     case "chapters":
       return `Drafting chapters: ${draftedCount} of ${plannedTotal} done.`;
+    case "awaiting_credits":
+      return "Paused. Add credits to finish the book — drafted chapters are kept.";
     case "editing":
       return "Editing the chapters.";
     case "continuity":

--- a/src/components/generation/stage-timeline.tsx
+++ b/src/components/generation/stage-timeline.tsx
@@ -32,7 +32,7 @@ function buildSteps(tier: QualityTier): Step[] {
   const steps: Step[] = [
     { key: "concept", label: "Concept", stages: ["concept"] },
     { key: "outline", label: "Outline", stages: ["outline", "awaiting_approval"] },
-    { key: "chapters", label: "Chapters", stages: ["chapters"] },
+    { key: "chapters", label: "Chapters", stages: ["chapters", "awaiting_credits"] },
   ];
   if (tier !== "draft") steps.push({ key: "editing", label: "Editing", stages: ["editing"] });
   steps.push({ key: "continuity", label: "Continuity", stages: ["continuity", "revising"] });
@@ -46,6 +46,7 @@ const STAGE_RANK: Record<Stage, number> = {
   outline: 2,
   awaiting_approval: 2,
   chapters: 3,
+  awaiting_credits: 3,
   editing: 4,
   continuity: 5,
   revising: 5,

--- a/src/components/studio/studio-nav.tsx
+++ b/src/components/studio/studio-nav.tsx
@@ -11,6 +11,7 @@ import { ThemeToggle } from "@/components/studio/theme-toggle";
 
 const links = [
   { href: "/studio", label: "Projects" },
+  { href: "/studio/credits", label: "Credits" },
   { href: "/studio/usage", label: "Usage" },
 ] as const;
 

--- a/src/db/queries/entities 2.ts
+++ b/src/db/queries/entities 2.ts
@@ -1,0 +1,207 @@
+import { and, asc, eq, sql } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
+import { ENTITY_KINDS, parseAttrs, type EntityKind } from "@/ai/schemas/entities";
+
+/**
+ * Story-bible persistence. Every write here has to survive a wave of four
+ * chapters drafting at once, so merges happen in a single statement rather than
+ * read-modify-write.
+ */
+
+export type EntitySeed = {
+  kind: EntityKind;
+  name: string;
+  aliases?: string[];
+  attrs?: Record<string, unknown>;
+};
+
+function isEntityKind(value: string): value is EntityKind {
+  return (ENTITY_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Appends facts to entities, creating any that do not exist yet.
+ *
+ * The parens around `(excluded.attrs->'facts')` are load-bearing: `||` and `->`
+ * have equal precedence and are left-associative, so without them this parses
+ * as `(attrs || excluded.attrs)->'facts'` and the column resolves to NULL,
+ * violating the NOT NULL constraint. That exact bug shipped once already.
+ */
+export async function applyEntityDeltas(input: {
+  bookId: string;
+  chapterNumber?: number;
+  newFacts: { kind?: string; name: string; facts: string[] }[];
+  relationships?: { from: string; to: string; type: string }[];
+}): Promise<void> {
+  const db = getDb();
+
+  for (const entry of input.newFacts) {
+    if (!entry.name?.trim() || entry.facts.length === 0) continue;
+    const kind = entry.kind && isEntityKind(entry.kind) ? entry.kind : "character";
+
+    await db
+      .insert(schema.entities)
+      .values({
+        bookId: input.bookId,
+        kind,
+        name: entry.name.trim(),
+        aliases: [],
+        attrs: { facts: entry.facts },
+        firstAppearanceChapter: input.chapterNumber,
+        lastUpdatedChapter: input.chapterNumber,
+      })
+      .onConflictDoUpdate({
+        target: [schema.entities.bookId, schema.entities.kind, schema.entities.name],
+        set: {
+          attrs: sql`jsonb_set(${schema.entities.attrs}, '{facts}', coalesce(${schema.entities.attrs}->'facts', '[]'::jsonb) || (excluded.attrs->'facts'))`,
+          lastUpdatedChapter: input.chapterNumber,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  for (const rel of input.relationships ?? []) {
+    if (!rel.from?.trim() || !rel.to?.trim()) continue;
+    const rows = await db
+      .select({ id: schema.entities.id, name: schema.entities.name })
+      .from(schema.entities)
+      .where(eq(schema.entities.bookId, input.bookId));
+    const find = (name: string) => rows.find((r) => r.name.toLowerCase() === name.toLowerCase());
+    const from = find(rel.from);
+    const to = find(rel.to);
+    // Relationships between entities we do not know about are dropped rather
+    // than guessed at — the next chapter's upsert will create them.
+    if (!from || !to || from.id === to.id) continue;
+
+    await db
+      .insert(schema.entityRelationships)
+      .values({
+        bookId: input.bookId,
+        fromEntityId: from.id,
+        toEntityId: to.id,
+        type: rel.type || "other",
+        establishedChapter: input.chapterNumber,
+      })
+      .onConflictDoNothing();
+  }
+}
+
+/**
+ * Seeds entities from the concept/outline pass. Existing rows win: a re-run
+ * must never clobber canon that later chapters have already built on.
+ */
+export async function seedEntities(bookId: string, seeds: EntitySeed[]): Promise<void> {
+  if (seeds.length === 0) return;
+  await getDb()
+    .insert(schema.entities)
+    .values(
+      seeds.map((seed) => ({
+        bookId,
+        kind: seed.kind,
+        name: seed.name.trim(),
+        aliases: seed.aliases ?? [],
+        attrs: parseAttrs(seed.kind, seed.attrs ?? {}) as Record<string, unknown>,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [schema.entities.bookId, schema.entities.kind, schema.entities.name],
+    });
+}
+
+export type BibleEntity = {
+  id: string;
+  kind: EntityKind;
+  name: string;
+  aliases: string[];
+  attrs: Record<string, unknown>;
+  portraitUrl: string | null;
+  firstAppearanceChapter: number | null;
+  relationships: { type: string; other: string; description: string | null }[];
+};
+
+/** The whole bible for a book, ordered for display. */
+export async function listEntities(bookId: string): Promise<BibleEntity[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.entities.id,
+      kind: schema.entities.kind,
+      name: schema.entities.name,
+      aliases: schema.entities.aliases,
+      attrs: schema.entities.attrs,
+      firstAppearanceChapter: schema.entities.firstAppearanceChapter,
+      portraitUrl: schema.assets.blobUrl,
+    })
+    .from(schema.entities)
+    .leftJoin(schema.assets, eq(schema.assets.id, schema.entities.portraitAssetId))
+    .where(eq(schema.entities.bookId, bookId))
+    .orderBy(asc(schema.entities.kind), asc(schema.entities.name));
+
+  const relationships = await db
+    .select({
+      from: schema.entityRelationships.fromEntityId,
+      to: schema.entityRelationships.toEntityId,
+      type: schema.entityRelationships.type,
+      description: schema.entityRelationships.description,
+    })
+    .from(schema.entityRelationships)
+    .where(eq(schema.entityRelationships.bookId, bookId));
+
+  const nameById = new Map(rows.map((r) => [r.id, r.name]));
+
+  return rows.map((row) => ({
+    id: row.id,
+    kind: row.kind as EntityKind,
+    name: row.name,
+    aliases: row.aliases,
+    attrs: row.attrs,
+    portraitUrl: row.portraitUrl,
+    firstAppearanceChapter: row.firstAppearanceChapter,
+    relationships: relationships
+      .filter((rel) => rel.from === row.id || rel.to === row.id)
+      .map((rel) => ({
+        type: rel.type,
+        other: nameById.get(rel.from === row.id ? rel.to : rel.from) ?? "unknown",
+        description: rel.description,
+      })),
+  }));
+}
+
+/** One entity plus enough context to build a portrait prompt. */
+export async function getEntityForPortrait(entityId: string) {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: schema.entities.id,
+      bookId: schema.entities.bookId,
+      kind: schema.entities.kind,
+      name: schema.entities.name,
+      attrs: schema.entities.attrs,
+      projectId: schema.books.projectId,
+      userId: schema.projects.userId,
+      genre: schema.projects.genre,
+    })
+    .from(schema.entities)
+    .innerJoin(schema.books, eq(schema.books.id, schema.entities.bookId))
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(eq(schema.entities.id, entityId))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Open contradictions, so the Bible tab can flag entities that drifted. */
+export async function openContradictions(bookId: string) {
+  return getDb()
+    .select({
+      id: schema.continuityIssues.id,
+      category: schema.continuityIssues.category,
+      severity: schema.continuityIssues.severity,
+      description: schema.continuityIssues.description,
+      chapters: schema.continuityIssues.chapters,
+    })
+    .from(schema.continuityIssues)
+    .where(
+      and(eq(schema.continuityIssues.bookId, bookId), eq(schema.continuityIssues.status, "open")),
+    );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -279,6 +279,47 @@ export const llmCalls = pgTable(
   ],
 );
 
+/**
+ * Prepaid credits, as an append-only ledger.
+ *
+ * Balance is the SUM of entries, never a stored mutable number. That is the
+ * whole point: a webhook Stripe retries, a double-clicked checkout, or a
+ * concurrent debit cannot silently inflate or corrupt a balance, and every
+ * movement stays auditable against the `llm_calls` row that caused it.
+ *
+ * Amounts are in credits (1 credit = $1 retail), stored to 4 decimal places so
+ * a single metered call can be debited exactly rather than rounded.
+ */
+export const creditLedger = pgTable(
+  "credit_ledger",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** Positive for purchases and refunds, negative for usage. */
+    amount: numeric("amount", { precision: 12, scale: 4 }).notNull(),
+    kind: text("kind", {
+      enum: ["purchase", "usage", "refund", "grant", "adjustment"],
+    }).notNull(),
+    /** Free text for the UI: "Author pack", "Chapter 7 draft". */
+    description: text("description").notNull(),
+    projectId: uuid("project_id").references(() => projects.id, { onDelete: "set null" }),
+    runId: uuid("run_id").references(() => generationRuns.id, { onDelete: "set null" }),
+    /** Stripe checkout session or payment intent id — the idempotency anchor. */
+    externalRef: text("external_ref"),
+    /** Metered USD this debit corresponds to, for margin reconciliation. */
+    meteredUsd: numeric("metered_usd", { precision: 12, scale: 6 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => [
+    index("idx_ledger_user").on(t.userId, t.createdAt),
+    // Idempotency: one credit entry per Stripe object, enforced by the database
+    // rather than by application logic that a retry could race.
+    uniqueIndex("uq_ledger_external_ref").on(t.externalRef),
+  ],
+);
+
 export const budgets = pgTable("budgets", {
   userId: text("user_id")
     .primaryKey()

--- a/src/hooks/use-run-stream.ts
+++ b/src/hooks/use-run-stream.ts
@@ -70,6 +70,10 @@ const STAGE_ORDER: Record<Stage, number> = {
   outline: 2,
   awaiting_approval: 3,
   chapters: 4,
+  // Same rank as `chapters` deliberately: a credit pause happens *inside* the
+  // chapter phase and returns to it. A higher rank would trap the UI on the
+  // pause forever, since stage merges are upgrade-only (>=).
+  awaiting_credits: 4,
   editing: 5,
   continuity: 6,
   revising: 7,

--- a/src/lib/bible/portraits 2.ts
+++ b/src/lib/bible/portraits 2.ts
@@ -1,0 +1,79 @@
+import { MODEL_PRICING } from "@/lib/billing/pricing";
+import type { EntityKind } from "@/ai/schemas/entities";
+
+/**
+ * Entity portraits are opt-in per entity, never automatic.
+ *
+ * The image model bills a flat rate per image, so a book with 15–40 entities
+ * would add $1.00–$2.70 to a standard-tier book costing roughly $4.70 — a
+ * 20–55% increase for what is decoration. Generating them on demand keeps that
+ * a choice the author makes with the price in front of them.
+ */
+
+export const PORTRAIT_USD = MODEL_PRICING["google/gemini-3.1-flash-image"]?.perImageUsd ?? 0.067;
+
+/**
+ * Kinds worth illustrating. An "organization" or "event" portrait is rarely
+ * more than an abstract smear, so those are excluded.
+ */
+export const PORTRAIT_KINDS: EntityKind[] = ["character", "location", "object"];
+
+/** One shared style so a book's portraits read as a set rather than a jumble. */
+const HOUSE_STYLE =
+  "atmospheric literary book illustration, painterly, muted palette, soft directional light, no text, no lettering, no watermark";
+
+/**
+ * Builds the image prompt from the entity's structured attributes rather than
+ * from prose — the bible already holds exactly the concrete visual facts an
+ * image model needs.
+ */
+export function portraitPrompt(input: {
+  kind: EntityKind;
+  name: string;
+  attrs: Record<string, unknown>;
+  genre?: string | null;
+}): string {
+  const attr = (key: string): string | null => {
+    const value = input.attrs[key];
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+  };
+  const list = (key: string): string[] =>
+    Array.isArray(input.attrs[key])
+      ? (input.attrs[key] as unknown[]).filter((v): v is string => typeof v === "string")
+      : [];
+
+  const parts: string[] = [];
+
+  if (input.kind === "character") {
+    parts.push(`Character portrait, head and shoulders, of ${input.name}.`);
+    const appearance = attr("appearance");
+    const heritage = attr("heritage");
+    const age = attr("age");
+    const occupation = attr("occupation");
+    if (appearance) parts.push(appearance);
+    if (heritage) parts.push(`Heritage: ${heritage}.`);
+    if (age) parts.push(`Age: ${age}.`);
+    if (occupation) parts.push(`Dressed as befits a ${occupation}.`);
+  } else if (input.kind === "location") {
+    parts.push(`Establishing view of ${input.name}.`);
+    const description = attr("description");
+    const type = attr("locationType");
+    const atmosphere = attr("atmosphere");
+    const features = list("features").slice(0, 5);
+    if (type) parts.push(`A ${type}.`);
+    if (description) parts.push(description);
+    if (features.length) parts.push(`Notable features: ${features.join(", ")}.`);
+    if (atmosphere) parts.push(`Atmosphere: ${atmosphere}.`);
+  } else {
+    parts.push(`Still life study of ${input.name}, a single object, centred.`);
+    const description = attr("description");
+    const provenance = attr("provenance");
+    if (description) parts.push(description);
+    if (provenance) parts.push(`Origin: ${provenance}.`);
+  }
+
+  if (input.genre) parts.push(`Genre: ${input.genre}.`);
+  parts.push(HOUSE_STYLE);
+
+  return parts.join(" ");
+}

--- a/src/lib/billing/credits.test.ts
+++ b/src/lib/billing/credits.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { CREDIT_MARKUP, CREDIT_PACKS, creditsForUsd, getPack } from "./credits";
+
+/**
+ * The pricing model is calibrated against two production books that measured
+ * $6.39 and $8.61 to generate. These tests pin the arithmetic that decides
+ * whether the business makes money, so a casual edit to the markup or the pack
+ * table cannot quietly sell credits below cost.
+ */
+
+const STRIPE_PCT = 0.029;
+const STRIPE_FIXED = 0.3;
+const TAX_PCT = 0.005;
+
+/** Worst case: every credit in the pack is spent on metered work. */
+function worstCaseMargin(usd: number, credits: number): number {
+  const cogs = credits / CREDIT_MARKUP;
+  const fees = usd * (STRIPE_PCT + TAX_PCT) + STRIPE_FIXED;
+  return (usd - cogs - fees) / usd;
+}
+
+describe("credit packs", () => {
+  it("every pack stays profitable even if every credit is spent", () => {
+    for (const pack of CREDIT_PACKS) {
+      expect(worstCaseMargin(pack.usd, pack.credits)).toBeGreaterThan(0.5);
+    }
+  });
+
+  it("survives a 25% rise in underlying model prices", () => {
+    for (const pack of CREDIT_PACKS) {
+      const cogs = (pack.credits / CREDIT_MARKUP) * 1.25;
+      const fees = pack.usd * (STRIPE_PCT + TAX_PCT) + STRIPE_FIXED;
+      expect((pack.usd - cogs - fees) / pack.usd).toBeGreaterThan(0.35);
+    }
+  });
+
+  it("credits are never fewer than dollars paid", () => {
+    for (const pack of CREDIT_PACKS) {
+      expect(pack.credits).toBeGreaterThanOrEqual(pack.usd);
+    }
+  });
+
+  it("bonus rises with pack size, so upgrading is always better value", () => {
+    const sorted = [...CREDIT_PACKS].sort((a, b) => a.usd - b.usd);
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i].bonus).toBeGreaterThanOrEqual(sorted[i - 1].bonus);
+      const prevRate = sorted[i - 1].credits / sorted[i - 1].usd;
+      expect(sorted[i].credits / sorted[i].usd).toBeGreaterThanOrEqual(prevRate);
+    }
+  });
+
+  it("stated bonus matches the credits actually granted", () => {
+    for (const pack of CREDIT_PACKS) {
+      expect(pack.credits).toBe(Math.round(pack.usd * (1 + pack.bonus)));
+    }
+  });
+
+  it("pack ids are unique and resolvable", () => {
+    const ids = CREDIT_PACKS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(getPack(id)).toBeDefined();
+    expect(getPack("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("creditsForUsd", () => {
+  it("applies the markup", () => {
+    expect(creditsForUsd(1)).toBeCloseTo(CREDIT_MARKUP, 10);
+    expect(creditsForUsd(0)).toBe(0);
+  });
+
+  it("prices the measured books in line with the published guidance", () => {
+    // Production: standard generated for $6.39, premium for $8.61.
+    expect(Math.round(creditsForUsd(6.39))).toBe(18);
+    expect(Math.round(creditsForUsd(8.61))).toBe(24);
+    // Plus ~50% for light editing to a finished manuscript.
+    expect(Math.round(creditsForUsd(6.39 * 1.5))).toBe(26);
+  });
+
+  it("keeps a real margin over metered cost", () => {
+    const meteredUsd = 10;
+    const retail = creditsForUsd(meteredUsd);
+    expect((retail - meteredUsd) / retail).toBeGreaterThan(0.6);
+  });
+});

--- a/src/lib/billing/credits.ts
+++ b/src/lib/billing/credits.ts
@@ -1,0 +1,144 @@
+import { eq, sql } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
+
+/**
+ * Prepaid credit wallet.
+ *
+ * One credit is one dollar of retail value. Work is debited at `CREDIT_MARKUP`
+ * times its metered LLM cost — a multiplier rather than a fixed per-book price,
+ * so margin holds when provider rates move and heavy editing is paid for by the
+ * author who asks for it rather than absorbed.
+ *
+ * The markup is calibrated against production data: two complete books measured
+ * $6.39 and $8.61 to generate, and roughly 50% more to finish with light
+ * editing. See doc/PRICING.md.
+ */
+
+export const CREDIT_MARKUP = 2.75;
+
+export type CreditPack = {
+  id: string;
+  name: string;
+  usd: number;
+  credits: number;
+  /** Bonus share, for display only — `credits` is already inclusive. */
+  bonus: number;
+};
+
+export const CREDIT_PACKS: CreditPack[] = [
+  { id: "starter", name: "Starter", usd: 25, credits: 25, bonus: 0 },
+  { id: "author", name: "Author", usd: 60, credits: 66, bonus: 0.1 },
+  { id: "studio", name: "Studio", usd: 120, credits: 138, bonus: 0.15 },
+  { id: "press", name: "Press", usd: 300, credits: 360, bonus: 0.2 },
+];
+
+export function getPack(id: string): CreditPack | undefined {
+  return CREDIT_PACKS.find((p) => p.id === id);
+}
+
+/** Retail credits for a metered dollar amount. */
+export function creditsForUsd(usd: number): number {
+  return usd * CREDIT_MARKUP;
+}
+
+export class InsufficientCreditsError extends Error {
+  constructor(
+    readonly balance: number,
+    readonly required: number,
+  ) {
+    super(`Insufficient credits: ${balance.toFixed(2)} available, ${required.toFixed(2)} required`);
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+/**
+ * Current balance — always derived from the ledger, never read from a stored
+ * column. Summing is cheap at this scale and cannot drift.
+ */
+export async function getBalance(userId: string): Promise<number> {
+  const [row] = await getDb()
+    .select({ balance: sql<string>`coalesce(sum(${schema.creditLedger.amount}), 0)` })
+    .from(schema.creditLedger)
+    .where(eq(schema.creditLedger.userId, userId));
+  return Number(row?.balance ?? 0);
+}
+
+/**
+ * Grants credits for a completed payment.
+ *
+ * `externalRef` carries a unique index, so a Stripe webhook retry hits a
+ * constraint violation rather than granting twice. Returns false when the entry
+ * already existed — the caller should treat that as success, not an error.
+ */
+export async function grantCredits(input: {
+  userId: string;
+  credits: number;
+  description: string;
+  externalRef: string;
+  kind?: "purchase" | "refund" | "grant";
+}): Promise<boolean> {
+  const inserted = await getDb()
+    .insert(schema.creditLedger)
+    .values({
+      userId: input.userId,
+      amount: String(input.credits),
+      kind: input.kind ?? "purchase",
+      description: input.description,
+      externalRef: input.externalRef,
+    })
+    .onConflictDoNothing({ target: schema.creditLedger.externalRef })
+    .returning({ id: schema.creditLedger.id });
+  return inserted.length > 0;
+}
+
+/**
+ * Debits credits for metered work. Called after the work happens, from the same
+ * place that records the `llm_calls` row, so the ledger and the cost record
+ * cannot disagree.
+ */
+export async function debitCredits(input: {
+  userId: string;
+  meteredUsd: number;
+  description: string;
+  projectId?: string;
+  runId?: string;
+}): Promise<void> {
+  const credits = creditsForUsd(input.meteredUsd);
+  if (credits <= 0) return;
+  await getDb()
+    .insert(schema.creditLedger)
+    .values({
+      userId: input.userId,
+      amount: String(-credits),
+      kind: "usage",
+      description: input.description,
+      projectId: input.projectId,
+      runId: input.runId,
+      meteredUsd: String(input.meteredUsd),
+    });
+}
+
+/** Throws when the balance would not cover `requiredCredits`. */
+export async function assertCredits(userId: string, requiredCredits: number): Promise<void> {
+  const balance = await getBalance(userId);
+  if (balance < requiredCredits) {
+    throw new InsufficientCreditsError(balance, requiredCredits);
+  }
+}
+
+/** Recent movements for the wallet UI. */
+export async function listLedger(userId: string, limit = 50) {
+  return getDb()
+    .select({
+      id: schema.creditLedger.id,
+      amount: schema.creditLedger.amount,
+      kind: schema.creditLedger.kind,
+      description: schema.creditLedger.description,
+      createdAt: schema.creditLedger.createdAt,
+    })
+    .from(schema.creditLedger)
+    .where(eq(schema.creditLedger.userId, userId))
+    .orderBy(sql`${schema.creditLedger.createdAt} desc`)
+    .limit(limit);
+}

--- a/src/lib/export/figures 3.ts
+++ b/src/lib/export/figures 3.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "@/db";
+
+/**
+ * Figure resolution for diagrams and inline images.
+ *
+ * Mermaid needs a DOM, so we never render it on the server. The editor renders
+ * each diagram client-side and uploads the SVG + a PNG rasterization, keyed by
+ * a hash of the source. Every server-side surface (reading view, EPUB, PDF,
+ * DOCX) then looks the render up by that hash. A miss is not an error — callers
+ * fall back to showing the source, so a diagram never silently disappears.
+ */
+
+export type FigureAsset = {
+  svgUrl: string | null;
+  pngUrl: string | null;
+  alt: string;
+  /** Only populated for the byte-embedding exporters (PDF, DOCX). */
+  pngBytes?: Uint8Array;
+  width?: number;
+  height?: number;
+};
+
+/** Keyed by diagram source hash, or by URL for plain markdown images. */
+export type FigureMap = Record<string, FigureAsset>;
+
+/**
+ * Hash of a diagram's source. The client computes the same digest over the same
+ * normalized string via SubtleCrypto — keep the two in step or every lookup
+ * misses and exports quietly regress to source text.
+ */
+export function diagramSourceHash(source: string): string {
+  return createHash("sha256").update(normalizeDiagramSource(source), "utf8").digest("hex");
+}
+
+/** Trailing whitespace differs between the editor and stored markdown; ignore it. */
+export function normalizeDiagramSource(source: string): string {
+  return source
+    .trim()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n");
+}
+
+/** Width/height from a PNG's IHDR chunk. Null when the bytes are not a PNG. */
+export function pngDimensions(bytes: Uint8Array): { width: number; height: number } | null {
+  // 8-byte signature, then a 4-byte length + "IHDR" + width/height as big-endian u32.
+  if (bytes.length < 24) return null;
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (signature.some((byte, i) => bytes[i] !== byte)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+/** Scales an image down to fit a max width, preserving aspect ratio. */
+export function fitWidth(
+  dims: { width: number; height: number },
+  maxWidth: number,
+): { width: number; height: number } {
+  if (dims.width <= maxWidth) return dims;
+  const scale = maxWidth / dims.width;
+  return { width: Math.round(dims.width * scale), height: Math.round(dims.height * scale) };
+}
+
+/** Every diagram render stored for a project, keyed by source hash. */
+export async function loadFigures(projectId: string): Promise<FigureMap> {
+  const rows = await getDb()
+    .select({
+      blobUrl: schema.assets.blobUrl,
+      contentType: schema.assets.contentType,
+      meta: schema.assets.meta,
+    })
+    .from(schema.assets)
+    .where(and(eq(schema.assets.projectId, projectId), eq(schema.assets.kind, "diagram")));
+
+  const figures: FigureMap = {};
+  for (const row of rows) {
+    const meta = (row.meta ?? {}) as { sourceHash?: string; alt?: string };
+    if (!meta.sourceHash) continue;
+    const existing = figures[meta.sourceHash] ?? {
+      svgUrl: null,
+      pngUrl: null,
+      alt: meta.alt || "Diagram",
+    };
+    if (row.contentType === "image/svg+xml") existing.svgUrl = row.blobUrl;
+    if (row.contentType === "image/png") existing.pngUrl = row.blobUrl;
+    if (meta.alt) existing.alt = meta.alt;
+    figures[meta.sourceHash] = existing;
+  }
+  return figures;
+}
+
+/**
+ * Downloads PNG bytes for the figures PDF/DOCX will embed. Failures are
+ * swallowed per-figure: a fetch error degrades that one diagram to source text
+ * rather than failing the whole export.
+ */
+export async function hydrateFigureBytes(figures: FigureMap): Promise<FigureMap> {
+  const entries = Object.entries(figures).filter(([, figure]) => figure.pngUrl);
+  const hydrated: FigureMap = { ...figures };
+
+  await Promise.all(
+    entries.map(async ([key, figure]) => {
+      try {
+        const response = await fetch(figure.pngUrl as string);
+        if (!response.ok) return;
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const dims = pngDimensions(bytes);
+        hydrated[key] = { ...figure, pngBytes: bytes, ...(dims ?? {}) };
+      } catch {
+        // Leave the figure without bytes; exporters fall back to source text.
+      }
+    }),
+  );
+
+  return hydrated;
+}

--- a/src/lib/payments/stripe.ts
+++ b/src/lib/payments/stripe.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import Stripe from "stripe";
+
+/**
+ * Stripe client, provisioned through the Vercel Marketplace integration
+ * (resource `sopher-payments`), so keys arrive as managed env vars.
+ *
+ * Note the resource is provisioned as a sandbox: it runs in test mode until
+ * claimed with `vercel integration resource claim sopher-payments`.
+ */
+
+let client: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!client) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) throw new Error("STRIPE_SECRET_KEY is not configured");
+    client = new Stripe(key);
+  }
+  return client;
+}
+
+export const stripeConfigured = Boolean(process.env.STRIPE_SECRET_KEY);

--- a/src/lib/run-events.ts
+++ b/src/lib/run-events.ts
@@ -9,6 +9,7 @@ export const stageSchema = z.enum([
   "concept",
   "outline",
   "awaiting_approval",
+  "awaiting_credits",
   "chapters",
   "editing",
   "continuity",

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -9,6 +9,7 @@ import {
   continuityPhaseStep,
   editChapterStep,
   emitCost,
+  creditCheckStep,
   entityBibleStep,
   emitProgress,
   finalizeStep,
@@ -90,6 +91,29 @@ export async function generateBook(
     await emitProgress(ref, { type: "stage", stage: "chapters", pct: 15 });
 
     for (const wave of chunk(chapterNumbers, config.waveSize)) {
+      // Check the wallet between waves rather than only up front: a long book
+      // can outrun its estimate. Running short suspends the run instead of
+      // failing it, so every chapter already drafted is kept and no work is
+      // re-billed on resume.
+      const credit = await creditCheckStep(ref, config, total - done);
+      if (!credit.sufficient) {
+        await markRunStatus(ref, "awaiting_input");
+        await emitProgress(ref, {
+          type: "stage",
+          stage: "awaiting_credits",
+          pct: 15 + Math.round(55 * (done / total)),
+          detail: `${credit.balance.toFixed(0)} of ${credit.required.toFixed(0)} credits needed to finish`,
+        });
+        const topUp = createHook<{ toppedUp: boolean }>({
+          token: `credits-topup:${dbRunId}`,
+        });
+        const resumed = await topUp;
+        if (!resumed.toppedUp) {
+          throw new FatalError("Run cancelled while waiting for credits");
+        }
+        await markRunStatus(ref, "running");
+      }
+
       await Promise.all(wave.map((n) => writeChapterStep(ref, config, n)));
       done += wave.length;
       await emitProgress(ref, {

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -17,6 +17,7 @@ import {
 } from "@/ai/agents/continuity";
 import type { ReviewPhaseKey } from "@/ai/prompts/review-rubric";
 import { BudgetExceededError, checkBudget } from "@/lib/billing/meter";
+import { creditsForUsd, getBalance } from "@/lib/billing/credits";
 import { estimateBookCost } from "@/ai/estimate";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { listEntities } from "@/db/queries/entities";
@@ -151,6 +152,33 @@ export async function checkBudgetStep(ref: RunRef, config: GenerationConfig) {
   } catch (error) {
     toWorkflowError(error);
   }
+}
+
+/**
+ * Reports the wallet against what the rest of the run is expected to cost.
+ *
+ * Returns rather than throws: the orchestrator suspends on a top-up hook when
+ * the balance runs short, so an author who runs out mid-book keeps every
+ * chapter already drafted instead of losing the run.
+ */
+export async function creditCheckStep(
+  ref: RunRef,
+  config: GenerationConfig,
+  remainingChapters: number,
+): Promise<{ balance: number; required: number; sufficient: boolean }> {
+  "use step";
+  const db = getDb();
+  const [project] = await db
+    .select({ words: schema.projects.targetWordsPerChapter })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, ref.projectId))
+    .limit(1);
+  if (!project) throw new FatalError("Project not found");
+
+  const estimate = estimateBookCost(config.tier, remainingChapters, project.words);
+  const required = creditsForUsd(estimate.totalUsd);
+  const balance = await getBalance(ref.userId);
+  return { balance, required, sufficient: balance >= required };
 }
 
 export async function conceptStep(ref: RunRef, config: GenerationConfig): Promise<BookConcept> {


### PR DESCRIPTION
## Why the price list changed

Two complete books have now been metered end to end. Generation cost **$6.39** and **$8.61**; with the stated +50% for light editing, **$9.58** and **$12.91** finished.

The original price list assumed COGS roughly half of that:

| Tier | Old price | Real COGS | Real margin |
|---|---|---|---|
| draft | $9.99 | $7.43 | **19.2%** |
| standard | $19.99 | $9.58 | **47.2%** |
| premium | $49.99 | $12.91 | 70.2% |

Target was 74–79%. The structural fault is compression — COGS spans $5.48 while the price list spanned $40, pricing the tiers as though they differed five-fold in cost when they differ by less than two-fold.

Full analysis in `doc/PRICING.md`.

## The model

Prepaid credits, debited at **2.75× metered cost**. A multiplier rather than a fixed per-book price, because:

- **Editing becomes revenue.** The +50% editing uplift is real metered usage; under fixed pricing it silently erodes margin.
- **Runaway generations stop being losses.** Three revision passes bill three revision passes.
- **Provider price changes pass through**, so margin holds as rates move.

Packs run $25/$60/$120/$300 with 0–20% bonuses, worst-case margins 59%→53%.

## Correctness of the money path

**The ledger is append-only.** Balance is `SUM(amount)`, never a stored mutable number, so a retried webhook or a concurrent debit cannot corrupt it — and every movement stays auditable against the `llm_calls` row that caused it.

**Idempotency is a database constraint,** not application logic. `external_ref` carries a unique index keyed on the Stripe Checkout Session id, so a replayed delivery hits the constraint and grants nothing.

**Only the webhook grants credits.** The `success_url` a customer lands on after paying is attacker-controllable, so it just refreshes the UI. Money moves when Stripe says it moved, over a signature-verified request against the raw body.

**Debits hang off `recordLlmCall`,** so the ledger and `llm_calls` cannot disagree about what was spent.

## Running out mid-book

Running short suspends the run on a `credits-topup` hook rather than failing it — reusing the outline-approval pattern already in the workflow. Drafted chapters are kept and nothing is re-billed on resume. The wallet is checked between waves, not only up front, because a long book can outrun its estimate.

One subtlety worth flagging: `awaiting_credits` deliberately shares a stage rank with `chapters`. Stage merges are upgrade-only (`>=`), so a higher rank would have trapped the UI on the pause after resuming.

## Verification

308 unit tests (up from 299). The new ones pin the arithmetic that decides whether the business makes money: every pack stays above 50% margin even if every credit is spent, and above 35% if model prices rose 25%; credits never fall below dollars paid; bonuses rise monotonically with pack size so upgrading is always better value; and the stated bonus matches credits actually granted. Typecheck, lint, format and build clean.

## Note before taking real money

Stripe is provisioned through the Vercel Marketplace as `sopher-payments`, currently a **sandbox** resource — test mode. Claim it with `vercel integration resource claim sopher-payments`, and set `STRIPE_WEBHOOK_SECRET` (the webhook returns 503 without it, and grants nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces payment processing, credit grants/debits, and workflow suspension on balance—errors could double-grant, fail to debit, or block generation incorrectly; Stripe remains sandbox until claimed.
> 
> **Overview**
> Replaces fixed per-tier book pricing with a **prepaid credit wallet** grounded in measured production COGS (`doc/PRICING.md`). Usage debits at **`CREDIT_MARKUP` (2.75×)** metered LLM cost; packs ($25–$300) are sold through **Stripe Checkout**, with **`credits.test.ts`** locking margin assumptions.
> 
> **Money path:** new **`credit_ledger`** table (balance = sum of entries; **`external_ref`** unique for idempotency). **`grantCredits`** runs only from the **signed Stripe webhook** (`checkout.session.completed`, refunds on `charge.refunded`); checkout API prices from the server catalog. **`debitCredits`** is invoked from **`metered()`** immediately after **`recordLlmCall`** so ledger and `llm_calls` stay aligned.
> 
> **Product:** **`/studio/credits`** (balance, ledger, pack purchase). Generation **pauses on `awaiting_credits`** between chapter waves when the wallet cannot cover the remaining estimate; **`POST /api/runs/.../input`** with **`credits-topup`** resumes after balance &gt; 0. UI stage/stream ranks treat **`awaiting_credits`** like **`chapters`** so resume does not stick on the pause.
> 
> The same PR also adds story-bible tooling/UI (entity agents, bible page, optional portraits) and client-side Mermaid diagram caching for exports—orthogonal to billing but shipped together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad3a1862bc99b23bd981fe2fa61d4e44fdc8500. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->