### PR TITLE
Book & project management: edit titles, rename/archive/delete, chapter management, regenerate

### DIFF
--- a/e2e/studio.spec.ts
+++ b/e2e/studio.spec.ts
@@ -45,3 +45,51 @@ test.describe("studio usage", () => {
     await fullPageScreenshot(page, testInfo, "studio-usage");
   });
 });
+
+test.describe("project management", () => {
+  /** These specs exercise real data; an empty library (fresh dev DB) skips. */
+  async function firstProjectOrSkip(page: import("@playwright/test").Page) {
+    await page.goto("/studio");
+    // Project cards are the only /projects/... links on the dashboard. Wait for
+    // the Suspense-streamed grid to settle before deciding the library is empty.
+    const card = page.locator('a[href^="/projects/"]').first();
+    try {
+      await card.waitFor({ state: "attached", timeout: 10_000 });
+    } catch {
+      test.skip(true, "no projects in this environment");
+    }
+    return card;
+  }
+
+  test("dashboard cards expose a management menu", async ({ page }) => {
+    await firstProjectOrSkip(page);
+    const menu = page.getByRole("button", { name: /^Actions for / }).first();
+    await expect(menu).toBeAttached();
+    await menu.click();
+    for (const item of ["Rename", "Archive", "Delete…"]) {
+      await expect(page.getByRole("menuitem", { name: item })).toBeVisible();
+    }
+    await page.keyboard.press("Escape");
+  });
+
+  test("project settings stage edits shape and voice", async ({ page }) => {
+    const card = await firstProjectOrSkip(page);
+    await card.click();
+    await page.locator('a[href^="/projects/"][href$="/settings"]').click();
+    await expect(page.getByRole("heading", { name: "Project settings" })).toBeVisible();
+    await expect(page.getByLabel("Style guide")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save settings" })).toBeVisible();
+  });
+
+  test("the manuscript page can edit the book's identity", async ({ page }) => {
+    const card = await firstProjectOrSkip(page);
+    await card.click();
+    await page.locator('a[href^="/projects/"][href$="/manuscript"]').click();
+    const edit = page.getByRole("button", { name: "Edit title, synopsis, and author" });
+    await expect(edit).toBeVisible();
+    await edit.click();
+    await expect(page.getByRole("heading", { name: "Book details" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Author" })).toBeVisible();
+    await page.keyboard.press("Escape");
+  });
+});

--- a/src/app/(studio)/projects/[projectId]/brief/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/brief/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { BriefEditor } from "@/components/studio/brief-editor";
 import { requireUser } from "@/lib/auth";
 import { getProjectWithBook } from "@/db/queries/books";
 import { TIER_LABELS } from "@/ai/models";
@@ -63,6 +64,9 @@ export default async function BriefPage({ params }: { params: Promise<{ projectI
               This project has no brief yet — the agents will be working from the title alone.
             </p>
           )}
+        </div>
+        <div className="mt-8">
+          <BriefEditor projectId={projectId} brief={project.brief ?? ""} />
         </div>
       </article>
 

--- a/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
@@ -3,6 +3,7 @@ import type { Route } from "next";
 import { notFound } from "next/navigation";
 
 import { ChapterPager } from "@/components/manuscript/chapter-pager";
+import { BookIdentityDialog } from "@/components/manuscript/book-identity-dialog";
 import { ExportDialog } from "@/components/manuscript/export-dialog";
 import { ManuscriptRail } from "@/components/manuscript/manuscript-rail";
 import { buttonVariants } from "@/components/ui/button";
@@ -96,7 +97,15 @@ export default async function ManuscriptPage({
             activeChapter={active.chapterNumber}
           />
         </div>
-        <ExportDialog projectId={projectId} />
+        <div className="flex items-center gap-2">
+          <BookIdentityDialog
+            projectId={projectId}
+            title={book.title}
+            synopsis={book.synopsis}
+            author={(book.frontMatter as { author?: string }).author ?? null}
+          />
+          <ExportDialog projectId={projectId} />
+        </div>
       </header>
 
       <div className="paper-surface px-6 py-12 sm:px-12 sm:py-16">

--- a/src/app/(studio)/projects/[projectId]/settings/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/settings/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+
+import { ProjectSettingsForm } from "@/components/studio/project-settings-form";
+import { requireUser } from "@/lib/auth";
+import { getProjectWithBook } from "@/db/queries/books";
+
+export const metadata = { title: "Project settings" };
+
+export default async function ProjectSettingsPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = await params;
+  const { userId } = await requireUser();
+  const data = await getProjectWithBook(userId, projectId);
+  if (!data) notFound();
+  const { project } = data;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <header>
+        <h2 className="font-display text-xl font-semibold tracking-tight">Project settings</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Shape, voice, and content boundaries. Changes apply to future generation runs — existing
+          chapters stay as written.
+        </p>
+      </header>
+      <ProjectSettingsForm
+        projectId={projectId}
+        defaults={{
+          genre: project.genre ?? "",
+          targetChapters: project.targetChapters,
+          targetWordsPerChapter: project.targetWordsPerChapter,
+          styleGuide: project.styleGuide ?? "",
+          settings: project.settings,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(studio)/projects/[projectId]/write/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/write/page.tsx
@@ -46,7 +46,7 @@ export default async function WritePage({ params }: { params: Promise<{ projectI
         .where(eq(schema.llmCalls.runId, run.id)),
     ]);
     snapshot = {
-      run: { id: run.id, status: run.status as RunStatus, error: run.error },
+      run: { id: run.id, status: run.status as RunStatus, error: run.error, kind: run.kind },
       events: events.map((event) => event.payload),
       chapters: chapters.map((chapter) => ({
         number: chapter.chapterNumber,

--- a/src/app/(studio)/studio/page.tsx
+++ b/src/app/(studio)/studio/page.tsx
@@ -17,7 +17,7 @@ function toCard(project: ProjectWithStats): ProjectCardData {
     id: project.id,
     title: project.title,
     genre: project.genre,
-    status: project.status === "archived" ? "draft" : project.status,
+    status: project.status,
     archived: project.status === "archived",
     updatedAt: project.updatedAt.toISOString(),
     wordCount: project.wordCount,

--- a/src/app/(studio)/studio/page.tsx
+++ b/src/app/(studio)/studio/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { estimateBookCost } from "@/ai/estimate";
 import { EmptyLibrary } from "@/components/studio/empty-library";
 import { NewBookCard, ProjectCard, type ProjectCardData } from "@/components/studio/project-card";
-import { listProjectsWithStats } from "@/db/queries/projects";
+import { listProjectsWithStats, type ProjectWithStats } from "@/db/queries/projects";
 import { requireUser } from "@/lib/auth";
 import { ProjectGridSkeleton } from "./loading";
 
@@ -12,19 +12,13 @@ export const metadata: Metadata = {
   title: "Your books",
 };
 
-async function ProjectGrid() {
-  const { userId } = await requireUser();
-  const projects = await listProjectsWithStats(userId);
-
-  if (projects.length === 0) {
-    return <EmptyLibrary />;
-  }
-
-  const cards: ProjectCardData[] = projects.map((project) => ({
+function toCard(project: ProjectWithStats): ProjectCardData {
+  return {
     id: project.id,
     title: project.title,
     genre: project.genre,
     status: project.status === "archived" ? "draft" : project.status,
+    archived: project.status === "archived",
     updatedAt: project.updatedAt.toISOString(),
     wordCount: project.wordCount,
     chaptersDone: project.chaptersDone,
@@ -35,15 +29,42 @@ async function ProjectGrid() {
       project.targetChapters,
       project.targetWordsPerChapter,
     ).totalUsd,
-  }));
+  };
+}
+
+async function ProjectGrid() {
+  const { userId } = await requireUser();
+  const [projects, archived] = await Promise.all([
+    listProjectsWithStats(userId),
+    listProjectsWithStats(userId, { archived: true }),
+  ]);
+
+  if (projects.length === 0 && archived.length === 0) {
+    return <EmptyLibrary />;
+  }
 
   return (
-    <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-      {cards.map((card) => (
-        <ProjectCard key={card.id} project={card} />
-      ))}
-      <NewBookCard />
-    </div>
+    <>
+      <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((project) => (
+          <ProjectCard key={project.id} project={toCard(project)} />
+        ))}
+        <NewBookCard />
+      </div>
+
+      {archived.length > 0 ? (
+        <details className="mt-8">
+          <summary className="cursor-pointer text-sm font-medium text-muted-foreground hover:text-foreground">
+            Archived · {archived.length}
+          </summary>
+          <div className="mt-4 grid gap-5 opacity-80 sm:grid-cols-2 lg:grid-cols-3">
+            {archived.map((project) => (
+              <ProjectCard key={project.id} project={toCard(project)} />
+            ))}
+          </div>
+        </details>
+      ) : null}
+    </>
   );
 }
 

--- a/src/app/api/chapters/[chapterId]/regenerate/route.ts
+++ b/src/app/api/chapters/[chapterId]/regenerate/route.ts
@@ -1,0 +1,107 @@
+import { start } from "workflow/api";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import { getChapterOwnership } from "@/db/queries/books";
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
+import { estimateBookCost } from "@/ai/estimate";
+import { generateChapter } from "@/workflows/generate-chapter";
+import type { GenerationConfig } from "@/lib/run-events";
+import type { QualityTier } from "@/ai/models";
+
+export const maxDuration = 60;
+
+/**
+ * Regenerates one chapter through the full writing pipeline. The current
+ * prose is snapshotted to the revision history before anything is replaced.
+ */
+export async function POST(_req: Request, ctx: { params: Promise<{ chapterId: string }> }) {
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const { chapterId } = await ctx.params;
+  if (!z.uuid().safeParse(chapterId).success) {
+    return Response.json({ error: "Chapter not found" }, { status: 404 });
+  }
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) {
+    return Response.json({ error: "Chapter not found" }, { status: 404 });
+  }
+
+  const db = getDb();
+  const [row] = await db
+    .select({
+      chapterNumber: schema.chapters.chapterNumber,
+      words: schema.projects.targetWordsPerChapter,
+      settings: schema.projects.settings,
+    })
+    .from(schema.chapters)
+    .innerJoin(schema.books, eq(schema.books.id, schema.chapters.bookId))
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(eq(schema.chapters.id, chapterId))
+    .limit(1);
+  if (!row) return Response.json({ error: "Chapter not found" }, { status: 404 });
+
+  // One run per project at a time — same rule as full-book generation, backed
+  // by the same partial unique index.
+  const [active] = await db
+    .select({ id: schema.generationRuns.id })
+    .from(schema.generationRuns)
+    .where(
+      and(
+        eq(schema.generationRuns.projectId, ownership.projectId),
+        inArray(schema.generationRuns.status, ["queued", "running", "awaiting_input"]),
+      ),
+    )
+    .limit(1);
+  if (active) {
+    return Response.json({ error: "A run is already in progress" }, { status: 409 });
+  }
+
+  const tier: QualityTier = row.settings.qualityTier ?? "standard";
+  const config: GenerationConfig = { tier, requireOutlineApproval: false, waveSize: 1 };
+
+  try {
+    // Single chapters are refused, not suspended: the cost is small and known.
+    await assertCreditsForUsd(userId, estimateBookCost(tier, 1, row.words).totalUsd);
+  } catch (error) {
+    if (error instanceof InsufficientCreditsError) {
+      return Response.json({ error: "Not enough credits" }, { status: 402 });
+    }
+    throw error;
+  }
+
+  const [run] = await db
+    .insert(schema.generationRuns)
+    .values({
+      projectId: ownership.projectId,
+      userId,
+      kind: "chapter",
+      status: "queued",
+      config,
+    })
+    .returning({ id: schema.generationRuns.id });
+
+  const workflowRun = await start(generateChapter, [
+    run.id,
+    ownership.projectId,
+    userId,
+    row.chapterNumber,
+    config,
+  ]);
+  await db
+    .update(schema.generationRuns)
+    .set({ workflowRunId: workflowRun.runId })
+    .where(eq(schema.generationRuns.id, run.id));
+
+  return Response.json({ runId: run.id });
+}

--- a/src/app/api/chapters/[chapterId]/regenerate/route.ts
+++ b/src/app/api/chapters/[chapterId]/regenerate/route.ts
@@ -8,6 +8,7 @@ import { requireUser, UnauthorizedError } from "@/lib/auth";
 import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { estimateBookCost } from "@/ai/estimate";
 import { generateChapter } from "@/workflows/generate-chapter";
+import { isActiveRunConflict } from "@/lib/run-conflict";
 import type { GenerationConfig } from "@/lib/run-events";
 import type { QualityTier } from "@/ai/models";
 
@@ -80,16 +81,26 @@ export async function POST(_req: Request, ctx: { params: Promise<{ chapterId: st
     throw error;
   }
 
-  const [run] = await db
-    .insert(schema.generationRuns)
-    .values({
-      projectId: ownership.projectId,
-      userId,
-      kind: "chapter",
-      status: "queued",
-      config,
-    })
-    .returning({ id: schema.generationRuns.id });
+  let run: { id: string };
+  try {
+    [run] = await db
+      .insert(schema.generationRuns)
+      .values({
+        projectId: ownership.projectId,
+        userId,
+        kind: "chapter",
+        status: "queued",
+        config,
+      })
+      .returning({ id: schema.generationRuns.id });
+  } catch (error) {
+    // Concurrent request won the race past the pre-check; the partial unique
+    // index is the backstop, and it deserves a 409 rather than a 500.
+    if (isActiveRunConflict(error)) {
+      return Response.json({ error: "A run is already in progress" }, { status: 409 });
+    }
+    throw error;
+  }
 
   const workflowRun = await start(generateChapter, [
     run.id,

--- a/src/components/bible/entity-card.tsx
+++ b/src/components/bible/entity-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { ImagePlus, Loader2, TriangleAlert } from "lucide-react";
 
@@ -8,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { BibleEntity } from "@/db/queries/entities";
 import { PORTRAIT_USD, PORTRAIT_KINDS } from "@/lib/bible/portraits";
+import { setContinuityIssueStatus } from "@/lib/actions/continuity";
 import { cn } from "@/lib/utils";
 
 type Conflict = { id: string; severity: string; description: string };
@@ -78,9 +80,23 @@ function asList(value: unknown): string[] {
 }
 
 export function EntityCard({ entity, conflicts }: { entity: BibleEntity; conflicts: Conflict[] }) {
+  const router = useRouter();
   const [portraitUrl, setPortraitUrl] = useState(entity.portraitUrl);
   const [busy, setBusy] = useState(false);
+  const [busyIssue, setBusyIssue] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  async function settleIssue(issueId: string, status: "resolved" | "dismissed") {
+    setBusyIssue(issueId);
+    try {
+      await setContinuityIssueStatus(issueId, status);
+      router.refresh();
+    } catch {
+      // The row simply stays; nothing destructive happened.
+    } finally {
+      setBusyIssue(null);
+    }
+  }
 
   const attrs = entity.attrs as Record<string, unknown>;
   const facts = asList(attrs.facts);
@@ -184,9 +200,29 @@ export function EntityCard({ entity, conflicts }: { entity: BibleEntity; conflic
       ) : null}
 
       {conflicts.length > 0 ? (
-        <ul className="space-y-1 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+        <ul className="space-y-2 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
           {conflicts.map((c) => (
-            <li key={c.id}>{c.description}</li>
+            <li key={c.id} className="space-y-1">
+              <p>{c.description}</p>
+              <span className="flex gap-1.5">
+                <button
+                  type="button"
+                  disabled={busyIssue !== null}
+                  onClick={() => settleIssue(c.id, "resolved")}
+                  className="rounded border border-destructive/40 px-1.5 py-0.5 font-sans font-medium hover:bg-destructive/10 disabled:opacity-50"
+                >
+                  {busyIssue === c.id ? "…" : "Mark resolved"}
+                </button>
+                <button
+                  type="button"
+                  disabled={busyIssue !== null}
+                  onClick={() => settleIssue(c.id, "dismissed")}
+                  className="rounded px-1.5 py-0.5 font-sans text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  Dismiss
+                </button>
+              </span>
+            </li>
           ))}
         </ul>
       ) : null}

--- a/src/components/editor/chapter-menu.tsx
+++ b/src/components/editor/chapter-menu.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowDown, ArrowUp, MoreHorizontal, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { addChapter, deleteChapter, moveChapter, renameChapter } from "@/lib/actions/chapters";
+
+/**
+ * Structural chapter actions: rename, reorder, insert, delete. Content is the
+ * editor's job; this menu only rearranges the shelf.
+ */
+export function ChapterMenu({
+  projectId,
+  chapterId,
+  chapterNumber,
+  title,
+  isFirst,
+  isLast,
+}: {
+  projectId: string;
+  chapterId: string;
+  chapterNumber: number;
+  title: string | null;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  const router = useRouter();
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [regenOpen, setRegenOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const label = title ? `${chapterNumber}. ${title}` : `Chapter ${chapterNumber}`;
+
+  function run(action: () => Promise<unknown>, close?: () => void) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await action();
+        close?.();
+        router.refresh();
+      } catch {
+        setError("That didn't work — try again.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Actions for ${label}`}
+              className="text-muted-foreground hover:text-foreground"
+            />
+          }
+        >
+          <MoreHorizontal aria-hidden="true" className="size-3.5" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setRenameOpen(true)}>
+            <Pencil aria-hidden="true" className="size-3.5" /> Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={isFirst || pending}
+            onClick={() => run(() => moveChapter(chapterId, "up"))}
+          >
+            <ArrowUp aria-hidden="true" className="size-3.5" /> Move up
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={isLast || pending}
+            onClick={() => run(() => moveChapter(chapterId, "down"))}
+          >
+            <ArrowDown aria-hidden="true" className="size-3.5" /> Move down
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={pending}
+            onClick={() => run(() => addChapter(projectId, chapterNumber))}
+          >
+            <Plus aria-hidden="true" className="size-3.5" /> Insert chapter after
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={pending} onClick={() => setRegenOpen(true)}>
+            <RefreshCw aria-hidden="true" className="size-3.5" /> Regenerate…
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
+            <Trash2 aria-hidden="true" className="size-3.5" /> Delete…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename chapter {chapterNumber}</DialogTitle>
+          </DialogHeader>
+          <form
+            action={(formData) =>
+              run(
+                () => renameChapter(chapterId, String(formData.get("title") ?? "")),
+                () => setRenameOpen(false),
+              )
+            }
+            className="space-y-4"
+          >
+            <div className="space-y-1.5">
+              <Label htmlFor={`ch-rename-${chapterId}`}>Title</Label>
+              <Input
+                id={`ch-rename-${chapterId}`}
+                name="title"
+                defaultValue={title ?? ""}
+                maxLength={300}
+                placeholder={`Chapter ${chapterNumber}`}
+              />
+              <p className="text-xs text-muted-foreground">
+                Leave blank to use the plain chapter number.
+              </p>
+            </div>
+            {error ? (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            ) : null}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setRenameOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending}>
+                {pending ? "Saving…" : "Save"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={regenOpen} onOpenChange={setRegenOpen}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rewrite {label}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The chapter runs back through the full writing pipeline with your current story bible
+              and brief. Today&rsquo;s text is saved to the revision history first.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {error ? (
+            <p role="alert" className="px-6 text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={() => setRegenOpen(false)} disabled={pending}>
+              Cancel
+            </Button>
+            <Button
+              disabled={pending}
+              onClick={() =>
+                run(
+                  async () => {
+                    const response = await fetch(`/api/chapters/${chapterId}/regenerate`, {
+                      method: "POST",
+                    });
+                    if (!response.ok) {
+                      const body = (await response.json().catch(() => ({}))) as {
+                        error?: string;
+                      };
+                      throw new Error(body.error ?? "Could not start");
+                    }
+                  },
+                  () => {
+                    setRegenOpen(false);
+                    router.push(`/projects/${projectId}/write`);
+                  },
+                )
+              }
+            >
+              {pending ? "Starting…" : "Rewrite chapter"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {label}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The chapter and its revision history are removed and later chapters renumber. There is
+              no undo.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {error ? (
+            <p role="alert" className="px-6 text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={pending}>
+              Keep it
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={pending}
+              onClick={() =>
+                run(
+                  () => deleteChapter(chapterId),
+                  () => {
+                    setDeleteOpen(false);
+                    router.push(`/projects/${projectId}/editor`);
+                  },
+                )
+              }
+            >
+              {pending ? "Deleting…" : "Delete chapter"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/editor/chapter-sidebar.tsx
+++ b/src/components/editor/chapter-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   formatWordCount,
 } from "@/lib/editor/chapter-status";
 import type { ChapterNavItem } from "@/lib/editor/types";
+import { ChapterMenu } from "@/components/editor/chapter-menu";
 
 export function ChapterSidebar({
   projectId,
@@ -85,18 +86,30 @@ export function ChapterSidebar({
                 active && "bg-accent text-accent-foreground",
               );
               return (
-                <li key={chapter.id}>
+                <li key={chapter.id} className="group/chapter relative">
                   {drafted ? (
                     <Link
                       href={`/projects/${projectId}/editor/${chapter.chapterNumber}`}
                       aria-current={active ? "page" : undefined}
-                      className={cn(itemClass, "transition-colors hover:bg-accent/70")}
+                      className={cn(itemClass, "pr-8 transition-colors hover:bg-accent/70")}
                     >
                       {inner}
                     </Link>
                   ) : (
-                    <div className={cn(itemClass, "opacity-50")}>{inner}</div>
+                    <div className={cn(itemClass, "pr-8 opacity-50")}>{inner}</div>
                   )}
+                  <span className="absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity group-focus-within/chapter:opacity-100 group-hover/chapter:opacity-100">
+                    <ChapterMenu
+                      projectId={projectId}
+                      chapterId={chapter.id}
+                      chapterNumber={chapter.chapterNumber}
+                      title={chapter.title}
+                      isFirst={chapter.chapterNumber === chapters[0]?.chapterNumber}
+                      isLast={
+                        chapter.chapterNumber === chapters[chapters.length - 1]?.chapterNumber
+                      }
+                    />
+                  </span>
                 </li>
               );
             })}

--- a/src/components/generation/completion-moment.tsx
+++ b/src/components/generation/completion-moment.tsx
@@ -20,12 +20,14 @@ export function CompletionMoment({
   chapterCount,
   recommendation,
   review,
+  onWriteAgain,
 }: {
   projectId: string;
   projectTitle: string;
   chapterCount: number;
   recommendation?: string;
   review?: { score: number; issueCount: number };
+  onWriteAgain?: () => void;
 }) {
   const [closed, setClosed] = React.useState(false);
 
@@ -112,6 +114,11 @@ export function CompletionMoment({
         >
           Start editing
         </Button>
+        {onWriteAgain ? (
+          <Button variant="ghost" onClick={onWriteAgain}>
+            Write again
+          </Button>
+        ) : null}
       </div>
     </section>
   );

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -115,6 +115,7 @@ export function RunViewer({
             ? { score: state.review.score, issueCount: state.review.issueCount }
             : undefined
         }
+        onWriteAgain={onRestart}
       />
     );
   } else if (state.stage === "failed") {

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -62,6 +62,7 @@ function announcementFor(stage: Stage, draftedCount: number, plannedTotal: numbe
  */
 export function RunViewer({
   runId,
+  runKind = "full_book",
   projectId,
   projectTitle,
   snapshot,
@@ -74,6 +75,8 @@ export function RunViewer({
   restartError,
 }: {
   runId: string;
+  /** Restart affordances re-run the FULL BOOK — hide them for scoped runs. */
+  runKind?: "full_book" | "chapter" | "edit_pass" | "continuity" | "export";
   projectId: string;
   projectTitle: string;
   snapshot: RunSnapshot;
@@ -115,7 +118,7 @@ export function RunViewer({
             ? { score: state.review.score, issueCount: state.review.issueCount }
             : undefined
         }
-        onWriteAgain={onRestart}
+        onWriteAgain={runKind === "full_book" ? onRestart : undefined}
       />
     );
   } else if (state.stage === "failed") {
@@ -127,8 +130,8 @@ export function RunViewer({
           state.error?.message ??
           "Something went wrong while writing. Chapters already drafted are saved."
         }
-        actionLabel="Try again"
-        onAction={onRestart}
+        actionLabel={runKind === "full_book" ? "Try again" : undefined}
+        onAction={runKind === "full_book" ? onRestart : undefined}
         pending={restartPending}
         error={restartError}
       />
@@ -139,8 +142,8 @@ export function RunViewer({
         icon={<OctagonX aria-hidden="true" className="size-5 text-muted-foreground" />}
         title="You stopped this run."
         body="Everything drafted before the stop is saved. A new run starts fresh from the brief."
-        actionLabel="Start a new run"
-        onAction={onRestart}
+        actionLabel={runKind === "full_book" ? "Start a new run" : undefined}
+        onAction={runKind === "full_book" ? onRestart : undefined}
         pending={restartPending}
         error={restartError}
       />
@@ -224,8 +227,8 @@ function EndCard({
   icon: React.ReactNode;
   title: string;
   body: string;
-  actionLabel: string;
-  onAction: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
   pending: boolean;
   error: string | null;
 }) {
@@ -236,10 +239,12 @@ function EndCard({
         <h2 className="font-display text-xl font-semibold tracking-tight">{title}</h2>
         <p className="mx-auto max-w-md text-sm text-muted-foreground">{body}</p>
       </div>
-      <Button onClick={onAction} disabled={pending}>
-        {pending ? <Spinner /> : null}
-        {actionLabel}
-      </Button>
+      {actionLabel && onAction ? (
+        <Button onClick={onAction} disabled={pending}>
+          {pending ? <Spinner /> : null}
+          {actionLabel}
+        </Button>
+      ) : null}
       {error ? (
         <p role="alert" className="text-sm text-destructive">
           {error}

--- a/src/components/generation/write-experience.tsx
+++ b/src/components/generation/write-experience.tsx
@@ -114,6 +114,7 @@ export function WriteExperience({
       <RunViewer
         key={snapshot.run.id}
         runId={snapshot.run.id}
+        runKind={snapshot.run.kind ?? "full_book"}
         projectId={projectId}
         projectTitle={projectTitle}
         snapshot={snapshot}

--- a/src/components/manuscript/book-identity-dialog.tsx
+++ b/src/components/manuscript/book-identity-dialog.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Pencil } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { updateBook } from "@/lib/actions/books";
+
+/**
+ * Edits the book's identity — title, synopsis, author byline. The concept
+ * agent proposes these once; after that they belong to the author, and the
+ * byline flows into every export in place of the house line.
+ */
+export function BookIdentityDialog({
+  projectId,
+  title,
+  synopsis,
+  author,
+}: {
+  projectId: string;
+  title: string;
+  synopsis: string | null;
+  author: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function submit(formData: FormData) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await updateBook(projectId, {
+          title: String(formData.get("title") ?? "").trim(),
+          synopsis: String(formData.get("synopsis") ?? "").trim() || null,
+          author: String(formData.get("author") ?? "").trim() || null,
+        });
+        setOpen(false);
+      } catch {
+        setError("Could not save — try again.");
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={<Button variant="ghost" size="sm" aria-label="Edit title, synopsis, and author" />}
+      >
+        <Pencil aria-hidden="true" className="size-3.5" />
+        Edit details
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Book details</DialogTitle>
+          <DialogDescription>
+            The title, synopsis, and author byline used on the title page and in every export.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={submit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="book-title">Title</Label>
+            <Input id="book-title" name="title" defaultValue={title} required maxLength={300} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="book-author">Author</Label>
+            <Input
+              id="book-author"
+              name="author"
+              defaultValue={author ?? ""}
+              maxLength={200}
+              placeholder="Written with sopher.ai"
+            />
+            <p className="text-xs text-muted-foreground">Leave blank to keep the default byline.</p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="book-synopsis">Synopsis</Label>
+            <Textarea
+              id="book-synopsis"
+              name="synopsis"
+              defaultValue={synopsis ?? ""}
+              maxLength={2000}
+              rows={4}
+            />
+          </div>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/studio/brief-editor.tsx
+++ b/src/components/studio/brief-editor.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Pencil } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { updateProject } from "@/lib/actions/projects";
+
+/**
+ * In-place editing for the brief. The brief seeds future generation runs, so
+ * edits matter even after a book exists — a re-run reads the new text.
+ */
+export function BriefEditor({ projectId, brief }: { projectId: string; brief: string }) {
+  const [editing, setEditing] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  if (!editing) {
+    return (
+      <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+        <Pencil aria-hidden="true" className="size-3.5" />
+        Edit the brief
+      </Button>
+    );
+  }
+
+  function submit(formData: FormData) {
+    setError(null);
+    const next = String(formData.get("brief") ?? "").trim();
+    if (next.length < 20) {
+      setError("A brief needs at least 20 characters.");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await updateProject(projectId, { brief: next });
+        setEditing(false);
+      } catch {
+        setError("Could not save — try again.");
+      }
+    });
+  }
+
+  return (
+    <form action={submit} className="space-y-3">
+      <label htmlFor="brief-editor" className="sr-only">
+        Brief
+      </label>
+      <Textarea
+        id="brief-editor"
+        name="brief"
+        defaultValue={brief}
+        rows={10}
+        maxLength={20_000}
+        className="font-serif"
+        autoFocus
+      />
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : "Save brief"}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => setEditing(false)}>
+          Cancel
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Changes apply to future generation runs — chapters already written stay as they are.
+      </p>
+    </form>
+  );
+}

--- a/src/components/studio/project-card.tsx
+++ b/src/components/studio/project-card.tsx
@@ -10,7 +10,7 @@ import { genreLabel } from "@/lib/genres";
 import { ProjectMenu } from "@/components/studio/project-menu";
 import { CREDIT_MARKUP } from "@/lib/billing/credits-shared";
 
-export type ProjectCardStatus = "draft" | "generating" | "editing" | "complete";
+export type ProjectCardStatus = "draft" | "generating" | "editing" | "complete" | "archived";
 
 /** Serializable card shape, assembled from the DB by the dashboard. */
 export interface ProjectCardData {
@@ -39,6 +39,9 @@ function stageForStatus(status: ProjectCardStatus): "brief" | "write" | "editor"
       return "editor";
     case "complete":
       return "manuscript";
+    case "archived":
+      // Read-only stroll through what exists; brief is the safest landing.
+      return "brief";
   }
 }
 

--- a/src/components/studio/project-card.tsx
+++ b/src/components/studio/project-card.tsx
@@ -7,6 +7,7 @@ import { Progress } from "@/components/ui/progress";
 import { StatusBadge } from "@/components/studio/status-badge";
 import { RelativeTime } from "@/components/relative-time";
 import { genreLabel } from "@/lib/genres";
+import { ProjectMenu } from "@/components/studio/project-menu";
 import { CREDIT_MARKUP } from "@/lib/billing/credits-shared";
 
 export type ProjectCardStatus = "draft" | "generating" | "editing" | "complete";
@@ -24,6 +25,7 @@ export interface ProjectCardData {
   chaptersTotal: number;
   spendUsd: number;
   estimateUsd: number;
+  archived?: boolean;
 }
 
 /** The workspace stage a book naturally opens on, given its status. */
@@ -49,50 +51,57 @@ export function ProjectCard({ project }: { project: ProjectCardData }) {
     project.chaptersTotal > 0 ? (project.chaptersDone / project.chaptersTotal) * 100 : 0;
 
   return (
-    <Link
-      href={`/projects/${project.id}/${stageForStatus(project.status)}`}
-      className="group block h-full rounded-xl"
-    >
-      <Card className="h-full transition-shadow group-hover:ring-foreground/25">
-        <CardHeader>
-          <CardTitle className="font-display text-lg leading-snug font-semibold tracking-tight text-balance">
-            {project.title}
-          </CardTitle>
-          <div className="mt-1 flex flex-wrap items-center gap-1.5">
-            {project.genre ? <Badge variant="outline">{genreLabel(project.genre)}</Badge> : null}
-            <StatusBadge status={project.status} />
-          </div>
-        </CardHeader>
-        <CardContent className="mt-auto space-y-2">
-          <div className="flex items-baseline justify-between text-xs text-muted-foreground">
-            <span>
-              Chapters{" "}
+    <div className="group relative h-full">
+      {/* The menu floats above the link so it is clickable without nesting
+          interactive elements inside the anchor. */}
+      <div className="absolute top-3 right-3 z-10">
+        <ProjectMenu projectId={project.id} title={project.title} archived={project.archived} />
+      </div>
+      <Link
+        href={`/projects/${project.id}/${stageForStatus(project.status)}`}
+        className="block h-full rounded-xl"
+      >
+        <Card className="h-full transition-shadow group-hover:ring-foreground/25">
+          <CardHeader>
+            <CardTitle className="pr-8 font-display text-lg leading-snug font-semibold tracking-tight text-balance">
+              {project.title}
+            </CardTitle>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              {project.genre ? <Badge variant="outline">{genreLabel(project.genre)}</Badge> : null}
+              <StatusBadge status={project.status} />
+            </div>
+          </CardHeader>
+          <CardContent className="mt-auto space-y-2">
+            <div className="flex items-baseline justify-between text-xs text-muted-foreground">
+              <span>
+                Chapters{" "}
+                <span className="font-mono tabular-nums">
+                  {project.chaptersDone}/{project.chaptersTotal}
+                </span>
+              </span>
               <span className="font-mono tabular-nums">
-                {project.chaptersDone}/{project.chaptersTotal}
+                {new Intl.NumberFormat("en-US").format(project.wordCount)} words
+              </span>
+            </div>
+            <Progress
+              value={progress}
+              aria-label={`Chapters completed: ${project.chaptersDone} of ${project.chaptersTotal}`}
+            />
+          </CardContent>
+          <CardFooter className="justify-between text-xs">
+            <span className="font-mono tabular-nums">
+              {formatSpendCredits(project.spendUsd)}{" "}
+              <span className="text-muted-foreground">
+                of ~{formatSpendCredits(project.estimateUsd)}
               </span>
             </span>
-            <span className="font-mono tabular-nums">
-              {new Intl.NumberFormat("en-US").format(project.wordCount)} words
-            </span>
-          </div>
-          <Progress
-            value={progress}
-            aria-label={`Chapters completed: ${project.chaptersDone} of ${project.chaptersTotal}`}
-          />
-        </CardContent>
-        <CardFooter className="justify-between text-xs">
-          <span className="font-mono tabular-nums">
-            {formatSpendCredits(project.spendUsd)}{" "}
             <span className="text-muted-foreground">
-              of ~{formatSpendCredits(project.estimateUsd)}
+              Updated <RelativeTime iso={project.updatedAt} />
             </span>
-          </span>
-          <span className="text-muted-foreground">
-            Updated <RelativeTime iso={project.updatedAt} />
-          </span>
-        </CardFooter>
-      </Card>
-    </Link>
+          </CardFooter>
+        </Card>
+      </Link>
+    </div>
   );
 }
 

--- a/src/components/studio/project-menu.tsx
+++ b/src/components/studio/project-menu.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Archive, ArchiveRestore, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { deleteProject, updateProject } from "@/lib/actions/projects";
+
+/**
+ * The card's overflow menu — the first place a project can be renamed,
+ * archived, or deleted from the UI. Deletion is the only destructive path and
+ * sits behind an explicit confirmation naming the project.
+ */
+export function ProjectMenu({
+  projectId,
+  title,
+  archived,
+}: {
+  projectId: string;
+  title: string;
+  archived?: boolean;
+}) {
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function rename(formData: FormData) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await updateProject(projectId, { title: String(formData.get("title") ?? "").trim() });
+        setRenameOpen(false);
+      } catch {
+        setError("Could not rename — try again.");
+      }
+    });
+  }
+
+  function setArchived(next: boolean) {
+    startTransition(async () => {
+      try {
+        await updateProject(projectId, { status: next ? "archived" : "draft" });
+      } catch {
+        // The card simply doesn't move; nothing destructive happened.
+      }
+    });
+  }
+
+  function destroy() {
+    startTransition(async () => {
+      // deleteProject redirects to /studio on success, so only failures return.
+      try {
+        await deleteProject(projectId);
+      } catch {
+        setDeleteOpen(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Actions for ${title}`}
+              className="text-muted-foreground hover:text-foreground"
+            />
+          }
+        >
+          <MoreHorizontal aria-hidden="true" className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setRenameOpen(true)}>
+            <Pencil aria-hidden="true" className="size-3.5" /> Rename
+          </DropdownMenuItem>
+          {archived ? (
+            <DropdownMenuItem onClick={() => setArchived(false)}>
+              <ArchiveRestore aria-hidden="true" className="size-3.5" /> Unarchive
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem onClick={() => setArchived(true)}>
+              <Archive aria-hidden="true" className="size-3.5" /> Archive
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
+            <Trash2 aria-hidden="true" className="size-3.5" /> Delete…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename project</DialogTitle>
+          </DialogHeader>
+          <form action={rename} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor={`rename-${projectId}`}>Title</Label>
+              <Input
+                id={`rename-${projectId}`}
+                name="title"
+                defaultValue={title}
+                required
+                maxLength={200}
+              />
+            </div>
+            {error ? (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            ) : null}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setRenameOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending}>
+                {pending ? "Saving…" : "Save"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete “{title}”?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes the project — manuscript, story bible, and exports. There is
+              no undo. Export anything you want to keep first.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={pending}>
+              Keep it
+            </Button>
+            <Button variant="destructive" onClick={destroy} disabled={pending}>
+              {pending ? "Deleting…" : "Delete forever"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/studio/project-menu.tsx
+++ b/src/components/studio/project-menu.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { deleteProject, updateProject } from "@/lib/actions/projects";
+import { deleteProject, setProjectArchived, updateProject } from "@/lib/actions/projects";
 
 /**
  * The card's overflow menu — the first place a project can be renamed,
@@ -64,7 +64,7 @@ export function ProjectMenu({
   function setArchived(next: boolean) {
     startTransition(async () => {
       try {
-        await updateProject(projectId, { status: next ? "archived" : "draft" });
+        await setProjectArchived(projectId, next);
       } catch {
         // The card simply doesn't move; nothing destructive happened.
       }

--- a/src/components/studio/project-settings-form.tsx
+++ b/src/components/studio/project-settings-form.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { ProjectSettings } from "@/db/schema";
+import { updateProject } from "@/lib/actions/projects";
+import { GENRES } from "@/lib/genres";
+
+/**
+ * Post-creation editing for everything the wizard set: genre, shape, style
+ * guide, POV/tense/tone and content boundaries. One form, one action.
+ */
+export function ProjectSettingsForm({
+  projectId,
+  defaults,
+}: {
+  projectId: string;
+  defaults: {
+    genre: string;
+    targetChapters: number;
+    targetWordsPerChapter: number;
+    styleGuide: string;
+    settings: ProjectSettings;
+  };
+}) {
+  const [pending, startTransition] = useTransition();
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function submit(formData: FormData) {
+    setError(null);
+    setSaved(false);
+    const read = (key: string) => String(formData.get(key) ?? "").trim();
+    startTransition(async () => {
+      try {
+        await updateProject(projectId, {
+          genre: read("genre") || undefined,
+          targetChapters: Number(formData.get("targetChapters")),
+          targetWordsPerChapter: Number(formData.get("targetWordsPerChapter")),
+          styleGuide: read("styleGuide") || undefined,
+          settings: {
+            ...defaults.settings,
+            pov: (read("pov") || undefined) as ProjectSettings["pov"],
+            tense: (read("tense") || undefined) as ProjectSettings["tense"],
+            tone: read("tone") || undefined,
+            qualityTier: (read("qualityTier") || undefined) as ProjectSettings["qualityTier"],
+          },
+        });
+        setSaved(true);
+      } catch {
+        setError("Could not save — check the values and try again.");
+      }
+    });
+  }
+
+  const selectClass =
+    "border-input bg-transparent focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-3 text-sm shadow-xs focus-visible:ring-[3px] outline-none";
+
+  return (
+    <form action={submit} className="space-y-5">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="ps-genre">Genre</Label>
+          <select id="ps-genre" name="genre" defaultValue={defaults.genre} className={selectClass}>
+            {GENRES.map((genre) => (
+              <option key={genre.id} value={genre.id}>
+                {genre.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ps-tier">Quality tier</Label>
+          <select
+            id="ps-tier"
+            name="qualityTier"
+            defaultValue={defaults.settings.qualityTier ?? "standard"}
+            className={selectClass}
+          >
+            <option value="draft">Draft</option>
+            <option value="standard">Standard</option>
+            <option value="premium">Premium</option>
+          </select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ps-chapters">Chapters</Label>
+          <Input
+            id="ps-chapters"
+            name="targetChapters"
+            type="number"
+            min={3}
+            max={60}
+            defaultValue={defaults.targetChapters}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ps-words">Words per chapter</Label>
+          <Input
+            id="ps-words"
+            name="targetWordsPerChapter"
+            type="number"
+            min={800}
+            max={8000}
+            step={100}
+            defaultValue={defaults.targetWordsPerChapter}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ps-pov">Point of view</Label>
+          <select
+            id="ps-pov"
+            name="pov"
+            defaultValue={defaults.settings.pov ?? ""}
+            className={selectClass}
+          >
+            <option value="">Let the agents choose</option>
+            <option value="first">First person</option>
+            <option value="third_limited">Third limited</option>
+            <option value="third_omniscient">Third omniscient</option>
+          </select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ps-tense">Tense</Label>
+          <select
+            id="ps-tense"
+            name="tense"
+            defaultValue={defaults.settings.tense ?? ""}
+            className={selectClass}
+          >
+            <option value="">Let the agents choose</option>
+            <option value="past">Past</option>
+            <option value="present">Present</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="ps-tone">Tone</Label>
+        <Input
+          id="ps-tone"
+          name="tone"
+          defaultValue={defaults.settings.tone ?? ""}
+          maxLength={200}
+          placeholder="Wry, warm, a little melancholy…"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="ps-style">Style guide</Label>
+        <Textarea
+          id="ps-style"
+          name="styleGuide"
+          defaultValue={defaults.styleGuide}
+          rows={6}
+          maxLength={10_000}
+          placeholder="House rules for the prose: sentence rhythm, vocabulary, things to avoid…"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : "Save settings"}
+        </Button>
+        {saved ? (
+          <p role="status" className="text-sm text-ai">
+            Saved.
+          </p>
+        ) : null}
+        {error ? (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/components/studio/stage-nav.tsx
+++ b/src/components/studio/stage-nav.tsx
@@ -14,6 +14,7 @@ const stages = [
   { slug: "editor", label: "Editor" },
   { slug: "manuscript", label: "Manuscript" },
   { slug: "usage", label: "Usage" },
+  { slug: "settings", label: "Settings" },
 ] as const;
 
 function StageTabs({ projectId, pathname }: { projectId: string; pathname?: string }) {

--- a/src/db/queries/projects.ts
+++ b/src/db/queries/projects.ts
@@ -16,12 +16,19 @@ export type ProjectWithStats = Awaited<ReturnType<typeof listProjectsWithStats>>
  * Dashboard listing: every non-archived project with chapter progress, word
  * count, and metered spend — batched into three queries total (no N+1).
  */
-export async function listProjectsWithStats(userId: string) {
+export async function listProjectsWithStats(userId: string, opts?: { archived?: boolean }) {
   const db = getDb();
   const projects = await db
     .select()
     .from(schema.projects)
-    .where(and(eq(schema.projects.userId, userId), ne(schema.projects.status, "archived")))
+    .where(
+      and(
+        eq(schema.projects.userId, userId),
+        opts?.archived
+          ? eq(schema.projects.status, "archived")
+          : ne(schema.projects.status, "archived"),
+      ),
+    )
     .orderBy(desc(schema.projects.updatedAt));
   if (projects.length === 0) return [];
 

--- a/src/hooks/use-run-stream.ts
+++ b/src/hooks/use-run-stream.ts
@@ -51,7 +51,12 @@ export type RunStatus =
 
 /** Page-load snapshot (run row + persisted progress events + DB chapter statuses). */
 export type RunSnapshot = {
-  run: { id: string; status: RunStatus; error: string | null };
+  run: {
+    id: string;
+    status: RunStatus;
+    error: string | null;
+    kind?: "full_book" | "chapter" | "edit_pass" | "continuity" | "export";
+  };
   /** Persisted event payloads in seq order (validated here; invalid ones dropped). */
   events: unknown[];
   /** Chapter statuses read from the DB at render time. */

--- a/src/lib/actions/books.ts
+++ b/src/lib/actions/books.ts
@@ -45,6 +45,15 @@ export async function updateBook(projectId: string, input: unknown): Promise<voi
   }
 
   await db.update(schema.books).set(patch).where(eq(schema.books.id, book.id));
+  // Title lives on both rows — the studio grid and project header read the
+  // project, exports and the reading view read the book. Keep them mirrored so
+  // neither edit path leaves the other surface stale.
+  if (data.title !== undefined) {
+    await db
+      .update(schema.projects)
+      .set({ title: data.title.trim(), updatedAt: new Date() })
+      .where(eq(schema.projects.id, projectId));
+  }
   revalidatePath(`/projects/${projectId}`);
   revalidatePath("/studio");
 }

--- a/src/lib/actions/books.ts
+++ b/src/lib/actions/books.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import { requireUser } from "@/lib/auth";
+
+const updateBookSchema = z.object({
+  title: z.string().min(1).max(300).optional(),
+  synopsis: z.string().max(2_000).nullable().optional(),
+  /** Author byline used on the title page and in every export. */
+  author: z.string().max(200).nullable().optional(),
+});
+
+export type UpdateBookInput = z.infer<typeof updateBookSchema>;
+
+/**
+ * Edits the book's identity — title, synopsis, author byline. The concept
+ * agent proposes these once; from then on they belong to the author. The
+ * byline lives in books.front_matter so exports and the reading view share it.
+ */
+export async function updateBook(projectId: string, input: unknown): Promise<void> {
+  const { userId } = await requireUser();
+  const data = updateBookSchema.parse(input);
+
+  const db = getDb();
+  const [book] = await db
+    .select({ id: schema.books.id, frontMatter: schema.books.frontMatter })
+    .from(schema.books)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
+    .limit(1);
+  if (!book) throw new Error("Book not found");
+
+  const patch: Record<string, unknown> = { updatedAt: new Date() };
+  if (data.title !== undefined) patch.title = data.title.trim();
+  if (data.synopsis !== undefined) patch.synopsis = data.synopsis?.trim() || null;
+  if (data.author !== undefined) {
+    const front = { ...(book.frontMatter as Record<string, unknown>) };
+    if (data.author?.trim()) front.author = data.author.trim();
+    else delete front.author;
+    patch.frontMatter = front;
+  }
+
+  await db.update(schema.books).set(patch).where(eq(schema.books.id, book.id));
+  revalidatePath(`/projects/${projectId}`);
+  revalidatePath("/studio");
+}

--- a/src/lib/actions/chapters.ts
+++ b/src/lib/actions/chapters.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { revalidatePath } from "next/cache";
@@ -9,6 +9,26 @@ import { getDb, schema } from "@/db";
 import { getChapterOwnership } from "@/db/queries/books";
 import { requireUser } from "@/lib/auth";
 import { countWords } from "@/lib/editor/anchors";
+
+/**
+ * Structural edits renumber chapters, and an in-flight run addresses chapters
+ * by number — reordering under it would desynchronize the workflow's targets.
+ * Rename is exempt (titles are cosmetic to the pipeline).
+ */
+async function assertNoActiveRun(projectId: string): Promise<void> {
+  const db = getDb();
+  const [active] = await db
+    .select({ id: schema.generationRuns.id })
+    .from(schema.generationRuns)
+    .where(
+      and(
+        eq(schema.generationRuns.projectId, projectId),
+        inArray(schema.generationRuns.status, ["queued", "running", "awaiting_input"]),
+      ),
+    )
+    .limit(1);
+  if (active) throw new Error("Finish or stop the current run before restructuring chapters");
+}
 
 export type SaveChapterResult =
   | { ok: true; version: number; wordCount: number }
@@ -116,6 +136,7 @@ export async function deleteChapter(chapterId: string): Promise<void> {
 
   const ownership = await getChapterOwnership(chapterId);
   if (!ownership || ownership.userId !== userId) throw new Error("Chapter not found");
+  await assertNoActiveRun(ownership.projectId);
 
   const db = getDb();
   const [chapter] = await db
@@ -154,6 +175,7 @@ export async function addChapter(
     .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
     .limit(1);
   if (!book) throw new Error("Book not found");
+  await assertNoActiveRun(projectId);
 
   const insertAt = Math.max(0, Math.trunc(afterNumber)) + 1;
   // Same two-phase shift, upward this time, to open the slot.
@@ -182,6 +204,7 @@ export async function moveChapter(chapterId: string, direction: "up" | "down"): 
 
   const ownership = await getChapterOwnership(chapterId);
   if (!ownership || ownership.userId !== userId) throw new Error("Chapter not found");
+  await assertNoActiveRun(ownership.projectId);
 
   const db = getDb();
   const [chapter] = await db

--- a/src/lib/actions/chapters.ts
+++ b/src/lib/actions/chapters.ts
@@ -1,7 +1,9 @@
 "use server";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
+
+import { revalidatePath } from "next/cache";
 
 import { getDb, schema } from "@/db";
 import { getChapterOwnership } from "@/db/queries/books";
@@ -84,4 +86,133 @@ export async function saveChapter(
   }
 
   return { ok: true, version: newVersion, wordCount };
+}
+
+/**
+ * Chapter management. All of these check ownership through the same
+ * getChapterOwnership/project join as saveChapter, and none touch content —
+ * they are structural edits an author makes around the prose.
+ */
+
+export async function renameChapter(chapterId: string, title: string): Promise<void> {
+  const { userId } = await requireUser();
+  if (!z.uuid().safeParse(chapterId).success) throw new Error("Chapter not found");
+  const trimmed = title.trim().slice(0, 300);
+
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) throw new Error("Chapter not found");
+
+  await getDb()
+    .update(schema.chapters)
+    // Empty title reverts to the default "Chapter N" rendering.
+    .set({ title: trimmed || null, updatedAt: new Date() })
+    .where(eq(schema.chapters.id, chapterId));
+  revalidatePath(`/projects/${ownership.projectId}`);
+}
+
+export async function deleteChapter(chapterId: string): Promise<void> {
+  const { userId } = await requireUser();
+  if (!z.uuid().safeParse(chapterId).success) throw new Error("Chapter not found");
+
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) throw new Error("Chapter not found");
+
+  const db = getDb();
+  const [chapter] = await db
+    .select({ bookId: schema.chapters.bookId, number: schema.chapters.chapterNumber })
+    .from(schema.chapters)
+    .where(eq(schema.chapters.id, chapterId))
+    .limit(1);
+  if (!chapter) throw new Error("Chapter not found");
+
+  await db.delete(schema.chapters).where(eq(schema.chapters.id, chapterId));
+  // Close the numbering gap. Two-phase renumber: the unique (bookId, number)
+  // index would reject in-place decrements meeting their predecessor, so pass
+  // one parks the tail at an offset no real chapter uses.
+  await db.execute(sql`
+    update chapters set chapter_number = chapter_number + 100000
+    where book_id = ${chapter.bookId} and chapter_number > ${chapter.number}
+  `);
+  await db.execute(sql`
+    update chapters set chapter_number = chapter_number - 100001
+    where book_id = ${chapter.bookId} and chapter_number > 100000
+  `);
+  revalidatePath(`/projects/${ownership.projectId}`);
+}
+
+/** Inserts a blank chapter after `afterNumber` (0 = at the start). */
+export async function addChapter(
+  projectId: string,
+  afterNumber: number,
+): Promise<{ chapterNumber: number }> {
+  const { userId } = await requireUser();
+  const db = getDb();
+  const [book] = await db
+    .select({ id: schema.books.id })
+    .from(schema.books)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
+    .limit(1);
+  if (!book) throw new Error("Book not found");
+
+  const insertAt = Math.max(0, Math.trunc(afterNumber)) + 1;
+  // Same two-phase shift, upward this time, to open the slot.
+  await db.execute(sql`
+    update chapters set chapter_number = chapter_number + 100000
+    where book_id = ${book.id} and chapter_number >= ${insertAt}
+  `);
+  await db.execute(sql`
+    update chapters set chapter_number = chapter_number - 99999
+    where book_id = ${book.id} and chapter_number > 100000
+  `);
+  await db.insert(schema.chapters).values({
+    bookId: book.id,
+    chapterNumber: insertAt,
+    status: "drafted",
+    content: "",
+  });
+  revalidatePath(`/projects/${projectId}`);
+  return { chapterNumber: insertAt };
+}
+
+/** Moves a chapter up or down one slot by swapping numbers with its neighbour. */
+export async function moveChapter(chapterId: string, direction: "up" | "down"): Promise<void> {
+  const { userId } = await requireUser();
+  if (!z.uuid().safeParse(chapterId).success) throw new Error("Chapter not found");
+
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) throw new Error("Chapter not found");
+
+  const db = getDb();
+  const [chapter] = await db
+    .select({ bookId: schema.chapters.bookId, number: schema.chapters.chapterNumber })
+    .from(schema.chapters)
+    .where(eq(schema.chapters.id, chapterId))
+    .limit(1);
+  if (!chapter) throw new Error("Chapter not found");
+
+  const targetNumber = direction === "up" ? chapter.number - 1 : chapter.number + 1;
+  const [neighbour] = await db
+    .select({ id: schema.chapters.id })
+    .from(schema.chapters)
+    .where(
+      and(
+        eq(schema.chapters.bookId, chapter.bookId),
+        eq(schema.chapters.chapterNumber, targetNumber),
+      ),
+    )
+    .limit(1);
+  if (!neighbour) return; // already at the edge
+
+  // Three-step swap through a parking number the unique index never sees twice.
+  await db.execute(sql`
+    update chapters set chapter_number = 100000 where id = ${chapterId}
+  `);
+  await db.execute(sql`
+    update chapters set chapter_number = ${chapter.number} where id = ${neighbour.id}
+  `);
+  await db.execute(sql`
+    update chapters set chapter_number = ${targetNumber} where id = ${chapterId}
+  `);
+  revalidatePath(`/projects/${ownership.projectId}`);
 }

--- a/src/lib/actions/continuity.ts
+++ b/src/lib/actions/continuity.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import { requireUser } from "@/lib/auth";
+
+/**
+ * Resolve or dismiss a continuity issue. Resolution is a human judgement —
+ * the agents only ever open issues; closing them belongs to the author.
+ */
+export async function setContinuityIssueStatus(
+  issueId: string,
+  status: "resolved" | "dismissed",
+): Promise<void> {
+  const { userId } = await requireUser();
+  if (!z.uuid().safeParse(issueId).success) throw new Error("Issue not found");
+
+  const db = getDb();
+  // Ownership: issue -> book -> project -> user.
+  const [issue] = await db
+    .select({ id: schema.continuityIssues.id, projectId: schema.projects.id })
+    .from(schema.continuityIssues)
+    .innerJoin(schema.books, eq(schema.books.id, schema.continuityIssues.bookId))
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(and(eq(schema.continuityIssues.id, issueId), eq(schema.projects.userId, userId)))
+    .limit(1);
+  if (!issue) throw new Error("Issue not found");
+
+  await db
+    .update(schema.continuityIssues)
+    .set({ status })
+    .where(eq(schema.continuityIssues.id, issueId));
+  revalidatePath(`/projects/${issue.projectId}/bible`);
+}

--- a/src/lib/actions/projects.ts
+++ b/src/lib/actions/projects.ts
@@ -2,13 +2,14 @@
 
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { start } from "workflow/api";
 import { z } from "zod";
 import { getDb, schema } from "@/db";
 import { requireUser } from "@/lib/auth";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { generateBook } from "@/workflows/generate-book";
+import { isActiveRunConflict } from "@/lib/run-conflict";
 import type { GenerationConfig } from "@/lib/run-events";
 import {
   createProjectSchema,
@@ -47,14 +48,6 @@ const startBookSchema = z.object({
   targetWordsPerChapter: z.number().int().min(800).max(8_000),
   settings: projectSettingsSchema.default({}),
 });
-
-/** Postgres unique violation on uq_runs_active_per_project, possibly wrapped by the driver. */
-function isActiveRunConflict(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const { code, message, cause } = error as { code?: string; message?: string; cause?: unknown };
-  if (code === "23505" || message?.includes("uq_runs_active_per_project")) return true;
-  return cause !== undefined && isActiveRunConflict(cause);
-}
 
 /**
  * Shared run-start logic — the server-side equivalent of
@@ -154,7 +147,50 @@ export async function updateProject(projectId: string, input: unknown) {
     .returning({ id: schema.projects.id });
 
   if (!updated) throw new Error("Project not found");
+  // Mirror a rename onto the book row so exports and the reading view agree
+  // with the dashboard (see updateBook for the reverse direction).
+  if (data.title !== undefined) {
+    await db
+      .update(schema.books)
+      .set({ title: data.title, updatedAt: new Date() })
+      .where(eq(schema.books.projectId, projectId));
+  }
   revalidatePath(`/projects/${projectId}`);
+  revalidatePath("/studio");
+}
+
+/**
+ * Archive/unarchive. Restoring derives the status from the book's actual state
+ * rather than resetting to draft, so a finished book comes back as finished.
+ */
+export async function setProjectArchived(projectId: string, archived: boolean) {
+  const { userId } = await requireUser();
+  const db = getDb();
+
+  let status: "draft" | "editing" | "complete" | "archived" = "archived";
+  if (!archived) {
+    const [stats] = await db
+      .select({
+        total: sql<number>`count(*)::int`,
+        written: sql<number>`count(*) filter (where length(${schema.chapters.content}) > 0)::int`,
+      })
+      .from(schema.chapters)
+      .innerJoin(schema.books, eq(schema.books.id, schema.chapters.bookId))
+      .where(eq(schema.books.projectId, projectId));
+    status =
+      stats && stats.written > 0
+        ? stats.written >= stats.total
+          ? "complete"
+          : "editing"
+        : "draft";
+  }
+
+  const [updated] = await db
+    .update(schema.projects)
+    .set({ status, updatedAt: new Date() })
+    .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
+    .returning({ id: schema.projects.id });
+  if (!updated) throw new Error("Project not found");
   revalidatePath("/studio");
 }
 

--- a/src/lib/export/assemble.ts
+++ b/src/lib/export/assemble.ts
@@ -41,6 +41,8 @@ export function buildManuscript(input: {
   title: string;
   synopsis?: string | null;
   genre?: string | null;
+  /** Author byline; falls back to the house line when unset. */
+  author?: string | null;
   chapters: ManuscriptSourceChapter[];
   figures?: FigureMap;
 }): AssembledManuscript {
@@ -58,7 +60,7 @@ export function buildManuscript(input: {
     });
   return {
     title: input.title.trim(),
-    author: MANUSCRIPT_AUTHOR,
+    author: input.author?.trim() || MANUSCRIPT_AUTHOR,
     synopsis: input.synopsis?.trim() || null,
     genre: input.genre?.trim() || null,
     chapters,
@@ -266,6 +268,7 @@ export async function loadManuscript(
       bookId: schema.books.id,
       bookTitle: schema.books.title,
       synopsis: schema.books.synopsis,
+      frontMatter: schema.books.frontMatter,
     })
     .from(schema.projects)
     .innerJoin(schema.books, eq(schema.books.projectId, schema.projects.id))
@@ -285,10 +288,12 @@ export async function loadManuscript(
     )
     .orderBy(schema.chapters.chapterNumber);
 
+  const author = (row.frontMatter as { author?: string } | null)?.author;
   return buildManuscript({
     title: row.bookTitle,
     synopsis: row.synopsis,
     genre: row.genre,
+    author,
     chapters,
     figures: await loadFigures(row.projectId),
   });

--- a/src/lib/run-conflict.ts
+++ b/src/lib/run-conflict.ts
@@ -1,0 +1,11 @@
+/**
+ * Postgres unique violation on uq_runs_active_per_project, possibly wrapped by
+ * the driver. The partial unique index is the race-proof backstop behind every
+ * "is a run already active?" pre-check.
+ */
+export function isActiveRunConflict(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const { code, message, cause } = error as { code?: string; message?: string; cause?: unknown };
+  if (code === "23505" || message?.includes("uq_runs_active_per_project")) return true;
+  return cause !== undefined && isActiveRunConflict(cause);
+}

--- a/src/lib/validation/project.ts
+++ b/src/lib/validation/project.ts
@@ -28,7 +28,9 @@ export const createProjectSchema = z.object({
   settings: projectSettingsSchema.default({}),
 });
 
-export const updateProjectSchema = createProjectSchema.partial();
+export const updateProjectSchema = createProjectSchema.partial().extend({
+  status: z.enum(["draft", "generating", "editing", "complete", "archived"]).optional(),
+});
 
 export const estimateRequestSchema = z.object({
   tier: qualityTierSchema,

--- a/src/workflows/generate-chapter.ts
+++ b/src/workflows/generate-chapter.ts
@@ -1,0 +1,48 @@
+import { FatalError } from "workflow";
+import type { GenerationConfig } from "@/lib/run-events";
+import { emitCost, emitProgress, markRunStatus, resetChapterStep, writeChapterStep } from "./steps";
+
+/**
+ * Regenerates a single chapter in place. The old prose is snapshotted to the
+ * revision history first, then the chapter runs back through the full
+ * plan → draft → critique → revise pipeline with current canon (story bible,
+ * neighbouring summaries) as context.
+ */
+export async function generateChapter(
+  dbRunId: string,
+  projectId: string,
+  userId: string,
+  chapterNumber: number,
+  config: GenerationConfig,
+) {
+  "use workflow";
+  const ref = { dbRunId, projectId, userId };
+
+  try {
+    await markRunStatus(ref, "running");
+    await emitProgress(ref, { type: "stage", stage: "chapters", pct: 5 });
+    await emitProgress(ref, {
+      type: "agent",
+      agent: "writer",
+      message: `Rewriting chapter ${chapterNumber}`,
+    });
+
+    await resetChapterStep(ref, chapterNumber);
+    const result = await writeChapterStep(ref, config, chapterNumber);
+    await emitCost(ref);
+
+    await markRunStatus(ref, "completed");
+    await emitProgress(ref, {
+      type: "stage",
+      stage: "done",
+      pct: 100,
+      detail: `Chapter ${chapterNumber} rewritten — ${result.wordCount.toLocaleString()} words`,
+    });
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Chapter regeneration failed";
+    await markRunStatus(ref, "failed", message);
+    await emitProgress(ref, { type: "error", message, fatal: true });
+    throw error instanceof FatalError ? error : new FatalError(message);
+  }
+}

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -299,10 +299,14 @@ export async function resetChapterStep(ref: RunRef, chapterNumber: number): Prom
     .update(schema.chapters)
     .set({
       content: "",
-      summary: null,
+      // Summary stays: it doubles as regeneration context when the outline no
+      // longer has an entry for this number (user-added or reordered chapters).
       wordCount: 0,
       qualityScore: null,
       status: "planned",
+      // Invalidate any open editor tab: a stale baseVersion must conflict
+      // rather than silently overwrite the freshly generated prose.
+      version: sql`${schema.chapters.version} + 1`,
       updatedAt: new Date(),
     })
     .where(eq(schema.chapters.id, chapter.id));
@@ -371,9 +375,26 @@ export async function writeChapterStep(
     .limit(1);
   if (!outlineRow) throw new FatalError("No outline to write from");
   const outline = outlineRow.content as BookOutline;
-  const chapterOutline = outline.chapters.find((c) => c.number === chapterNumber) as
+  let chapterOutline = outline.chapters.find((c) => c.number === chapterNumber) as
     ChapterOutlinePlan | undefined;
-  if (!chapterOutline) throw new FatalError(`Chapter ${chapterNumber} missing from outline`);
+  if (!chapterOutline) {
+    // The author restructured chapters after the outline was written (added,
+    // moved, or is regenerating one) — synthesize an entry from what the
+    // chapter row itself knows rather than refusing.
+    chapterOutline = {
+      number: chapterNumber,
+      title: existing?.title ?? `Chapter ${chapterNumber}`,
+      summary:
+        existing?.summary ??
+        "Continue the story naturally from the surrounding chapters, honoring the story bible.",
+      keyEvents: [],
+      charactersPresent: [],
+      emotionalArc: "transition",
+      openingHook: "Pick up where the previous chapter's summary leaves off.",
+      closingHook: "Hand off cleanly to the next chapter's summary.",
+      targetWords: project.targetWordsPerChapter,
+    };
+  }
 
   const prevSummaries = await db
     .select({

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -272,6 +272,42 @@ export async function entityBibleStep(
   }
 }
 
+/**
+ * Prepares a chapter for regeneration: snapshots the current prose into the
+ * revision history, then clears content and status so writeChapterStep's
+ * resume check treats it as unwritten. The old text is one restore away.
+ */
+export async function resetChapterStep(ref: RunRef, chapterNumber: number): Promise<void> {
+  "use step";
+  const { book } = await loadRunContext(ref);
+  const db = getDb();
+  const [chapter] = await db
+    .select({ id: schema.chapters.id, content: schema.chapters.content })
+    .from(schema.chapters)
+    .where(
+      and(eq(schema.chapters.bookId, book.id), eq(schema.chapters.chapterNumber, chapterNumber)),
+    )
+    .limit(1);
+  if (!chapter) return;
+
+  if (chapter.content.trim().length > 0) {
+    await db
+      .insert(schema.chapterRevisions)
+      .values({ chapterId: chapter.id, content: chapter.content, source: "regenerate" });
+  }
+  await db
+    .update(schema.chapters)
+    .set({
+      content: "",
+      summary: null,
+      wordCount: 0,
+      qualityScore: null,
+      status: "planned",
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.chapters.id, chapter.id));
+}
+
 export async function writeChapterStep(
   ref: RunRef,
   config: GenerationConfig,


### PR DESCRIPTION
## The gap

The audit's spot-check — *"can you edit book titles after writing?"* — was no, for nearly everything. The concept agent named the book once, forever. `updateProject`/`deleteProject` were dead code with no callers. Chapters couldn't be renamed, reordered, added, or deleted. A finished book could never be re-run. Continuity issues could never be closed.

## What this adds

**Book identity** — an edit dialog on the manuscript page for title, synopsis, and **author byline**. The byline lives in `books.front_matter` (schema field that existed unused since the rebuild) and flows into every export in place of the hardcoded "Written with sopher.ai".

**Project management** — the card gains an overflow menu wiring the dead actions: rename, archive/unarchive (with an archived section on the dashboard), delete behind a confirmation that names the project. The brief is editable in place, and a new **Settings** stage edits everything the wizard set — genre, targets, style guide, POV/tense/tone, tier — with the honest caveat that changes apply to future runs.

**Chapter management** — a per-chapter menu in the editor sidebar: rename (blank reverts to "Chapter N"), move up/down, insert after, delete. Renumbering uses two-phase shifts through a parking offset because `uq_chapter_num` rejects in-place decrements that meet their predecessor.

**Regeneration** — "Rewrite chapter" snapshots today's prose to the revision history, resets the chapter, and runs it back through the full plan→draft→critique→revise pipeline via a new `generateChapter` workflow (run kind `"chapter"` — enum value that existed unused). Credits-gated with a 402 refusal (single chapters are small and known-cost, so no suspend machinery), one-run-per-project enforced by the same partial unique index as full books. Plus **"Write again"** on the completion card — the done state previously had no restart affordance at all.

**Continuity closure** — resolve/dismiss buttons on the Bible page's conflict list. Agents open issues; closing them is the author's judgement.

## Verification

Local e2e: **28/28** including three new management specs (card menu, settings stage, identity dialog) that exercise real data — href-based locators, data-aware skip for empty environments, and a seeded fixture project for the dev identity. 311 unit tests; typecheck/lint/format/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive project/chapter deletes and raw SQL renumbering can corrupt chapter order if mis-invoked; chapter regeneration charges credits and replaces prose (with revision snapshots). Ownership checks are consistent with existing patterns.
> 
> **Overview**
> Authors can manage books and projects end-to-end from the studio instead of treating agent output as immutable.
> 
> **Project & book metadata** — Dashboard cards get an overflow menu (rename, archive/unarchive, delete with confirmation). Archived projects appear in a collapsible section. The brief is editable in place; a new **Settings** stage edits genre, targets, style guide, POV/tense/tone, and tier (with copy that changes apply to future runs). Manuscript adds **Book details** for title, synopsis, and **author byline** stored in `front_matter` and used in exports instead of the default house line.
> 
> **Chapter structure** — The editor sidebar exposes per-chapter actions: rename, move up/down, insert after, delete (with two-phase renumbering around the unique chapter index), plus **Regenerate** which POSTs to a new API route. That route enforces ownership, one active run per project, credit check (402), snapshots prose via `resetChapterStep`, and starts the `generateChapter` workflow (`kind: "chapter"`). Completion UI gains **Write again** wired to the existing restart handler.
> 
> **Bible** — Continuity conflicts on entity cards can be marked resolved or dismissed via a new server action.
> 
> Playwright adds three management specs (card menu, settings, book identity) with skip when no projects exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f147f9c71e81f62b8c05e2d59f19433915308a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->