### PR TITLE
Writing tools: revision history, find & replace, ⌘K, covers, outline editing

### DIFF
--- a/src/app/(studio)/layout.tsx
+++ b/src/app/(studio)/layout.tsx
@@ -1,9 +1,11 @@
+import { CommandPalette } from "@/components/studio/command-palette";
 import { StudioNav } from "@/components/studio/studio-nav";
 
 export default function StudioLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-dvh flex-col">
       <StudioNav />
+      <CommandPalette />
       {/* id + tabIndex are the skip link's target (rendered once in the root layout). */}
       <main id="main-content" tabIndex={-1} className="mx-auto w-full max-w-7xl flex-1 px-6 py-8">
         {children}

--- a/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
@@ -3,7 +3,10 @@ import type { Route } from "next";
 import { notFound } from "next/navigation";
 
 import { ChapterPager } from "@/components/manuscript/chapter-pager";
+import Image from "next/image";
+
 import { BookIdentityDialog } from "@/components/manuscript/book-identity-dialog";
+import { CoverButton } from "@/components/manuscript/cover-button";
 import { ExportDialog } from "@/components/manuscript/export-dialog";
 import { ManuscriptRail } from "@/components/manuscript/manuscript-rail";
 import { buttonVariants } from "@/components/ui/button";
@@ -98,6 +101,10 @@ export default async function ManuscriptPage({
           />
         </div>
         <div className="flex items-center gap-2">
+          <CoverButton
+            projectId={projectId}
+            hasCover={Boolean((book.frontMatter as { coverUrl?: string }).coverUrl)}
+          />
           <BookIdentityDialog
             projectId={projectId}
             title={book.title}
@@ -111,6 +118,15 @@ export default async function ManuscriptPage({
       <div className="paper-surface px-6 py-12 sm:px-12 sm:py-16">
         {isOpening ? (
           <header className="mx-auto max-w-2xl py-10 text-center sm:py-16 [content-visibility:auto]">
+            {(book.frontMatter as { coverUrl?: string }).coverUrl ? (
+              <Image
+                src={(book.frontMatter as { coverUrl?: string }).coverUrl as string}
+                alt={`Cover of ${book.title}`}
+                width={288}
+                height={432}
+                className="mx-auto mb-8 h-auto w-48 rounded-sm shadow-lg sm:w-56"
+              />
+            ) : null}
             {project.genre ? (
               <p className="font-sans text-xs tracking-[0.25em] text-paper-muted uppercase">
                 {project.genre}

--- a/src/app/(studio)/projects/[projectId]/outline/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/outline/page.tsx
@@ -7,6 +7,7 @@ import { requireUser } from "@/lib/auth";
 import { getActiveRun, getLatestOutline, getProjectWithBook } from "@/db/queries/books";
 import { bookOutlineSchema, type BookOutline } from "@/ai/schemas";
 import { OutlineApprovalBar } from "@/components/generation/outline-approval-bar";
+import { OutlineEditor } from "@/components/studio/outline-editor";
 
 function words(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
@@ -66,10 +67,14 @@ export default async function OutlinePage({ params }: { params: Promise<{ projec
     <div className="space-y-4">
       <header className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="font-display text-xl font-semibold tracking-tight">Outline</h2>
-        <p className="font-mono text-xs text-muted-foreground tabular-nums">
-          v{outlineRow?.version ?? 1} · {outline.chapters.length} chapters · ~{words(plannedWords)}{" "}
-          words planned
-        </p>
+        <div className="flex items-center gap-3">
+          <p className="font-mono text-xs text-muted-foreground tabular-nums">
+            v{outlineRow?.version ?? 1}
+            {outlineRow?.source === "user" ? " (edited)" : ""} · {outline.chapters.length} chapters
+            · ~{words(plannedWords)} words planned
+          </p>
+          {!awaitingApproval ? <OutlineEditor projectId={projectId} outline={outline} /> : null}
+        </div>
       </header>
 
       <article className="paper-surface px-6 py-8 sm:px-10 sm:py-10">

--- a/src/app/api/projects/[projectId]/cover/route.ts
+++ b/src/app/api/projects/[projectId]/cover/route.ts
@@ -6,7 +6,12 @@ import { gatewayOptions, metered } from "@/ai/metering";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
 import { requireUser, UnauthorizedError } from "@/lib/auth";
-import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
+import {
+  assertCreditsForUsd,
+  creditsForUsd,
+  grantCredits,
+  InsufficientCreditsError,
+} from "@/lib/billing/credits";
 import { MODEL_PRICING } from "@/lib/billing/pricing";
 
 /**
@@ -84,37 +89,55 @@ export async function POST(_req: Request, ctx: { params: Promise<{ projectId: st
       }),
   );
 
-  const file = result.files.find((f) => f.mediaType?.startsWith("image/"));
-  if (!file) {
-    return Response.json({ error: "The image model returned no image" }, { status: 502 });
+  // From here the user has already been debited (metered() charged the model
+  // call). Any failure to actually deliver a cover refunds that debit — a
+  // charge with nothing to show for it is the one outcome we never allow.
+  async function refundAndFail(message: string): Promise<Response> {
+    await grantCredits({
+      userId,
+      credits: creditsForUsd(COVER_USD),
+      description: "Cover generation failed after billing — refunded",
+      externalRef: `cover-refund:${crypto.randomUUID()}`,
+      kind: "grant",
+    });
+    return Response.json({ error: message }, { status: 502 });
   }
 
-  const contentType = file.mediaType ?? "image/png";
-  const blob = await put(
-    `covers/${projectId}/${crypto.randomUUID()}.png`,
-    Buffer.from(file.uint8Array),
-    { access: "public", contentType },
-  );
+  const file = result.files.find((f) => f.mediaType?.startsWith("image/"));
+  if (!file) {
+    return refundAndFail("The image model returned no image");
+  }
 
-  await db.insert(schema.assets).values({
-    projectId,
-    kind: "cover",
-    blobUrl: blob.url,
-    blobPathname: blob.pathname,
-    contentType,
-    sizeBytes: file.uint8Array.byteLength,
-    meta: { title: row.title },
-  });
+  try {
+    const contentType = file.mediaType ?? "image/png";
+    const blob = await put(
+      `covers/${projectId}/${crypto.randomUUID()}.png`,
+      Buffer.from(file.uint8Array),
+      { access: "public", contentType },
+    );
 
-  // The cover URL rides in front_matter next to the author byline, so the
-  // exports and reading view read one place for the book's identity.
-  await db
-    .update(schema.books)
-    .set({
-      frontMatter: { ...(row.frontMatter as Record<string, unknown>), coverUrl: blob.url },
-      updatedAt: new Date(),
-    })
-    .where(eq(schema.books.id, row.bookId));
+    await db.insert(schema.assets).values({
+      projectId,
+      kind: "cover",
+      blobUrl: blob.url,
+      blobPathname: blob.pathname,
+      contentType,
+      sizeBytes: file.uint8Array.byteLength,
+      meta: { title: row.title },
+    });
 
-  return Response.json({ url: blob.url });
+    // The cover URL rides in front_matter next to the author byline, so the
+    // exports and reading view read one place for the book's identity.
+    await db
+      .update(schema.books)
+      .set({
+        frontMatter: { ...(row.frontMatter as Record<string, unknown>), coverUrl: blob.url },
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.books.id, row.bookId));
+
+    return Response.json({ url: blob.url });
+  } catch {
+    return refundAndFail("Could not store the cover");
+  }
 }

--- a/src/app/api/projects/[projectId]/cover/route.ts
+++ b/src/app/api/projects/[projectId]/cover/route.ts
@@ -1,0 +1,120 @@
+import { put } from "@vercel/blob";
+import { generateText } from "ai";
+import { and, eq } from "drizzle-orm";
+
+import { gatewayOptions, metered } from "@/ai/metering";
+import { MODELS, type QualityTier } from "@/ai/models";
+import { getDb, schema } from "@/db";
+import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
+import { MODEL_PRICING } from "@/lib/billing/pricing";
+
+/**
+ * Generates a book cover from the book's own identity — title, synopsis,
+ * genre — and stores it as the project's cover asset. On demand only, priced
+ * like every other image call, metered into llm_calls.
+ */
+
+export const maxDuration = 120;
+
+const COVER_USD = MODEL_PRICING["google/gemini-3.1-flash-image"]?.perImageUsd ?? 0.067;
+
+function coverPrompt(input: { title: string; synopsis: string | null; genre: string | null }) {
+  return [
+    `Book cover illustration for "${input.title}".`,
+    input.genre ? `Genre: ${input.genre}.` : "",
+    input.synopsis ? `The story: ${input.synopsis}` : "",
+    `Portrait orientation, strong single focal image, atmospheric literary illustration,`,
+    `painterly, muted palette, space at the top third where a title would sit.`,
+    `No text, no lettering, no watermark, no borders.`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export async function POST(_req: Request, ctx: { params: Promise<{ projectId: string }> }) {
+  let userId: string;
+  try {
+    ({ userId } = await requireUser());
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  const { projectId } = await ctx.params;
+  const db = getDb();
+  const [row] = await db
+    .select({
+      bookId: schema.books.id,
+      title: schema.books.title,
+      synopsis: schema.books.synopsis,
+      frontMatter: schema.books.frontMatter,
+      genre: schema.projects.genre,
+      settings: schema.projects.settings,
+    })
+    .from(schema.books)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
+    .limit(1);
+  if (!row) return Response.json({ error: "Book not found" }, { status: 404 });
+
+  try {
+    await assertCreditsForUsd(userId, COVER_USD);
+  } catch (error) {
+    if (error instanceof InsufficientCreditsError) {
+      return Response.json({ error: "Not enough credits" }, { status: 402 });
+    }
+    throw error;
+  }
+
+  const tier: QualityTier = row.settings.qualityTier ?? "standard";
+  const model = MODELS[tier].image;
+  const meter = { userId, projectId };
+
+  const result = await metered(
+    meter,
+    { role: "content-tool", operation: "cover.generate", model },
+    () =>
+      generateText({
+        model,
+        prompt: coverPrompt(row),
+        providerOptions: gatewayOptions(meter, "content-tool"),
+      }),
+  );
+
+  const file = result.files.find((f) => f.mediaType?.startsWith("image/"));
+  if (!file) {
+    return Response.json({ error: "The image model returned no image" }, { status: 502 });
+  }
+
+  const contentType = file.mediaType ?? "image/png";
+  const blob = await put(
+    `covers/${projectId}/${crypto.randomUUID()}.png`,
+    Buffer.from(file.uint8Array),
+    { access: "public", contentType },
+  );
+
+  await db.insert(schema.assets).values({
+    projectId,
+    kind: "cover",
+    blobUrl: blob.url,
+    blobPathname: blob.pathname,
+    contentType,
+    sizeBytes: file.uint8Array.byteLength,
+    meta: { title: row.title },
+  });
+
+  // The cover URL rides in front_matter next to the author byline, so the
+  // exports and reading view read one place for the book's identity.
+  await db
+    .update(schema.books)
+    .set({
+      frontMatter: { ...(row.frontMatter as Record<string, unknown>), coverUrl: blob.url },
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.books.id, row.bookId));
+
+  return Response.json({ url: blob.url });
+}

--- a/src/components/editor/editor-shell.tsx
+++ b/src/components/editor/editor-shell.tsx
@@ -860,6 +860,7 @@ export function EditorShell({
           <HistoryPanel
             chapterId={chapterId}
             getCurrentContent={() => (editor ? serializeDoc(editor.state.doc) : "")}
+            flush={() => autosave.flush()}
             onRestored={(content, version) => {
               editor?.commands.setContent(content);
               autosave.markSynced(version);

--- a/src/components/editor/editor-shell.tsx
+++ b/src/components/editor/editor-shell.tsx
@@ -18,7 +18,7 @@ import type { Node as PMNode } from "@tiptap/pm/model";
 import StarterKit from "@tiptap/starter-kit";
 import CharacterCount from "@tiptap/extension-character-count";
 import { Markdown } from "tiptap-markdown";
-import { BookOpen } from "lucide-react";
+import { BookOpen, Search } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -52,6 +52,8 @@ import { mermaidCodeBlockView } from "./mermaid-code-block-view";
 import { ReviewPanel } from "./review-panel";
 import { SelectionToolbar, type ContentToolId } from "./selection-toolbar";
 import { StatusBar } from "./status-bar";
+import { HistoryPanel } from "./history-panel";
+import { FindReplace } from "./find-replace";
 import { SuggestionCard } from "./suggestion-card";
 import {
   getSuggestionItems,
@@ -193,6 +195,7 @@ export function EditorShell({
   const [busy, setBusy] = useState<Busy>(null);
   const [conflict, setConflict] = useState<{ currentVersion: number } | null>(null);
   const [reviewOpen, setReviewOpen] = useState(false);
+  const [findOpen, setFindOpen] = useState(false);
   const [, forceLayout] = useReducer((n: number) => n + 1, 0);
 
   const [paperEl, setPaperEl] = useState<HTMLDivElement | null>(null);
@@ -657,6 +660,7 @@ export function EditorShell({
   }, [pathname, router, zen]);
 
   // Keyboard: ⌘S save, ⌘⏎ accept active, ⌘⌫ reject active, Esc exits zen/card.
+  const openFind = useCallback(() => setFindOpen(true), []);
   const keysRef = useRef({
     zen,
     activeId,
@@ -664,6 +668,7 @@ export function EditorShell({
     acceptSuggestion,
     rejectSuggestion,
     dismissCard,
+    openFind,
   });
   useEffect(() => {
     keysRef.current = {
@@ -673,6 +678,7 @@ export function EditorShell({
       acceptSuggestion,
       rejectSuggestion,
       dismissCard,
+      openFind,
     };
   });
   useEffect(() => {
@@ -685,6 +691,11 @@ export function EditorShell({
       if (mod && event.key.toLowerCase() === "s") {
         event.preventDefault();
         void autosaveRef.current.flush();
+        return;
+      }
+      if (mod && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        keysRef.current.openFind();
         return;
       }
       if (mod && event.key === "Enter" && k.activeId) {
@@ -764,11 +775,12 @@ export function EditorShell({
 
           {/* Keyboard help, announced when focus enters the manuscript. */}
           <p id={shortcutsId} className="sr-only">
-            Rich text editor. Select a passage and press Tab to reach the AI editing tools. Press
-            Control or Command S to save. When a suggestion is selected, press Control or Command
-            Enter to accept it and Control or Command Backspace to reject it. Press Escape to close
-            a suggestion or leave zen mode. Every suggestion is also listed in the suggestions
-            panel.
+            Rich text editor. Select a passage and press Tab to reach the AI editing tools,
+            including Diagram this and Illustrate this under More tools. Press Control or Command S
+            to save, and Control or Command F to find and replace. When a suggestion is selected,
+            press Control or Command Enter to accept it and Control or Command Backspace to reject
+            it. Press Escape to close a suggestion, the find bar, or zen mode. Every suggestion is
+            also listed in the suggestions panel, and past versions are in the History dialog.
           </p>
 
           <EditorContent editor={editor} />
@@ -834,13 +846,38 @@ export function EditorShell({
       zen={zen}
       onToggleZen={toggleZen}
       onOpenReview={!zen && !isXl ? () => setReviewOpen(true) : undefined}
+      extras={
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            aria-label="Find and replace (⌘F)"
+            onClick={() => setFindOpen((prev) => !prev)}
+          >
+            <Search aria-hidden="true" className="size-3.5" />
+          </Button>
+          <HistoryPanel
+            chapterId={chapterId}
+            getCurrentContent={() => (editor ? serializeDoc(editor.state.doc) : "")}
+            onRestored={(content, version) => {
+              editor?.commands.setContent(content);
+              autosave.markSynced(version);
+            }}
+          />
+        </>
+      }
     />
   );
+
+  const findBar =
+    findOpen && editor ? <FindReplace editor={editor} onClose={() => setFindOpen(false)} /> : null;
 
   return (
     <>
       {zen ? (
         <div ref={zenRef} className="fixed inset-0 z-50 flex flex-col bg-background">
+          {findBar}
           <div className="min-h-0 flex-1 overflow-hidden">{canvas}</div>
           {statusBar}
         </div>
@@ -857,7 +894,12 @@ export function EditorShell({
                 />
               </ResizablePanel>
               <ResizableHandle />
-              <ResizablePanel minSize={360}>{canvas}</ResizablePanel>
+              <ResizablePanel minSize={360}>
+                <div className="flex h-full min-h-0 flex-col">
+                  {findBar}
+                  <div className="min-h-0 flex-1">{canvas}</div>
+                </div>
+              </ResizablePanel>
               {isXl ? (
                 <>
                   <ResizableHandle />

--- a/src/components/editor/find-replace.tsx
+++ b/src/components/editor/find-replace.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Editor } from "@tiptap/react";
+import { ChevronDown, ChevronUp, Replace, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/**
+ * Chapter-scoped find & replace, operating directly on the ProseMirror doc.
+ *
+ * Matches are located by walking text nodes (positions stay valid because
+ * every replace is a single transaction and the list is recomputed after).
+ * Case-insensitive, plain text — writers search for phrases, not regexes.
+ */
+
+type Match = { from: number; to: number };
+
+function findMatches(editor: Editor, query: string): Match[] {
+  if (!query) return [];
+  const needle = query.toLowerCase();
+  const matches: Match[] = [];
+  editor.state.doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    const haystack = node.text.toLowerCase();
+    let index = haystack.indexOf(needle);
+    while (index !== -1) {
+      matches.push({ from: pos + index, to: pos + index + query.length });
+      index = haystack.indexOf(needle, index + 1);
+    }
+  });
+  return matches;
+}
+
+export function FindReplace({ editor, onClose }: { editor: Editor; onClose: () => void }) {
+  const [query, setQuery] = useState("");
+  const [replacement, setReplacement] = useState("");
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [current, setCurrent] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const refresh = useCallback(
+    (nextQuery: string, keepIndex = false) => {
+      const found = findMatches(editor, nextQuery);
+      setMatches(found);
+      setCurrent((prev) => (keepIndex ? Math.min(prev, Math.max(found.length - 1, 0)) : 0));
+      return found;
+    },
+    [editor],
+  );
+
+  const jumpTo = useCallback(
+    (match: Match | undefined) => {
+      if (!match) return;
+      editor.chain().setTextSelection(match).scrollIntoView().run();
+    },
+    [editor],
+  );
+
+  function search(next: string) {
+    setQuery(next);
+    const found = refresh(next);
+    jumpTo(found[0]);
+  }
+
+  function step(direction: 1 | -1) {
+    if (matches.length === 0) return;
+    const next = (current + direction + matches.length) % matches.length;
+    setCurrent(next);
+    jumpTo(matches[next]);
+  }
+
+  function replaceCurrent() {
+    const match = matches[current];
+    if (!match) return;
+    editor.chain().insertContentAt(match, replacement).run();
+    const found = refresh(query, true);
+    jumpTo(found[Math.min(current, found.length - 1)]);
+  }
+
+  function replaceAll() {
+    // Back to front, so earlier positions stay valid within one pass.
+    const all = [...findMatches(editor, query)].reverse();
+    if (all.length === 0) return;
+    let chain = editor.chain();
+    for (const match of all) {
+      chain = chain.insertContentAt(match, replacement);
+    }
+    chain.run();
+    refresh(query);
+  }
+
+  return (
+    <div
+      role="search"
+      aria-label="Find and replace in this chapter"
+      className="flex flex-wrap items-center gap-2 border-b border-border bg-card px-3 py-2"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          onClose();
+          editor.commands.focus();
+        }
+        if (event.key === "Enter" && event.target === inputRef.current) {
+          event.preventDefault();
+          step(event.shiftKey ? -1 : 1);
+        }
+      }}
+    >
+      <Input
+        ref={inputRef}
+        value={query}
+        onChange={(event) => search(event.target.value)}
+        placeholder="Find…"
+        aria-label="Find"
+        className="h-7 w-40 text-xs"
+      />
+      <span className="font-mono text-[11px] text-muted-foreground tabular-nums" role="status">
+        {query ? `${matches.length === 0 ? 0 : current + 1}/${matches.length}` : ""}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7"
+        aria-label="Previous match"
+        disabled={matches.length === 0}
+        onClick={() => step(-1)}
+      >
+        <ChevronUp aria-hidden="true" className="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7"
+        aria-label="Next match"
+        disabled={matches.length === 0}
+        onClick={() => step(1)}
+      >
+        <ChevronDown aria-hidden="true" className="size-3.5" />
+      </Button>
+      <Input
+        value={replacement}
+        onChange={(event) => setReplacement(event.target.value)}
+        placeholder="Replace with…"
+        aria-label="Replace with"
+        className="h-7 w-40 text-xs"
+      />
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2 text-xs"
+        disabled={matches.length === 0}
+        onClick={replaceCurrent}
+      >
+        <Replace aria-hidden="true" className="size-3.5" />
+        Replace
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2 text-xs"
+        disabled={matches.length === 0}
+        onClick={replaceAll}
+      >
+        Replace all
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="ml-auto size-7"
+        aria-label="Close find and replace"
+        onClick={() => {
+          onClose();
+          editor.commands.focus();
+        }}
+      >
+        <X aria-hidden="true" className="size-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/editor/find-replace.tsx
+++ b/src/components/editor/find-replace.tsx
@@ -27,7 +27,9 @@ function findMatches(editor: Editor, query: string): Match[] {
     let index = haystack.indexOf(needle);
     while (index !== -1) {
       matches.push({ from: pos + index, to: pos + index + query.length });
-      index = haystack.indexOf(needle, index + 1);
+      // Non-overlapping, like every editor: the next search starts after the
+      // match, which is also what keeps replace-all ranges disjoint.
+      index = haystack.indexOf(needle, index + query.length);
     }
   });
   return matches;

--- a/src/components/editor/history-panel.tsx
+++ b/src/components/editor/history-panel.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { History, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { listChapterRevisions, restoreChapterRevision } from "@/lib/actions/chapters";
+import { wordDiff } from "@/lib/editor/word-diff";
+
+type Revision = {
+  id: string;
+  content: string;
+  source: string;
+  createdAt: Date;
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  user: "Manual save",
+  regenerate: "Before regeneration",
+  "pre-restore": "Before a restore",
+  suggestion: "Suggestion applied",
+  workflow: "Generated",
+};
+
+function timestamp(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+/**
+ * The chapter's saved history: every snapshot the autosaver, suggestion
+ * pipeline, or regeneration recorded, each viewable as a word diff against
+ * today's text and restorable in one click. Restoring snapshots the current
+ * text first, so nothing is ever lost by looking around.
+ */
+export function HistoryPanel({
+  chapterId,
+  getCurrentContent,
+  onRestored,
+}: {
+  chapterId: string;
+  /** Called when the dialog opens; serializing the doc per keystroke would be waste. */
+  getCurrentContent: () => string;
+  onRestored: (content: string, version: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [currentContent, setCurrentContent] = useState("");
+  const [revisions, setRevisions] = useState<Revision[] | null>(null);
+  const [selected, setSelected] = useState<Revision | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const rows = await listChapterRevisions(chapterId);
+        if (!cancelled) {
+          setRevisions(rows);
+          setSelected(rows[0] ?? null);
+        }
+      } catch {
+        if (!cancelled) setError("Could not load the history");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, chapterId]);
+
+  function restore(revision: Revision) {
+    setError(null);
+    startTransition(async () => {
+      const result = await restoreChapterRevision(chapterId, revision.id);
+      if (result.ok) {
+        onRestored(revision.content, result.version);
+        setOpen(false);
+      } else {
+        setError("Could not restore this revision");
+      }
+    });
+  }
+
+  const diff = selected ? wordDiff(currentContent, selected.content) : [];
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Snapshot the doc at open time — an event handler, not an effect, so
+        // there is no render cascade and the diff base is stable for the visit.
+        if (next) setCurrentContent(getCurrentContent());
+        setOpen(next);
+        if (!next) {
+          setRevisions(null);
+          setSelected(null);
+          setError(null);
+        }
+      }}
+    >
+      <DialogTrigger render={<Button variant="ghost" size="sm" aria-label="Chapter history" />}>
+        <History aria-hidden="true" className="size-3.5" />
+        History
+      </DialogTrigger>
+      <DialogContent className="max-h-[80dvh] sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Chapter history</DialogTitle>
+          <DialogDescription>
+            Saved snapshots of this chapter. Restoring keeps a copy of today&rsquo;s text, so
+            nothing is lost by looking around.
+          </DialogDescription>
+        </DialogHeader>
+
+        {revisions === null && !error ? (
+          <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+            <Loader2 aria-hidden="true" className="size-4 animate-spin" /> Loading history…
+          </div>
+        ) : null}
+        {error ? (
+          <p role="alert" className="py-4 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+        {revisions?.length === 0 ? (
+          <p className="py-6 text-sm text-muted-foreground">
+            No snapshots yet — the history fills in as you write and edit.
+          </p>
+        ) : null}
+
+        {revisions && revisions.length > 0 ? (
+          <div className="grid min-h-0 gap-4 sm:grid-cols-[14rem_minmax(0,1fr)]">
+            <ul
+              aria-label="Revisions"
+              className="max-h-[50dvh] space-y-1 overflow-y-auto pr-1 text-sm"
+            >
+              {revisions.map((revision) => (
+                <li key={revision.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelected(revision)}
+                    aria-pressed={selected?.id === revision.id}
+                    className={`w-full rounded-md px-2 py-1.5 text-left transition-colors ${
+                      selected?.id === revision.id
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-accent/60"
+                    }`}
+                  >
+                    <span className="block font-medium">
+                      {SOURCE_LABELS[revision.source] ?? revision.source}
+                    </span>
+                    <span className="block font-mono text-[11px] text-muted-foreground">
+                      {timestamp(revision.createdAt)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex min-h-0 flex-col gap-3">
+              <div
+                aria-label="Difference against the current text"
+                className="max-h-[44dvh] overflow-y-auto rounded-md border border-border bg-muted/30 p-3 font-serif text-sm leading-relaxed"
+              >
+                {diff.map((part, i) =>
+                  part.type === "same" ? (
+                    <span key={i}>{part.text}</span>
+                  ) : part.type === "del" ? (
+                    // Deleted relative to the revision = present today only.
+                    <del key={i} className="bg-destructive/15 text-destructive no-underline">
+                      {part.text}
+                    </del>
+                  ) : (
+                    <ins key={i} className="bg-ai-soft text-ai no-underline">
+                      {part.text}
+                    </ins>
+                  ),
+                )}
+              </div>
+              {selected ? (
+                <Button onClick={() => restore(selected)} disabled={pending} className="self-end">
+                  {pending ? <Loader2 aria-hidden="true" className="size-4 animate-spin" /> : null}
+                  {pending ? "Restoring…" : "Restore this version"}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/editor/history-panel.tsx
+++ b/src/components/editor/history-panel.tsx
@@ -48,11 +48,18 @@ function timestamp(value: Date): string {
 export function HistoryPanel({
   chapterId,
   getCurrentContent,
+  flush,
   onRestored,
 }: {
   chapterId: string;
   /** Called when the dialog opens; serializing the doc per keystroke would be waste. */
   getCurrentContent: () => string;
+  /**
+   * Flushes unsaved editor content to the server. Restore calls this first so
+   * the server-side pre-restore snapshot captures what the author actually
+   * sees, not the last autosave.
+   */
+  flush: () => Promise<boolean>;
   onRestored: (content: string, version: number) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -84,6 +91,8 @@ export function HistoryPanel({
   function restore(revision: Revision) {
     setError(null);
     startTransition(async () => {
+      // Unsaved keystrokes must reach the server before the snapshot happens.
+      await flush();
       const result = await restoreChapterRevision(chapterId, revision.id);
       if (result.ok) {
         onRestored(revision.content, result.version);

--- a/src/components/editor/status-bar.tsx
+++ b/src/components/editor/status-bar.tsx
@@ -2,7 +2,15 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useEditorState, type Editor } from "@tiptap/react";
-import { AlertTriangle, Check, Maximize2, MessageSquareText, Minimize2 } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  Maximize2,
+  MessageSquareText,
+  Minimize2,
+  Redo2,
+  Undo2,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -82,6 +90,7 @@ export function StatusBar({
   zen,
   onToggleZen,
   onOpenReview,
+  extras,
 }: {
   editor: Editor | null;
   saveState: SaveState;
@@ -89,12 +98,21 @@ export function StatusBar({
   pendingCount: number;
   zen: boolean;
   onToggleZen: () => void;
+  /** Slot for chapter-scoped tools (history, find & replace). */
+  extras?: React.ReactNode;
   /** Present when the review panel is hidden (<xl) — opens it as a sheet. */
   onOpenReview?: () => void;
 }) {
   const words = useEditorState({
     editor,
     selector: (ctx) => (ctx.editor?.storage.characterCount.words() as number | undefined) ?? 0,
+  });
+  const historyState = useEditorState({
+    editor,
+    selector: (ctx) => ({
+      canUndo: ctx.editor?.can().undo() ?? false,
+      canRedo: ctx.editor?.can().redo() ?? false,
+    }),
   });
   const wordCount = words ?? 0;
   const readingMinutes = Math.max(1, Math.round(wordCount / READING_WPM));
@@ -114,6 +132,41 @@ export function StatusBar({
         </p>
 
         <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  aria-label="Undo"
+                  disabled={!historyState?.canUndo}
+                  onClick={() => editor?.chain().focus().undo().run()}
+                />
+              }
+            >
+              <Undo2 aria-hidden="true" className="size-3.5" />
+            </TooltipTrigger>
+            <TooltipContent side="top">Undo (⌘Z)</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  aria-label="Redo"
+                  disabled={!historyState?.canRedo}
+                  onClick={() => editor?.chain().focus().redo().run()}
+                />
+              }
+            >
+              <Redo2 aria-hidden="true" className="size-3.5" />
+            </TooltipTrigger>
+            <TooltipContent side="top">Redo (⌘⇧Z)</TooltipContent>
+          </Tooltip>
+          {extras}
           {onOpenReview ? (
             <Button
               variant="ghost"

--- a/src/components/manuscript/cover-button.tsx
+++ b/src/components/manuscript/cover-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ImagePlus, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/** Generates (or replaces) the book cover. Priced per image, on demand only. */
+export function CoverButton({ projectId, hasCover }: { projectId: string; hasCover: boolean }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function generate() {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/projects/${projectId}/cover`, { method: "POST" });
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      if (!response.ok) {
+        setError(body.error ?? "Could not generate a cover");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Could not generate a cover");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="inline-flex flex-col items-start gap-1">
+      <Button variant="ghost" size="sm" onClick={generate} disabled={busy}>
+        {busy ? (
+          <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+        ) : (
+          <ImagePlus aria-hidden="true" className="size-3.5" />
+        )}
+        {busy ? "Painting…" : hasCover ? "New cover · $0.067" : "Generate cover · $0.067"}
+      </Button>
+      {error ? (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/studio/command-palette.tsx
+++ b/src/components/studio/command-palette.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+/**
+ * ⌘K navigation. Global destinations always; project stages appear when the
+ * current URL is inside a project. Actions stay in their own surfaces — the
+ * palette only ever navigates, so it can never surprise.
+ */
+/** usePathname must sit under Suspense with cacheComponents (see stage-nav). */
+export function CommandPalette() {
+  return (
+    <Suspense fallback={null}>
+      <CommandPaletteInner />
+    </Suspense>
+  );
+}
+
+function CommandPaletteInner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const projectMatch = pathname?.match(/^\/projects\/([^/]+)/);
+  const projectId = projectMatch?.[1];
+
+  function go(href: string) {
+    setOpen(false);
+    router.push(href as Route);
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen} title="Go to" description="Jump anywhere">
+      <CommandInput placeholder="Where to?" />
+      <CommandList>
+        <CommandEmpty>Nothing matches.</CommandEmpty>
+        <CommandGroup heading="Studio">
+          <CommandItem onSelect={() => go("/studio")}>Your books</CommandItem>
+          <CommandItem onSelect={() => go("/studio/new")}>Start a new book</CommandItem>
+          <CommandItem onSelect={() => go("/studio/credits")}>Credits</CommandItem>
+          <CommandItem onSelect={() => go("/studio/usage")}>Usage</CommandItem>
+          <CommandItem onSelect={() => go("/studio/settings")}>Settings</CommandItem>
+        </CommandGroup>
+        {projectId ? (
+          <CommandGroup heading="This book">
+            <CommandItem onSelect={() => go(`/projects/${projectId}/brief`)}>Brief</CommandItem>
+            <CommandItem onSelect={() => go(`/projects/${projectId}/outline`)}>Outline</CommandItem>
+            <CommandItem onSelect={() => go(`/projects/${projectId}/bible`)}>
+              Story bible
+            </CommandItem>
+            <CommandItem onSelect={() => go(`/projects/${projectId}/write`)}>Write</CommandItem>
+            <CommandItem onSelect={() => go(`/projects/${projectId}/editor`)}>Editor</CommandItem>
+            <CommandItem onSelect={() => go(`/projects/${projectId}/manuscript`)}>
+              Manuscript
+            </CommandItem>
+            <CommandItem onSelect={() => go(`/projects/${projectId}/settings`)}>
+              Project settings
+            </CommandItem>
+          </CommandGroup>
+        ) : null}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/studio/outline-editor.tsx
+++ b/src/components/studio/outline-editor.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Pencil } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { BookOutline } from "@/ai/schemas";
+import { saveOutline } from "@/lib/actions/outline";
+
+/**
+ * Author editing for the outline's chapter titles and summaries — the fields
+ * regeneration actually reads. Structural fields (hooks, arcs, key events)
+ * stay as the agents wrote them; a save appends a new outline version with
+ * source "user", never overwriting the original.
+ */
+export function OutlineEditor({ projectId, outline }: { projectId: string; outline: BookOutline }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(outline);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  if (!editing) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setDraft(outline);
+          setEditing(true);
+        }}
+      >
+        <Pencil aria-hidden="true" className="size-3.5" />
+        Edit the outline
+      </Button>
+    );
+  }
+
+  function patchChapter(index: number, patch: Partial<BookOutline["chapters"][number]>) {
+    setDraft((prev) => ({
+      ...prev,
+      chapters: prev.chapters.map((chapter, i) =>
+        i === index ? { ...chapter, ...patch } : chapter,
+      ),
+    }));
+  }
+
+  function submit() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await saveOutline(projectId, draft);
+        setEditing(false);
+      } catch (cause) {
+        setError(
+          cause instanceof Error && cause.message.includes("current run")
+            ? cause.message
+            : "Could not save the outline — try again.",
+        );
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border border-border bg-card p-4">
+      <p className="text-sm text-muted-foreground">
+        Edits apply to future writing — regenerating a chapter follows the outline you leave here.
+        The agents&rsquo; original version stays in the outline history.
+      </p>
+      <ol className="space-y-4">
+        {draft.chapters.map((chapter, index) => (
+          <li key={chapter.number} className="space-y-1.5">
+            <label
+              htmlFor={`ol-title-${chapter.number}`}
+              className="font-mono text-xs text-muted-foreground"
+            >
+              Chapter {chapter.number}
+            </label>
+            <Input
+              id={`ol-title-${chapter.number}`}
+              value={chapter.title}
+              maxLength={300}
+              onChange={(event) => patchChapter(index, { title: event.target.value })}
+            />
+            <Textarea
+              aria-label={`Chapter ${chapter.number} summary`}
+              value={chapter.summary}
+              rows={3}
+              maxLength={2000}
+              onChange={(event) => patchChapter(index, { summary: event.target.value })}
+            />
+          </li>
+        ))}
+      </ol>
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+      <div className="flex gap-2">
+        <Button onClick={submit} disabled={pending}>
+          {pending ? "Saving…" : "Save outline"}
+        </Button>
+        <Button variant="outline" onClick={() => setEditing(false)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/studio/outline-editor.tsx
+++ b/src/components/studio/outline-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { Pencil } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,7 @@ import { saveOutline } from "@/lib/actions/outline";
  * source "user", never overwriting the original.
  */
 export function OutlineEditor({ projectId, outline }: { projectId: string; outline: BookOutline }) {
+  const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(outline);
   const [pending, startTransition] = useTransition();
@@ -52,6 +54,10 @@ export function OutlineEditor({ projectId, outline }: { projectId: string; outli
       try {
         await saveOutline(projectId, draft);
         setEditing(false);
+        // Refresh so the props reflect the saved version — otherwise reopening
+        // the editor would start from stale data and a second save could undo
+        // this one.
+        router.refresh();
       } catch (cause) {
         setError(
           cause instanceof Error && cause.message.includes("current run")

--- a/src/lib/actions/chapters.ts
+++ b/src/lib/actions/chapters.ts
@@ -239,3 +239,64 @@ export async function moveChapter(chapterId: string, direction: "up" | "down"): 
   `);
   revalidatePath(`/projects/${ownership.projectId}`);
 }
+
+/** Revision history for the editor's History panel, newest first. */
+export async function listChapterRevisions(chapterId: string) {
+  const { userId } = await requireUser();
+  if (!z.uuid().safeParse(chapterId).success) throw new Error("Chapter not found");
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) throw new Error("Chapter not found");
+
+  return getDb()
+    .select({
+      id: schema.chapterRevisions.id,
+      content: schema.chapterRevisions.content,
+      source: schema.chapterRevisions.source,
+      createdAt: schema.chapterRevisions.createdAt,
+    })
+    .from(schema.chapterRevisions)
+    .where(eq(schema.chapterRevisions.chapterId, chapterId))
+    .orderBy(sql`${schema.chapterRevisions.createdAt} desc`)
+    .limit(30);
+}
+
+/**
+ * Restores a past revision by saving it as the newest content. Restoring is
+ * itself a save, so the pre-restore text lands in the history too — nothing is
+ * ever lost by restoring.
+ */
+export async function restoreChapterRevision(
+  chapterId: string,
+  revisionId: string,
+): Promise<SaveChapterResult> {
+  const { userId } = await requireUser();
+  if (!z.uuid().safeParse(revisionId).success) return { ok: false, error: "not_found" };
+  const ownership = await getChapterOwnership(chapterId);
+  if (!ownership || ownership.userId !== userId) return { ok: false, error: "not_found" };
+
+  const db = getDb();
+  const [revision] = await db
+    .select({ content: schema.chapterRevisions.content })
+    .from(schema.chapterRevisions)
+    .where(
+      and(
+        eq(schema.chapterRevisions.id, revisionId),
+        eq(schema.chapterRevisions.chapterId, chapterId),
+      ),
+    )
+    .limit(1);
+  if (!revision) return { ok: false, error: "not_found" };
+
+  const [current] = await db
+    .select({ content: schema.chapters.content, version: schema.chapters.version })
+    .from(schema.chapters)
+    .where(eq(schema.chapters.id, chapterId))
+    .limit(1);
+  if (!current) return { ok: false, error: "not_found" };
+
+  // Snapshot what is being replaced, then force-save the revision content.
+  await db
+    .insert(schema.chapterRevisions)
+    .values({ chapterId, content: current.content, source: "pre-restore" });
+  return saveChapter(chapterId, revision.content, current.version, { force: true });
+}

--- a/src/lib/actions/outline.ts
+++ b/src/lib/actions/outline.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
+import { requireUser } from "@/lib/auth";
+import { bookOutlineSchema } from "@/ai/schemas";
+
+/**
+ * Saves an author-edited outline as a new version with source "user" — the
+ * enum value that existed since the schema was written and was never used.
+ * Versions are append-only; the agents' original stays in the history.
+ */
+export async function saveOutline(projectId: string, input: unknown): Promise<void> {
+  const { userId } = await requireUser();
+  const outline = bookOutlineSchema.parse(input);
+
+  const db = getDb();
+  const [book] = await db
+    .select({ id: schema.books.id })
+    .from(schema.books)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .where(and(eq(schema.projects.id, projectId), eq(schema.projects.userId, userId)))
+    .limit(1);
+  if (!book) throw new Error("Book not found");
+
+  // An in-flight run reads the latest outline mid-stream; editing under it
+  // would hand different chapters different plans.
+  const [active] = await db
+    .select({ id: schema.generationRuns.id })
+    .from(schema.generationRuns)
+    .where(
+      and(
+        eq(schema.generationRuns.projectId, projectId),
+        inArray(schema.generationRuns.status, ["queued", "running"]),
+      ),
+    )
+    .limit(1);
+  if (active) throw new Error("Finish or stop the current run before editing the outline");
+
+  const [latest] = await db
+    .select({ version: schema.outlines.version })
+    .from(schema.outlines)
+    .where(eq(schema.outlines.bookId, book.id))
+    .orderBy(sql`${schema.outlines.version} desc`)
+    .limit(1);
+
+  await db.insert(schema.outlines).values({
+    bookId: book.id,
+    version: (latest?.version ?? 0) + 1,
+    content: outline,
+    source: "user",
+  });
+  revalidatePath(`/projects/${projectId}/outline`);
+}

--- a/src/lib/export/assemble.ts
+++ b/src/lib/export/assemble.ts
@@ -28,6 +28,8 @@ export type AssembledManuscript = {
   totalWords: number;
   /** Cached diagram/image renders, keyed by source hash or image URL. */
   figures: FigureMap;
+  /** Generated cover image, when the author made one. */
+  coverUrl: string | null;
 };
 
 export type ManuscriptSourceChapter = {
@@ -43,6 +45,7 @@ export function buildManuscript(input: {
   genre?: string | null;
   /** Author byline; falls back to the house line when unset. */
   author?: string | null;
+  coverUrl?: string | null;
   chapters: ManuscriptSourceChapter[];
   figures?: FigureMap;
 }): AssembledManuscript {
@@ -66,6 +69,7 @@ export function buildManuscript(input: {
     chapters,
     totalWords: chapters.reduce((sum, c) => sum + c.wordCount, 0),
     figures: input.figures ?? {},
+    coverUrl: input.coverUrl ?? null,
   };
 }
 
@@ -288,12 +292,13 @@ export async function loadManuscript(
     )
     .orderBy(schema.chapters.chapterNumber);
 
-  const author = (row.frontMatter as { author?: string } | null)?.author;
+  const front = row.frontMatter as { author?: string; coverUrl?: string } | null;
   return buildManuscript({
     title: row.bookTitle,
     synopsis: row.synopsis,
     genre: row.genre,
-    author,
+    author: front?.author,
+    coverUrl: front?.coverUrl,
     chapters,
     figures: await loadFigures(row.projectId),
   });

--- a/src/lib/export/epub.ts
+++ b/src/lib/export/epub.ts
@@ -53,6 +53,7 @@ export async function exportEpub(m: AssembledManuscript): Promise<ExportResult> 
     {
       title: m.title,
       author: m.author,
+      cover: m.coverUrl ?? undefined,
       description: m.synopsis ?? undefined,
       tocTitle: "Contents",
       prependChapterTitles: false,

--- a/src/lib/export/pdf.ts
+++ b/src/lib/export/pdf.ts
@@ -18,7 +18,20 @@ function pdfSafe(text: string): string {
     .replace(/[\u00a0\u2000-\u200b\u2028\u2029\u202f\u205f]/g, " ");
 }
 
+async function fetchCover(url: string | null): Promise<Buffer | null> {
+  if (!url) return null;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    return Buffer.from(await response.arrayBuffer());
+  } catch {
+    // A missing cover degrades to the plain title page, never a failed export.
+    return null;
+  }
+}
+
 export async function exportPdf(m: AssembledManuscript): Promise<ExportResult> {
+  const cover = await fetchCover(m.coverUrl);
   const doc = new PDFDocument({
     size: PAGE,
     margins: { top: MARGIN, bottom: MARGIN, left: MARGIN, right: MARGIN },
@@ -32,6 +45,12 @@ export async function exportPdf(m: AssembledManuscript): Promise<ExportResult> {
     doc.on("end", () => resolve(Buffer.concat(chunks)));
     doc.on("error", reject);
   });
+
+  // Cover, full-bleed on its own page, when one was generated.
+  if (cover) {
+    doc.image(cover, 0, 0, { cover: [PAGE[0], PAGE[1]], align: "center", valign: "center" });
+    doc.addPage();
+  }
 
   // Title page.
   doc.font(SERIF).fontSize(26).text(pdfSafe(m.title), MARGIN, 200, {


### PR DESCRIPTION
Fourth PR of the release sweep — the writing-tools layer.

## Revision history (visible at last)
`chapter_revisions` has been written to since launch — by the autosaver, the suggestion pipeline, and now regeneration — with **no way to see any of it**. A History dialog in the status bar lists snapshots, shows a word diff against the current text (reusing `word-diff.ts`), and restores in one click. Restoring snapshots the current text first, so browsing history can never lose work.

## Find & replace (⌘F)
Chapter-scoped, case-insensitive plain text. Matches come from walking ProseMirror text nodes directly; replace-all applies back-to-front so positions stay valid within a single transaction chain. Enter/Shift-Enter steps matches; Escape returns to the prose.

## Undo/redo + honest keyboard help
StarterKit's history was always active but had no visible affordance — buttons now sit in the status bar with live enabled-state. The sr-only keyboard help finally mentions the content tools, ⌘F, and History (it previously omitted "Diagram this"/"Illustrate this" entirely).

## ⌘K palette
`cmdk` was a dependency with zero imports. Now a navigation palette on the studio layout: studio destinations always, this-book stages when inside a project. Deliberately navigation-only. `usePathname` sits under Suspense per the cacheComponents rule (caught by the build, fixed the same way as `stage-nav`).

## Cover generation
Prompt built from the book's own identity (title, synopsis, genre), metered per image with the price on the button, stored via the Blob+assets path (`kind: "cover"` — in the enum since the rebuild, never used) with the URL in `books.front_matter` beside the author byline. Shown on the manuscript title page; **EPUB embeds it** via `epub-gen-memory`'s cover option; **PDF gets a full-bleed cover page**, degrading to the plain title page if the fetch fails rather than failing the export.

## Manual outline editing
Chapter titles and summaries are editable, saved as a new `outlines` version with `source: "user"` (the enum value that existed unused since the schema was written). Versions are append-only — the agents' original stays in history — and editing refuses while a run is active, since the workflow reads the latest outline mid-stream. The outline header shows "(edited)" on user versions, and regeneration follows whatever the author left.

## Verification
311 unit tests; local e2e 28/28 with the DB; typecheck/lint/format/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cover generation spends credits and writes book identity data; outline edits and revision restore change content that downstream generation and exports read, though both paths enforce auth and run-state guards.
> 
> **Overview**
> **Adds a batch of author-facing writing tools** across the studio editor, outline, manuscript, and exports.
> 
> The chapter editor gains **revision history** (list snapshots, word diff, one-click restore with a pre-restore backup), **find & replace** (⌘F, chapter-scoped plain text on the ProseMirror doc), and visible **undo/redo** in the status bar alongside History and find controls. Screen-reader shortcut help is updated to match.
> 
> A **⌘K command palette** on the studio layout provides navigation-only jumps to studio pages and, when inside a project, to each book stage.
> 
> **On-demand AI cover generation** charges credits via a new `POST` API (metered image model, Vercel Blob + `assets`), stores `coverUrl` in `front_matter`, shows the cover on the manuscript opening page, and threads it through **EPUB** and **PDF** export (PDF falls back if the image fetch fails).
> 
> The **outline page** lets authors edit chapter titles and summaries into a new append-only outline version (`source: "user"`), blocked while a generation run is active; the header marks user-edited versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d84dfda6cbd3a58cefb442ea8a0c7da681b4156. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->