### PR TITLE
Refund clawback: always fetch the refund list from the API

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -74,11 +74,10 @@ export async function POST(req: Request) {
     // `amount_refunded` is CUMULATIVE across partial refunds, so each event is
     // recorded per refund object — its own id, its own amount — and the unique
     // external_ref index makes redelivery of the same refund a no-op.
-    // Webhook payloads do not expand the refunds list on current API versions,
-    // so fetch it rather than trusting the (usually absent) inline data.
-    const refunds =
-      charge.refunds?.data ??
-      (await getStripe().refunds.list({ charge: charge.id, limit: 100 })).data;
+    // Always fetch the refund list from the API: webhook payloads either omit
+    // it entirely on current API versions or include a possibly-truncated
+    // inline copy — an empty-but-present array must not skip the clawback.
+    const refunds = (await getStripe().refunds.list({ charge: charge.id, limit: 100 })).data;
     if (userId) {
       for (const refund of refunds) {
         const usd = (refund.amount ?? 0) / 100;


### PR DESCRIPTION
Follow-up to #126: Bugbot re-flagged the refund path — correctly. `charge.refunds?.data ?? fetch` skips the API fetch whenever the payload contains a *present but empty or truncated* refunds array, which current Stripe API versions can send. The handler now always lists refunds via the API; per-refund-id idempotency behind the unique index is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment webhook refund clawback logic; behavior is more correct but adds an API call per refund event.
> 
> **Overview**
> Fixes a bug where **`charge.refunded`** could skip credit clawback when the webhook included an **empty or truncated** `charge.refunds.data` array—`??` only fell back to the API when that field was missing, not when it was present but wrong.
> 
> The handler **always** calls **`refunds.list`** for the charge; per-refund **`externalRef`** idempotency is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b54e4bccc0f3314c23c1946033628ffd3e49cbf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->