### PR TITLE
Address review-bot findings: entity dedup, credit recheck loops, Stripe refunds, FK cascades

### DIFF
--- a/drizzle/0006_conscious_sabretooth.sql
+++ b/drizzle/0006_conscious_sabretooth.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "content_tool_runs" DROP CONSTRAINT "content_tool_runs_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "generation_runs" DROP CONSTRAINT "generation_runs_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "llm_calls" DROP CONSTRAINT "llm_calls_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "content_tool_runs" ADD CONSTRAINT "content_tool_runs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "generation_runs" ADD CONSTRAINT "generation_runs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "llm_calls" ADD CONSTRAINT "llm_calls_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2033 @@
+{
+  "id": "226a97a4-e1c4-40bd-b825-ea492ec573b7",
+  "prevId": "916df5c7-27b9-43f2-85fd-29b08990d211",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metered_usd": {
+          "name": "metered_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ledger_user": {
+          "name": "idx_ledger_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_ledger_external_ref": {
+          "name": "uq_ledger_external_ref",
+          "columns": [
+            {
+              "expression": "external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_user_id_users_id_fk": {
+          "name": "credit_ledger_user_id_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_project_id_projects_id_fk": {
+          "name": "credit_ledger_project_id_projects_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_run_id_generation_runs_id_fk": {
+          "name": "credit_ledger_run_id_generation_runs_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "portrait_asset_id": {
+          "name": "portrait_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_appearance_chapter": {
+          "name": "first_appearance_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_chapter": {
+          "name": "last_updated_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_name": {
+          "name": "uq_entity_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_book": {
+          "name": "idx_entities_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_book_id_books_id_fk": {
+          "name": "entities_book_id_books_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationships": {
+      "name": "entity_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_chapter": {
+          "name": "established_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_relationship": {
+          "name": "uq_entity_relationship",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationships_book": {
+          "name": "idx_relationships_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_relationships_book_id_books_id_fk": {
+          "name": "entity_relationships_book_id_books_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_from_entity_id_entities_id_fk": {
+          "name": "entity_relationships_from_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_to_entity_id_entities_id_fk": {
+          "name": "entity_relationships_to_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785299689382,
       "tag": "0005_pale_starbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785301063778,
+      "tag": "0006_conscious_sabretooth",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/tools/entities.test.ts
+++ b/src/ai/tools/entities.test.ts
@@ -108,3 +108,20 @@ describe("KIND_TO_ISSUE_CATEGORY", () => {
     }
   });
 });
+
+describe("review-bot regression: partial updates must not wipe lists", () => {
+  // parseAttrs fills omitted list fields with [] — the upsert layer must strip
+  // those before merging, or a facts-only update erases stored personality.
+  it("parseAttrs defaults are distinguishable from provided values", () => {
+    const onlyFacts = parseAttrs("character", { facts: ["new fact"] }) as Record<string, unknown>;
+    expect(onlyFacts.personality).toEqual([]);
+    // The upsert filter drops empty non-facts arrays; assert the shape it keys on.
+    const kept = Object.entries(onlyFacts).filter(([key, value]) => {
+      if (value === undefined || value === null) return false;
+      if (Array.isArray(value) && value.length === 0 && key !== "facts") return false;
+      if (typeof value === "string" && !value.trim()) return false;
+      return true;
+    });
+    expect(kept.map(([k]) => k)).toEqual(["facts"]);
+  });
+});

--- a/src/ai/tools/entities.ts
+++ b/src/ai/tools/entities.ts
@@ -168,17 +168,25 @@ export function entityUpsert(ctx: EntityToolCtx) {
       const db = getDb();
       const parsed = parseAttrs(kind, attrs) as Record<string, unknown>;
 
+      // Case-insensitive resolution, then reuse the stored casing: get/search/
+      // relate all match case-insensitively, so "biscuit" must update Biscuit
+      // rather than minting a duplicate row the unique index cannot catch.
       const [existing] = await db
-        .select({ id: schema.entities.id, attrs: schema.entities.attrs })
+        .select({
+          id: schema.entities.id,
+          name: schema.entities.name,
+          attrs: schema.entities.attrs,
+        })
         .from(schema.entities)
         .where(
           and(
             eq(schema.entities.bookId, ctx.bookId),
             eq(schema.entities.kind, kind),
-            eq(schema.entities.name, name),
+            sql`lower(${schema.entities.name}) = lower(${name})`,
           ),
         )
         .limit(1);
+      const canonicalName = existing?.name ?? name;
 
       const conflicts = existing ? findConflicts(kind, existing.attrs, parsed) : [];
       if (conflicts.length > 0) {
@@ -188,16 +196,25 @@ export function entityUpsert(ctx: EntityToolCtx) {
             chapters: ctx.chapterNumber ? [ctx.chapterNumber] : [],
             category: KIND_TO_ISSUE_CATEGORY[kind],
             severity: "major" as const,
-            description: `${kind} "${name}": ${c.field} was established as "${c.from}" but chapter ${ctx.chapterNumber ?? "?"} says "${c.to}".`,
+            description: `${kind} "${canonicalName}": ${c.field} was established as "${c.from}" but chapter ${ctx.chapterNumber ?? "?"} says "${c.to}".`,
             suggestedFix: `Keep the established "${c.from}" unless the change is deliberate and explained in the prose.`,
           })),
         );
       }
 
       // Guarded scalars stay as first established; everything else may refine.
+      // Also drop empty values: parseAttrs fills omitted list fields with []
+      // defaults, and merging those would wipe stored personality/contents/etc
+      // on any partial update.
       const conflicted = new Set(conflicts.map((c) => c.field));
       const safeAttrs = Object.fromEntries(
-        Object.entries(parsed).filter(([key]) => !conflicted.has(key)),
+        Object.entries(parsed).filter(([key, value]) => {
+          if (conflicted.has(key)) return false;
+          if (value === undefined || value === null) return false;
+          if (Array.isArray(value) && value.length === 0 && key !== "facts") return false;
+          if (typeof value === "string" && !value.trim()) return false;
+          return true;
+        }),
       );
       const { facts: incomingFacts = [], ...scalars } = safeAttrs as {
         facts?: string[];
@@ -213,7 +230,7 @@ export function entityUpsert(ctx: EntityToolCtx) {
         .values({
           bookId: ctx.bookId,
           kind,
-          name,
+          name: canonicalName,
           aliases,
           attrs: { ...scalars, facts: incomingFacts },
           firstAppearanceChapter: ctx.chapterNumber,
@@ -239,7 +256,7 @@ export function entityUpsert(ctx: EntityToolCtx) {
       return {
         recorded: true,
         kind,
-        name,
+        name: canonicalName,
         conflicts: conflicts.map((c) => `${c.field}: "${c.from}" vs "${c.to}"`),
       };
     },

--- a/src/app/api/chapters/[chapterId]/edits/route.ts
+++ b/src/app/api/chapters/[chapterId]/edits/route.ts
@@ -10,7 +10,7 @@ import { selectionEditSchema } from "@/ai/schemas";
 import { getDb, schema } from "@/db";
 import { getChapterById, getChapterOwnership } from "@/db/queries/books";
 import { requireUser, UnauthorizedError } from "@/lib/auth";
-import { InsufficientCreditsError } from "@/lib/billing/credits";
+import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { contextWindow } from "@/lib/editor/anchors";
 import { toSuggestionDTO } from "@/lib/editor/types";
 
@@ -106,6 +106,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ chapterId: str
 
   let output: z.infer<typeof selectionEditSchema>;
   try {
+    // Pre-gate: a selection edit meters ~$0.01-0.05; refuse before the call
+    // rather than letting metered() spend into the floor.
+    await assertCreditsForUsd(userId, 0.05);
     const result = await metered(
       meter,
       { role: "editor", operation: "editor.selection", model },

--- a/src/app/api/chapters/[chapterId]/review/route.ts
+++ b/src/app/api/chapters/[chapterId]/review/route.ts
@@ -6,7 +6,7 @@ import { type QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
 import { getChapterById, getChapterOwnership } from "@/db/queries/books";
 import { requireUser, UnauthorizedError } from "@/lib/auth";
-import { InsufficientCreditsError } from "@/lib/billing/credits";
+import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { resolveAnchor } from "@/lib/editor/anchors";
 import { toSuggestionDTO } from "@/lib/editor/types";
 
@@ -62,6 +62,8 @@ export async function POST(req: Request, ctx: { params: Promise<{ chapterId: str
   const meter = { userId, projectId: ownership.projectId };
   let reviewed;
   try {
+    // Pre-gate before the metered call; a full-chapter review runs ~$0.05.
+    await assertCreditsForUsd(userId, 0.1);
     reviewed = await reviewChapter({
       meter,
       tools: {

--- a/src/app/api/credits/checkout/route.ts
+++ b/src/app/api/credits/checkout/route.ts
@@ -65,6 +65,12 @@ export async function POST(req: Request) {
     // Reconciled by the webhook; also lets us show the right pack on return.
     client_reference_id: userId,
     metadata: { userId, packId: pack.id, credits: String(pack.credits) },
+    // Charges only inherit metadata from the payment intent, and the refund
+    // webhook resolves the user from the charge — without this, refunds have
+    // no idea whose credits to claw back.
+    payment_intent_data: {
+      metadata: { userId, packId: pack.id, credits: String(pack.credits) },
+    },
     line_items: [
       {
         quantity: 1,

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -70,17 +70,24 @@ export async function POST(req: Request) {
 
   if (event.type === "charge.refunded") {
     const charge = event.data.object;
-    const usd = (charge.amount_refunded ?? 0) / 100;
     const userId = charge.metadata?.userId;
-    if (userId && usd > 0) {
-      await grantCredits({
-        userId,
-        // Refunds claw back at face value, not at the bonus-inclusive rate.
-        credits: -usd,
-        description: `Refund — $${usd.toFixed(2)}`,
-        externalRef: `refund:${charge.id}`,
-        kind: "refund",
-      });
+    // `amount_refunded` is CUMULATIVE across partial refunds, so each event is
+    // recorded per refund object — its own id, its own amount — and the unique
+    // external_ref index makes redelivery of the same refund a no-op.
+    const refunds = charge.refunds?.data ?? [];
+    if (userId) {
+      for (const refund of refunds) {
+        const usd = (refund.amount ?? 0) / 100;
+        if (usd <= 0) continue;
+        await grantCredits({
+          userId,
+          // Refunds claw back at face value, not at the bonus-inclusive rate.
+          credits: -usd,
+          description: `Refund — $${usd.toFixed(2)}`,
+          externalRef: `refund:${refund.id}`,
+          kind: "refund",
+        });
+      }
     }
     return Response.json({ received: true });
   }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -74,7 +74,11 @@ export async function POST(req: Request) {
     // `amount_refunded` is CUMULATIVE across partial refunds, so each event is
     // recorded per refund object — its own id, its own amount — and the unique
     // external_ref index makes redelivery of the same refund a no-op.
-    const refunds = charge.refunds?.data ?? [];
+    // Webhook payloads do not expand the refunds list on current API versions,
+    // so fetch it rather than trusting the (usually absent) inline data.
+    const refunds =
+      charge.refunds?.data ??
+      (await getStripe().refunds.list({ charge: charge.id, limit: 100 })).data;
     if (userId) {
       for (const refund of refunds) {
         const usd = (refund.amount ?? 0) / 100;

--- a/src/components/studio/studio-nav.tsx
+++ b/src/components/studio/studio-nav.tsx
@@ -16,6 +16,7 @@ const links = [
   { href: "/studio", label: "Projects" },
   { href: "/studio/credits", label: "Credits" },
   { href: "/studio/usage", label: "Usage" },
+  { href: "/studio/settings", label: "Settings" },
 ] as const;
 
 /**

--- a/src/db/queries/entities.ts
+++ b/src/db/queries/entities.ts
@@ -64,10 +64,21 @@ export async function applyEntityDeltas(input: {
   for (const rel of input.relationships ?? []) {
     if (!rel.from?.trim() || !rel.to?.trim()) continue;
     const rows = await db
-      .select({ id: schema.entities.id, name: schema.entities.name })
+      .select({ id: schema.entities.id, name: schema.entities.name, kind: schema.entities.kind })
       .from(schema.entities)
       .where(eq(schema.entities.bookId, input.bookId));
-    const find = (name: string) => rows.find((r) => r.name.toLowerCase() === name.toLowerCase());
+    // Prefer an exact-case match; among case-insensitive matches prefer a
+    // character (family ties are the common case). Ambiguity across kinds with
+    // no better signal drops the relationship rather than guessing wrong.
+    const find = (name: string) => {
+      const matches = rows.filter((r) => r.name.toLowerCase() === name.toLowerCase());
+      if (matches.length <= 1) return matches[0];
+      return (
+        matches.find((r) => r.name === name) ??
+        matches.find((r) => r.kind === "character") ??
+        undefined
+      );
+    };
     const from = find(rel.from);
     const to = find(rel.to);
     // Relationships between entities we do not know about are dropped rather

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -208,7 +208,7 @@ export const generationRuns = pgTable(
       .references(() => projects.id, { onDelete: "cascade" }),
     userId: text("user_id")
       .notNull()
-      .references(() => users.id),
+      .references(() => users.id, { onDelete: "cascade" }),
     workflowRunId: text("workflow_run_id"),
     kind: text("kind", {
       enum: ["full_book", "chapter", "edit_pass", "continuity", "export"],
@@ -257,7 +257,8 @@ export const llmCalls = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     userId: text("user_id")
       .notNull()
-      .references(() => users.id),
+      // Cascade so Clerk account deletion can remove the user row cleanly.
+      .references(() => users.id, { onDelete: "cascade" }),
     projectId: uuid("project_id").references(() => projects.id, { onDelete: "set null" }),
     runId: uuid("run_id").references(() => generationRuns.id, { onDelete: "set null" }),
     agentRole: text("agent_role").notNull(),
@@ -383,7 +384,8 @@ export const contentToolRuns = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     userId: text("user_id")
       .notNull()
-      .references(() => users.id),
+      // Cascade so Clerk account deletion can remove the user row cleanly.
+      .references(() => users.id, { onDelete: "cascade" }),
     projectId: uuid("project_id")
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,6 +20,15 @@ async function devFallbackUser(): Promise<{ userId: string }> {
     .insert(schema.users)
     .values({ id: DEV_USER_ID, email: "dev@sopher.ai", name: "Studio Guest" })
     .onConflictDoNothing();
+  // Same welcome grant real users get, so local dev exercises the same
+  // credit-gated paths instead of instantly suspending on a zero balance.
+  await grantCredits({
+    userId: DEV_USER_ID,
+    credits: SIGNUP_GRANT_CREDITS,
+    description: "Welcome credits",
+    externalRef: `signup:${DEV_USER_ID}`,
+    kind: "grant",
+  });
   return { userId: DEV_USER_ID };
 }
 

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -50,7 +50,9 @@ export async function generateBook(
     // pause at a natural seam, and zero-balance runs must burn nothing.
     // Loop, not if: a resume only proves the user clicked the button, so the
     // balance is re-checked until it actually covers the opening stretch.
-    let preflight = await creditCheckStep(ref, config, config.waveSize);
+    let preflight = await creditCheckStep(ref, config, config.waveSize, {
+      includeBookOverhead: true,
+    });
     while (!preflight.sufficient) {
       await markRunStatus(ref, "awaiting_input");
       await emitProgress(ref, {
@@ -62,7 +64,9 @@ export async function generateBook(
       const go = await topUpEvents.next();
       if (!go.value?.toppedUp) throw new FatalError("Run cancelled while waiting for credits");
       await markRunStatus(ref, "running");
-      preflight = await creditCheckStep(ref, config, config.waveSize);
+      preflight = await creditCheckStep(ref, config, config.waveSize, {
+        includeBookOverhead: true,
+      });
     }
 
     await emitProgress(ref, { type: "stage", stage: "concept", pct: 2 });

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -35,6 +35,12 @@ export async function generateBook(
   "use workflow";
   const ref = { dbRunId, projectId, userId };
 
+  // One top-up hook for the entire run: tokens belong to a single active hook,
+  // and both the pre-flight and the per-wave checks may need to wait on it —
+  // possibly more than once, since resuming only proves a button was clicked.
+  const topUps = createHook<{ toppedUp: boolean }>({ token: `credits-topup:${dbRunId}` });
+  const topUpEvents = topUps[Symbol.asyncIterator]();
+
   try {
     await markRunStatus(ref, "running");
 
@@ -42,8 +48,10 @@ export async function generateBook(
     // opening stretch (concept/outline/bible + the first wave). Deliberately
     // not the whole book — the welcome grant is sized to let a book begin and
     // pause at a natural seam, and zero-balance runs must burn nothing.
-    const preflight = await creditCheckStep(ref, config, config.waveSize);
-    if (!preflight.sufficient) {
+    // Loop, not if: a resume only proves the user clicked the button, so the
+    // balance is re-checked until it actually covers the opening stretch.
+    let preflight = await creditCheckStep(ref, config, config.waveSize);
+    while (!preflight.sufficient) {
       await markRunStatus(ref, "awaiting_input");
       await emitProgress(ref, {
         type: "stage",
@@ -51,10 +59,10 @@ export async function generateBook(
         pct: 1,
         detail: `${preflight.balance.toFixed(0)} of ${preflight.required.toFixed(0)} credits needed to start`,
       });
-      const hook = createHook<{ toppedUp: boolean }>({ token: `credits-topup:${dbRunId}` });
-      const go = await hook;
-      if (!go.toppedUp) throw new FatalError("Run cancelled while waiting for credits");
+      const go = await topUpEvents.next();
+      if (!go.value?.toppedUp) throw new FatalError("Run cancelled while waiting for credits");
       await markRunStatus(ref, "running");
+      preflight = await creditCheckStep(ref, config, config.waveSize);
     }
 
     await emitProgress(ref, { type: "stage", stage: "concept", pct: 2 });
@@ -112,8 +120,8 @@ export async function generateBook(
       // can outrun its estimate. Running short suspends the run instead of
       // failing it, so every chapter already drafted is kept and no work is
       // re-billed on resume.
-      const credit = await creditCheckStep(ref, config, Math.min(config.waveSize, total - done));
-      if (!credit.sufficient) {
+      let credit = await creditCheckStep(ref, config, Math.min(config.waveSize, total - done));
+      while (!credit.sufficient) {
         await markRunStatus(ref, "awaiting_input");
         await emitProgress(ref, {
           type: "stage",
@@ -121,14 +129,12 @@ export async function generateBook(
           pct: 15 + Math.round(55 * (done / total)),
           detail: `${credit.balance.toFixed(0)} of ${credit.required.toFixed(0)} credits needed to continue`,
         });
-        const topUp = createHook<{ toppedUp: boolean }>({
-          token: `credits-topup:${dbRunId}`,
-        });
-        const resumed = await topUp;
-        if (!resumed.toppedUp) {
+        const resumed = await topUpEvents.next();
+        if (!resumed.value?.toppedUp) {
           throw new FatalError("Run cancelled while waiting for credits");
         }
         await markRunStatus(ref, "running");
+        credit = await creditCheckStep(ref, config, Math.min(config.waveSize, total - done));
       }
 
       await Promise.all(wave.map((n) => writeChapterStep(ref, config, n)));

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -158,8 +158,20 @@ export async function creditCheckStep(
   if (!project) throw new FatalError("Project not found");
 
   const count = Math.min(Math.max(chaptersToCover, 1), project.chapters);
+  // Only the per-chapter stages: estimateBookCost totals book-level overhead
+  // (concept, outline, continuity) too, which for a mid-book wave check would
+  // demand credits for work that already ran or runs once at the end.
   const estimate = estimateBookCost(config.tier, count, project.words);
-  const required = creditsForUsd(estimate.totalUsd);
+  const perChapterStages = new Set([
+    "Chapter drafting",
+    "Critique + revisions",
+    "Editorial pass",
+    "Summaries + character bible",
+  ]);
+  const waveUsd = estimate.stages
+    .filter((stage) => perChapterStages.has(stage.stage))
+    .reduce((acc, stage) => acc + stage.usd, 0);
+  const required = creditsForUsd(waveUsd);
   const balance = await getBalance(ref.userId);
   return { balance, required, sufficient: balance >= required };
 }

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -144,6 +144,7 @@ export async function creditCheckStep(
   ref: RunRef,
   config: GenerationConfig,
   chaptersToCover: number,
+  opts?: { includeBookOverhead?: boolean },
 ): Promise<{ balance: number; required: number; sufficient: boolean }> {
   "use step";
   const db = getDb();
@@ -168,10 +169,13 @@ export async function creditCheckStep(
     "Editorial pass",
     "Summaries + character bible",
   ]);
-  const waveUsd = estimate.stages
-    .filter((stage) => perChapterStages.has(stage.stage))
+  // Pre-flight also charges for the book-level stages (concept, outline,
+  // bible, continuity) that run before/after the chapters; mid-book wave
+  // checks must not, since that work already ran or runs once at the end.
+  const requiredUsd = estimate.stages
+    .filter((stage) => opts?.includeBookOverhead || perChapterStages.has(stage.stage))
     .reduce((acc, stage) => acc + stage.usd, 0);
-  const required = creditsForUsd(waveUsd);
+  const required = creditsForUsd(requiredUsd);
   const balance = await getBalance(ref.userId);
   return { balance, required, sufficient: balance >= required };
 }


### PR DESCRIPTION
Response to Cursor Bugbot's findings on #121, #122, #124, #125 — every confirmed finding fixed, two acknowledged as deliberate.

## Fixed

| Finding | Fix |
|---|---|
| Case mismatch creates duplicate entities (121, Med) | `entityUpsert` resolves case-insensitively and reuses stored casing |
| Default attrs wipe list fields (121, **High**) | Empty/blank values stripped before the jsonb merge — a facts-only update can no longer erase `personality`/`contents` |
| Relationships bind first name match (121, Med) | Exact-case preferred, then character kind, else dropped rather than guessed |
| Resume ignores required credits (122, **High**) | Both pauses are now while-loops that re-check after resume — and share **one** AsyncIterable hook, since a token belongs to a single active hook (the old code created the same token twice) |
| Credit check over-estimates (122/124, **High**) | `creditCheckStep` sums only per-chapter stages; book-level overhead no longer charged to every wave |
| Refunds miss checkout userId (122, **High**) | Checkout sets `payment_intent_data.metadata`, so charges carry the user |
| Refund amount double-counts (122, **High**) | `amount_refunded` is cumulative; refunds now recorded per refund-object id behind the unique `external_ref` index |
| Edits lack credit preflight (124, **High**) | `edits` and `review` pre-gate with `assertCreditsForUsd` instead of relying on the floor backstop |
| User delete blocked by llm_calls (125, **High**) | Migration adds `ON DELETE CASCADE` to the three user FKs that lacked it |
| Studio settings link removed (125, Med) | Settings restored as a nav link |
| Dev auth skips welcome grant (124, Med) | Dev fallback identity gets the same grant, so local dev exercises real credit paths |

## Acknowledged, not fixed

- **Migration drops relationship attrs** (121): the old free-text `relationships` map wasn't carried into the backfill. Superseded by the structured `entity_relationships` graph; the source table is already dropped. Known, accepted loss.
- **Omitted kind becomes character** (121): deliberate default — most summarizer facts are characters, and a mis-kinded entry still merges canon rather than losing it.

Already fixed before this PR: no-resume-UI (#124's CreditsBanner), budget-blocks-credits (#124 removed the budget system), stray duplicate files (#124's cleanup + CI guard).

311 unit tests; full gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches billing (Stripe refunds, credit pre-gates, generation pause/resume), destructive cascade on user delete, and story-bible merge logic that affects canon data integrity.
> 
> **Overview**
> Addresses Bugbot findings across **story-bible persistence**, **credit gating**, **Stripe refunds**, and **account deletion**.
> 
> **Entity / bible:** `entityUpsert` resolves names case-insensitively and keeps stored casing so duplicates do not slip past the unique index. Partial updates no longer merge `parseAttrs` empty list defaults into jsonb (which could wipe `personality` and similar fields). Relationship resolution in `applyEntityDeltas` prefers exact-case matches, then `character`, otherwise drops ambiguous ties.
> 
> **Credits / generation:** Book generation uses one shared top-up hook and **while-loops** that re-run `creditCheckStep` after resume until balance is sufficient. Wave checks count only per-chapter cost stages, not whole-book overhead. Chapter **selection edits** and **full review** call `assertCreditsForUsd` before metered LLM work. Dev auth grants the same welcome credits as production.
> 
> **Stripe:** Checkout copies `userId` onto `payment_intent_data.metadata` for refund webhooks. Refunds are clawed back per refund object id (not cumulative `amount_refunded`).
> 
> **Schema / UI:** Migration `0006` adds `ON DELETE CASCADE` on `generation_runs`, `llm_calls`, and `content_tool_runs` → `users`. Studio nav restores the **Settings** link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd57125ba25774d5edfdae4ab093bb7e14f264a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->