### PR TITLE
Transactional email: book finished, paused for credits, purchase receipt

### DIFF
--- a/doc/CUTOVER.md
+++ b/doc/CUTOVER.md
@@ -119,12 +119,22 @@ orphaned. Safe to delete; left in place to avoid an unnecessary cascade.
 
 ## 2. Operator steps for launch
 
-- **support@sopher.ai** is now linked from the site footer and legal pages.
-  Set up Cloudflare Email Routing (dash → sopher.ai → Email → Email Routing →
-  route `support@sopher.ai` → your inbox). ~5 minutes, free tier.
-- **Stripe is still a sandbox** (test mode). Before taking real money:
-  `vercel integration resource claim sopher-payments`, then set
-  `STRIPE_WEBHOOK_SECRET` for the live-mode webhook endpoint and redeploy.
+- ~~support@sopher.ai email routing~~ — DONE 2026-07-29 (Cloudflare Email Routing).
+- ~~Stripe sandbox claim~~ — DONE 2026-07-29. Keys are still `sk_test_` until the
+  Stripe account completes activation; when live keys arrive, recreate the
+  fulfilment webhook in live mode (one command, creates the endpoint via the
+  API and pipes the secret straight into the env, never displaying it):
+
+  ```bash
+  vercel env pull /tmp/sk.txt --environment=production --yes
+  export STRIPE_SECRET_KEY=$(grep '^STRIPE_SECRET_KEY=' /tmp/sk.txt | cut -d= -f2- | tr -d '"') && rm /tmp/sk.txt
+  node -e 'const S=require("stripe");const s=new S(process.env.STRIPE_SECRET_KEY);s.webhookEndpoints.create({url:"https://sopher.ai/api/webhooks/stripe",enabled_events:["checkout.session.completed","charge.refunded"],description:"sopher.ai credits fulfilment"}).then(e=>process.stdout.write(e.secret))'     | vercel env add STRIPE_WEBHOOK_SECRET production --force
+  ```
+
+- **Resend** was linked manually (outside the Marketplace), so its key does not
+  auto-sync: create an API key at resend.com (Sending access) and
+  `printf "%s" "re_..." | vercel env add RESEND_API_KEY production preview development`.
+  Every email path no-ops safely until the key exists.
 - The legal pages (/terms, /privacy, /refunds) are honest drafts written for
   this product, **not legal advice** — have them reviewed before serious volume.
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-resizable-panels": "^4.12.2",
+    "resend": "^6.18.1",
     "shadcn": "^4.16.0",
     "sonner": "^2.0.7",
     "stripe": "^22.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.12.2
         version: 4.12.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      resend:
+        specifier: ^6.18.1
+        version: 6.18.1
       shadcn:
         specifier: ^4.16.0
         version: 4.16.0(typescript@5.9.3)
@@ -5550,6 +5553,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
+
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
@@ -5756,6 +5762,15 @@ packages:
 
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
+  resend@6.18.1:
+    resolution: {integrity: sha512-XN8XIaDdKF+ziSQ3K23ndUcyhP7U3ze2gky6SPgYkuAOq54mH4Wdhwm7QylEQ3zlz0NzdX7/l1AgmJUZbdPI/Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -12151,6 +12166,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.5: {}
+
   postcss-selector-parser@7.1.4:
     dependencies:
       cssesc: 3.0.0
@@ -12404,6 +12421,11 @@ snapshots:
   require-from-string@2.0.2: {}
 
   reselect@5.2.0: {}
+
+  resend@6.18.1:
+    dependencies:
+      postal-mime: 2.7.5
+      standardwebhooks: 1.0.0
 
   resolve-alpn@1.2.1: {}
 

--- a/src/app/(marketing)/refunds/page.tsx
+++ b/src/app/(marketing)/refunds/page.tsx
@@ -10,21 +10,24 @@ export const metadata: Metadata = {
 export default function RefundsPage() {
   return (
     <LegalPage title="Refund Policy" updated="July 29, 2026">
-      <p>Credits are prepaid, and the honest thing is to be precise about when money comes back.</p>
-
-      <h2>Unspent credits</h2>
       <p>
-        Credits you have purchased but not spent are refundable at face value (excluding any bonus
-        credits) within <strong>14 days</strong> of purchase — email{" "}
-        <a href="mailto:support@sopher.ai">support@sopher.ai</a> from your account address. Refunds
-        go back to the original payment method via Stripe, usually within 5–10 business days.
+        Credits are prepaid, and the honest thing is to be precise up front:{" "}
+        <strong>all credit purchases are final</strong>.
+      </p>
+
+      <h2>All sales are final</h2>
+      <p>
+        Credits — spent or unspent — are not refundable. Before you buy, the pricing page shows
+        exactly what a book costs, every account starts with free credits to try the product first,
+        and every run shows its estimate before anything is charged. Where local consumer law grants
+        you a mandatory withdrawal right, that law prevails.
       </p>
 
       <h2>Spent credits</h2>
       <p>
         Credits consumed by generation, editing, or image work paid for computation that already
-        ran, and are not refundable. This includes books you decide you do not like — AI output
-        varies, and the estimate shown before each run is how we keep that risk visible up front.
+        ran. This includes books you decide you do not like — AI output varies, and the estimate
+        shown before each run is how we keep that risk visible up front.
       </p>
 
       <h2>Failures on our side</h2>

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -60,8 +60,8 @@ export default function TermsPage() {
         </li>
         <li>Costs shown before a run are estimates; actual consumption is metered.</li>
         <li>
-          Credits are not transferable, have no cash value except as described in the refund policy,
-          and do not expire.
+          Credits are not transferable, have no cash value, do not expire, and — as set out in the
+          refund policy — are not refundable once purchased.
         </li>
         <li>Payments are processed by Stripe. We never see your card details.</li>
         <li>Refunds are governed by the refund policy, which is part of these terms.</li>
@@ -77,9 +77,9 @@ export default function TermsPage() {
       <h2>Termination</h2>
       <p>
         You can delete your account at any time. We may suspend or terminate accounts that break
-        these terms, with a refund of unspent credits unless the breach involves fraud or abuse. On
-        deletion, your projects and manuscripts are removed from our systems as described in the
-        privacy policy — export anything you want to keep first.
+        these terms. Unspent credits are not refunded on deletion or termination. On deletion, your
+        projects and manuscripts are removed from our systems as described in the privacy policy —
+        export anything you want to keep first.
       </p>
 
       <h2>Disclaimers and liability</h2>

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,10 @@
 import type Stripe from "stripe";
 
+import { eq } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
 import { grantCredits } from "@/lib/billing/credits";
+import { sendReceiptEmail } from "@/lib/email/send";
 import { getStripe, stripeConfigured } from "@/lib/payments/stripe";
 
 /**
@@ -64,6 +68,23 @@ export async function POST(req: Request) {
       description: `${packId} pack — ${credits} credits`,
       externalRef: session.id,
     });
+
+    // Receipt only on first fulfilment — a retried delivery must not re-mail.
+    if (granted) {
+      const [user] = await getDb()
+        .select({ email: schema.users.email })
+        .from(schema.users)
+        .where(eq(schema.users.id, userId))
+        .limit(1);
+      if (user?.email) {
+        await sendReceiptEmail({
+          to: user.email,
+          packName: packId,
+          credits,
+          usd: (session.amount_total ?? 0) / 100,
+        });
+      }
+    }
 
     return Response.json({ received: true, granted });
   }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -70,19 +70,25 @@ export async function POST(req: Request) {
     });
 
     // Receipt only on first fulfilment — a retried delivery must not re-mail.
+    // And never let the receipt path fail the response: a 500 here would make
+    // Stripe redeliver into the idempotent no-op, losing the receipt forever.
     if (granted) {
-      const [user] = await getDb()
-        .select({ email: schema.users.email })
-        .from(schema.users)
-        .where(eq(schema.users.id, userId))
-        .limit(1);
-      if (user?.email) {
-        await sendReceiptEmail({
-          to: user.email,
-          packName: packId,
-          credits,
-          usd: (session.amount_total ?? 0) / 100,
-        });
+      try {
+        const [user] = await getDb()
+          .select({ email: schema.users.email })
+          .from(schema.users)
+          .where(eq(schema.users.id, userId))
+          .limit(1);
+        if (user?.email) {
+          await sendReceiptEmail({
+            to: user.email,
+            packName: packId,
+            credits,
+            usd: (session.amount_total ?? 0) / 100,
+          });
+        }
+      } catch (error) {
+        console.warn("[email] receipt failed after grant:", error);
       }
     }
 

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -115,9 +115,7 @@ export async function sendReceiptEmail(input: {
       "Thanks — credits added.",
       p(
         `Your ${input.packName} purchase of <strong>${input.credits} credits</strong> ($${input.usd.toFixed(2)}) is on your balance now.`,
-      ) +
-        p(`Unspent credits are refundable within 14 days — just reply to this email.`) +
-        cta("https://sopher.ai/studio/credits", "View your balance"),
+      ) + cta("https://sopher.ai/studio/credits", "View your balance"),
     ),
   );
 }

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -1,0 +1,123 @@
+import { Resend } from "resend";
+
+/**
+ * Transactional email. Three messages exist, all triggered by things the user
+ * did: their book finished, their book paused for credits, they bought
+ * credits. No marketing, no digests, so there is no unsubscribe machinery —
+ * every mail is a receipt for an action.
+ *
+ * Degrades to a no-op when RESEND_API_KEY is absent (preview envs, local dev
+ * without the key), so email can never be the reason a workflow step fails —
+ * callers also catch, because a book that finished but couldn't say so is
+ * still a finished book.
+ */
+
+const FROM = "sopher.ai <no-reply@sopher.ai>";
+
+let client: Resend | null = null;
+
+function getResend(): Resend | null {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) return null;
+  if (!client) client = new Resend(key);
+  return client;
+}
+
+export const emailConfigured = () => Boolean(process.env.RESEND_API_KEY);
+
+function shell(title: string, bodyHtml: string): string {
+  return `<!doctype html>
+<html>
+  <body style="margin:0;padding:24px;background:#f7f6f3;font-family:Georgia,'Times New Roman',serif;color:#14161c;">
+    <div style="max-width:520px;margin:0 auto;background:#ffffff;border:1px solid #e2e0da;border-radius:10px;padding:32px;">
+      <p style="margin:0 0 4px;font-family:ui-monospace,Menlo,monospace;font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:#4a5fd0;">sopher.ai</p>
+      <h1 style="margin:0 0 16px;font-size:22px;line-height:1.25;">${title}</h1>
+      ${bodyHtml}
+    </div>
+    <p style="max-width:520px;margin:16px auto 0;font-family:ui-sans-serif,system-ui,sans-serif;font-size:12px;color:#7c8296;">
+      Sent because of activity on your sopher.ai account. Questions:
+      <a href="mailto:support@sopher.ai" style="color:#4a5fd0;">support@sopher.ai</a>
+    </p>
+  </body>
+</html>`;
+}
+
+const p = (text: string) =>
+  `<p style="margin:0 0 12px;font-size:15px;line-height:1.6;color:#4a4f5e;">${text}</p>`;
+const cta = (href: string, label: string) =>
+  `<p style="margin:20px 0 0;"><a href="${href}" style="display:inline-block;background:#4a5fd0;color:#ffffff;text-decoration:none;border-radius:8px;padding:10px 20px;font-family:ui-sans-serif,system-ui,sans-serif;font-size:14px;font-weight:600;">${label}</a></p>`;
+
+async function deliver(to: string, subject: string, html: string): Promise<void> {
+  const resend = getResend();
+  if (!resend || !to) return;
+  try {
+    await resend.emails.send({ from: FROM, to, subject, html });
+  } catch (error) {
+    // Email is best-effort by design; the product state is already correct.
+    console.warn("[email] send failed:", error instanceof Error ? error.message : error);
+  }
+}
+
+export async function sendBookFinishedEmail(input: {
+  to: string;
+  bookTitle: string;
+  projectId: string;
+  chapterCount: number;
+  wordCount: number;
+}): Promise<void> {
+  const url = `https://sopher.ai/projects/${input.projectId}/manuscript`;
+  await deliver(
+    input.to,
+    `“${input.bookTitle}” is finished`,
+    shell(
+      "Your book is finished.",
+      p(
+        `<em>${input.bookTitle}</em> — ${input.chapterCount} chapters, ${input.wordCount.toLocaleString(
+          "en-US",
+        )} words — is written, edited, and waiting for you.`,
+      ) + cta(url, "Open your manuscript"),
+    ),
+  );
+}
+
+export async function sendCreditsPausedEmail(input: {
+  to: string;
+  bookTitle: string;
+  projectId: string;
+  balance: number;
+  required: number;
+}): Promise<void> {
+  const url = `https://sopher.ai/studio/credits?return=${encodeURIComponent(
+    `/projects/${input.projectId}/write`,
+  )}`;
+  await deliver(
+    input.to,
+    `Writing paused on “${input.bookTitle}”`,
+    shell(
+      "Writing is paused — out of credits.",
+      p(
+        `<em>${input.bookTitle}</em> needs about ${Math.ceil(input.required)} credits to continue and your balance is ${input.balance.toFixed(1)}. Every chapter drafted so far is safe; the book picks up exactly where it stopped once you top up.`,
+      ) + cta(url, "Add credits and resume"),
+    ),
+  );
+}
+
+export async function sendReceiptEmail(input: {
+  to: string;
+  packName: string;
+  credits: number;
+  usd: number;
+}): Promise<void> {
+  await deliver(
+    input.to,
+    `Receipt — ${input.credits} credits`,
+    shell(
+      "Thanks — credits added.",
+      p(
+        `Your ${input.packName} purchase of <strong>${input.credits} credits</strong> ($${input.usd.toFixed(2)}) is on your balance now.`,
+      ) +
+        p(`Unspent credits are refundable within 14 days — just reply to this email.`) +
+        cta("https://sopher.ai/studio/credits", "View your balance"),
+    ),
+  );
+}

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -54,6 +54,7 @@ export async function generateBook(
     let preflight = await creditCheckStep(ref, config, config.waveSize, {
       includeBookOverhead: true,
     });
+    let preflightNotified = false;
     while (!preflight.sufficient) {
       await markRunStatus(ref, "awaiting_input");
       await emitProgress(ref, {
@@ -62,7 +63,12 @@ export async function generateBook(
         pct: 1,
         detail: `${preflight.balance.toFixed(0)} of ${preflight.required.toFixed(0)} credits needed to start`,
       });
-      await notifyCreditsPausedStep(ref, preflight.balance, preflight.required);
+      // One email per pause episode — a resume click without a top-up loops
+      // back here and must not mail again.
+      if (!preflightNotified) {
+        await notifyCreditsPausedStep(ref, preflight.balance, preflight.required);
+        preflightNotified = true;
+      }
       const go = await topUpEvents.next();
       if (!go.value?.toppedUp) throw new FatalError("Run cancelled while waiting for credits");
       await markRunStatus(ref, "running");
@@ -127,6 +133,7 @@ export async function generateBook(
       // failing it, so every chapter already drafted is kept and no work is
       // re-billed on resume.
       let credit = await creditCheckStep(ref, config, Math.min(config.waveSize, total - done));
+      let pauseNotified = false;
       while (!credit.sufficient) {
         await markRunStatus(ref, "awaiting_input");
         await emitProgress(ref, {
@@ -135,7 +142,10 @@ export async function generateBook(
           pct: 15 + Math.round(55 * (done / total)),
           detail: `${credit.balance.toFixed(0)} of ${credit.required.toFixed(0)} credits needed to continue`,
         });
-        await notifyCreditsPausedStep(ref, credit.balance, credit.required);
+        if (!pauseNotified) {
+          await notifyCreditsPausedStep(ref, credit.balance, credit.required);
+          pauseNotified = true;
+        }
         const resumed = await topUpEvents.next();
         if (!resumed.value?.toppedUp) {
           throw new FatalError("Run cancelled while waiting for credits");

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -13,6 +13,7 @@ import {
   emitProgress,
   finalizeStep,
   markRunStatus,
+  notifyCreditsPausedStep,
   outlineStep,
   readQualityGate,
   writeChapterStep,
@@ -61,6 +62,7 @@ export async function generateBook(
         pct: 1,
         detail: `${preflight.balance.toFixed(0)} of ${preflight.required.toFixed(0)} credits needed to start`,
       });
+      await notifyCreditsPausedStep(ref, preflight.balance, preflight.required);
       const go = await topUpEvents.next();
       if (!go.value?.toppedUp) throw new FatalError("Run cancelled while waiting for credits");
       await markRunStatus(ref, "running");
@@ -133,6 +135,7 @@ export async function generateBook(
           pct: 15 + Math.round(55 * (done / total)),
           detail: `${credit.balance.toFixed(0)} of ${credit.required.toFixed(0)} credits needed to continue`,
         });
+        await notifyCreditsPausedStep(ref, credit.balance, credit.required);
         const resumed = await topUpEvents.next();
         if (!resumed.value?.toppedUp) {
           throw new FatalError("Run cancelled while waiting for credits");

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -20,6 +20,7 @@ import { creditsForUsd, getBalance } from "@/lib/billing/credits";
 import { estimateBookCost } from "@/ai/estimate";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { listEntities } from "@/db/queries/entities";
+import { sendBookFinishedEmail, sendCreditsPausedEmail } from "@/lib/email/send";
 import { chapterNs, PROGRESS_NS, type GenerationConfig, type RunEvent } from "@/lib/run-events";
 import { isChapterComplete } from "./resume";
 import type { BookConcept, BookOutline, ChapterOutlinePlan } from "@/ai/schemas";
@@ -605,4 +606,62 @@ export async function finalizeStep(ref: RunRef): Promise<void> {
     .where(
       sql`${schema.chapters.bookId} = (select id from ${schema.books} where ${schema.books.projectId} = ${ref.projectId}) and ${schema.chapters.status} in ('drafted', 'edited')`,
     );
+
+  // Tell the author. Best-effort: a book that finished but could not say so
+  // is still a finished book, so email failures never fail the step.
+  try {
+    const [row] = await db
+      .select({
+        email: schema.users.email,
+        title: schema.books.title,
+        chapters: sql<number>`(select count(*)::int from ${schema.chapters} where ${schema.chapters.bookId} = ${schema.books.id})`,
+        words: sql<number>`(select coalesce(sum(${schema.chapters.wordCount}), 0)::int from ${schema.chapters} where ${schema.chapters.bookId} = ${schema.books.id})`,
+      })
+      .from(schema.books)
+      .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+      .innerJoin(schema.users, eq(schema.users.id, schema.projects.userId))
+      .where(eq(schema.projects.id, ref.projectId))
+      .limit(1);
+    if (row?.email) {
+      await sendBookFinishedEmail({
+        to: row.email,
+        bookTitle: row.title,
+        projectId: ref.projectId,
+        chapterCount: row.chapters,
+        wordCount: row.words,
+      });
+    }
+  } catch (error) {
+    console.warn("[email] book-finished notification failed:", error);
+  }
+}
+
+/** Emails the author that writing paused for credits. Best-effort, own step. */
+export async function notifyCreditsPausedStep(
+  ref: RunRef,
+  balance: number,
+  required: number,
+): Promise<void> {
+  "use step";
+  try {
+    const db = getDb();
+    const [row] = await db
+      .select({ email: schema.users.email, title: schema.books.title })
+      .from(schema.books)
+      .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+      .innerJoin(schema.users, eq(schema.users.id, schema.projects.userId))
+      .where(eq(schema.projects.id, ref.projectId))
+      .limit(1);
+    if (row?.email) {
+      await sendCreditsPausedEmail({
+        to: row.email,
+        bookTitle: row.title,
+        projectId: ref.projectId,
+        balance,
+        required,
+      });
+    }
+  } catch (error) {
+    console.warn("[email] credits-paused notification failed:", error);
+  }
 }


### PR DESCRIPTION
Final PR of the release sweep.

## The emails

Three messages, all receipts for things the user did — no marketing, no digests, so no unsubscribe machinery:

- **Book finished** — sent from `finalizeStep` with chapter/word counts and a manuscript link.
- **Paused for credits** — sent from both suspend points with the shortfall and a top-up link that returns to the paused run. Complements the in-app banner: the author who closed the tab finds out.
- **Purchase receipt** — sent from the Stripe webhook **only on first fulfilment** (`granted === true`), so Stripe's redeliveries can never re-mail.

All best-effort by design: the layer no-ops when `RESEND_API_KEY` is absent and catches send failures — email can never be the reason a workflow step fails.

## Provisioning note

The marketplace flow (`resend/resend-email`) required a browser handoff; the owner linked the domain in Resend directly instead. A manually-linked account means no key auto-sync — `RESEND_API_KEY` is a manual env var (documented in the runbook, with the pipe-don't-paste command).

## The landmine fixed on the way

`STRIPE_WEBHOOK_SECRET` **was never set** — the fulfilment webhook has been returning 503 since credits shipped. With the Stripe sandbox now claimed, a real purchase would have **charged the card and granted no credits**. The endpoint is now created via the Stripe API (`checkout.session.completed` + `charge.refunded`) with the signing secret piped directly into the Vercel env, never displayed. Keys are still `sk_test_` pending Stripe account activation; the runbook has the one-command recreate for live mode.

## Verification

311 unit tests; typecheck/lint/format/build clean. Live send verification pends the `RESEND_API_KEY` env var landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment webhook fulfilment and long-running generation workflows; email is isolated as best-effort but receipt timing depends on the same `grantCredits` idempotency flag as credit grants.
> 
> **Overview**
> Introduces **transactional email via Resend** (`resend` dependency and `src/lib/email/send.ts`) with three HTML templates: book finished, writing paused for credits, and credit-pack purchase receipt. Sending is **best-effort**: missing `RESEND_API_KEY` no-ops, and failures are logged without failing callers.
> 
> **Book generation** emails the author when `finalizeStep` completes (chapter/word counts + manuscript link) and when the run suspends for credits—new `notifyCreditsPausedStep` is invoked from both pre-flight and mid-book credit waits in `generate-book.ts`.
> 
> **Stripe fulfilment** looks up the buyer’s email after a successful `grantCredits` and sends a receipt **only when `granted` is true**, so webhook retries cannot duplicate receipts.
> 
> **`doc/CUTOVER.md`** marks support email routing and Stripe sandbox claim as done, documents manual `RESEND_API_KEY` setup, and adds a one-liner to recreate the live Stripe webhook secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2175292655fa64a1bfb24e9277d03882c7aa7cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->