### PR TITLE
Admin platform: roles, suspension, quiet moderation, Google Analytics

### DIFF
--- a/drizzle/0007_acoustic_wind_dancer.sql
+++ b/drizzle/0007_acoustic_wind_dancer.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "moderation_flags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"chapter_number" integer,
+	"source" text NOT NULL,
+	"category" text NOT NULL,
+	"severity" text DEFAULT 'review' NOT NULL,
+	"excerpt" text,
+	"detail" text,
+	"status" text DEFAULT 'open' NOT NULL,
+	"reviewed_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "role" text DEFAULT 'user' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "suspended" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "moderation_flags" ADD CONSTRAINT "moderation_flags_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_flags_status" ON "moderation_flags" USING btree ("status","created_at");--> statement-breakpoint
+-- Bootstrap admin access: the founder account, plus the dev fallback identity
+-- so local development and DB-gated e2e can exercise the admin surface.
+UPDATE "users" SET "role" = 'admin' WHERE "email" = 'cheesejaguar@gmail.com' OR "id" = 'dev-user';

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2166 @@
+{
+  "id": "354d21f3-ca99-43b5-a075-ed1d2eab6e72",
+  "prevId": "226a97a4-e1c4-40bd-b825-ea492ec573b7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metered_usd": {
+          "name": "metered_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ledger_user": {
+          "name": "idx_ledger_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_ledger_external_ref": {
+          "name": "uq_ledger_external_ref",
+          "columns": [
+            {
+              "expression": "external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_user_id_users_id_fk": {
+          "name": "credit_ledger_user_id_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_project_id_projects_id_fk": {
+          "name": "credit_ledger_project_id_projects_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_run_id_generation_runs_id_fk": {
+          "name": "credit_ledger_run_id_generation_runs_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "portrait_asset_id": {
+          "name": "portrait_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_appearance_chapter": {
+          "name": "first_appearance_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_chapter": {
+          "name": "last_updated_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_name": {
+          "name": "uq_entity_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_book": {
+          "name": "idx_entities_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_book_id_books_id_fk": {
+          "name": "entities_book_id_books_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationships": {
+      "name": "entity_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_chapter": {
+          "name": "established_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_relationship": {
+          "name": "uq_entity_relationship",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationships_book": {
+          "name": "idx_relationships_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_relationships_book_id_books_id_fk": {
+          "name": "entity_relationships_book_id_books_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_from_entity_id_entities_id_fk": {
+          "name": "entity_relationships_from_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_to_entity_id_entities_id_fk": {
+          "name": "entity_relationships_to_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_flags": {
+      "name": "moderation_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'review'"
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flags_status": {
+          "name": "idx_flags_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_flags_project_id_projects_id_fk": {
+          "name": "moderation_flags_project_id_projects_id_fk",
+          "tableFrom": "moderation_flags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785301063778,
       "tag": "0006_conscious_sabretooth",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785339918546,
+      "tag": "0007_acoustic_wind_dancer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ai/agents/concept.ts
+++ b/src/ai/agents/concept.ts
@@ -105,12 +105,16 @@ export async function persistConcept(bookId: string, concept: BookConcept): Prom
     }
   }
 
+  // The verdict is admin-only bookkeeping; the author-owned concept jsonb
+  // (loaded by getProjectWithBook) must never carry it.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructuring strips the field
+  const { moderation, ...persistableConcept } = concept;
   await db
     .update(schema.books)
     .set({
       title: concept.title,
       synopsis: concept.synopsis,
-      concept,
+      concept: persistableConcept,
       updatedAt: new Date(),
     })
     .where(eq(schema.books.id, bookId));

--- a/src/ai/agents/concept.ts
+++ b/src/ai/agents/concept.ts
@@ -2,6 +2,7 @@ import { generateText, isStepCount, Output } from "ai";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { seedEntities } from "@/db/queries/entities";
+import { MODERATION_PROMPT, recordModerationFlag } from "@/lib/moderation";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
 import { buildToolset, type ToolCtx } from "@/ai/tools";
@@ -30,6 +31,7 @@ function refinePrompt(ctx: ConceptCtx, draft: BookConcept): string {
       ctx.genre ? `${ctx.genre} readers` : "readers of this genre"
     } expect — a generic logline, a low-stakes central conflict, interchangeable characters, themes that don't connect to the plot, or "unique" elements that are actually common tropes.`,
     `Then return the REFINED concept: rewrite the weak elements to fix them, keep everything that already works, and preserve the same structure. Return the complete refined concept, not a critique.`,
+    MODERATION_PROMPT,
   ]
     .filter(Boolean)
     .join("\n\n");
@@ -86,6 +88,23 @@ export async function generateConcept(input: ConceptCtx): Promise<BookConcept> {
  */
 export async function persistConcept(bookId: string, concept: BookConcept): Promise<void> {
   const db = getDb();
+
+  // Quiet brief-level moderation: the verdict rode the concept call itself.
+  if (concept.moderation?.flagged) {
+    const [book] = await db
+      .select({ projectId: schema.books.projectId })
+      .from(schema.books)
+      .where(eq(schema.books.id, bookId))
+      .limit(1);
+    if (book) {
+      await recordModerationFlag({
+        projectId: book.projectId,
+        source: "brief",
+        verdict: concept.moderation,
+      });
+    }
+  }
+
   await db
     .update(schema.books)
     .set({

--- a/src/ai/agents/summarizer.ts
+++ b/src/ai/agents/summarizer.ts
@@ -5,6 +5,7 @@ import { MODELS, type QualityTier } from "@/ai/models";
 import { gatewayOptions, metered, type MeterCtx } from "@/ai/metering";
 import { chapterSummarySchema, type ChapterSummary } from "@/ai/schemas";
 import { applyEntityDeltas } from "@/db/queries/entities";
+import { MODERATION_PROMPT, recordModerationFlag } from "@/lib/moderation";
 
 /**
  * Writes the rolling ~250-token summary + the story-bible delta after a chapter
@@ -36,6 +37,7 @@ export async function summarizeChapter(input: {
           `Summarize chapter ${input.chapterNumber} ("${input.chapterTitle ?? "untitled"}") in at most 200 words, covering plot events, character developments, and any objects/promises/injuries that matter later.`,
           `Then list new canonical facts per entity this chapter established — not only characters but also locations (what a place contains), objects (who holds it, what it does), organizations and named events. Record only durable facts a later chapter must honor: appearance, heritage, possessions, wounds, secrets, commitments, contents, ownership.`,
           `Also list any relationships the chapter established between named entities (family ties especially — they govern surnames).`,
+          MODERATION_PROMPT,
           `## Chapter text\n${input.content}`,
         ].join("\n\n"),
         output: Output.object({ schema: chapterSummarySchema }),
@@ -61,6 +63,22 @@ export async function summarizeChapter(input: {
     newFacts: summary.newFacts,
     relationships: summary.relationships,
   });
+
+  if (summary.moderation?.flagged) {
+    const [book] = await db
+      .select({ projectId: schema.books.projectId })
+      .from(schema.books)
+      .where(eq(schema.books.id, input.bookId))
+      .limit(1);
+    if (book) {
+      await recordModerationFlag({
+        projectId: book.projectId,
+        source: "chapter",
+        chapterNumber: input.chapterNumber,
+        verdict: summary.moderation,
+      });
+    }
+  }
 
   return summary;
 }

--- a/src/ai/schemas/index.ts
+++ b/src/ai/schemas/index.ts
@@ -1,6 +1,21 @@
 import { z } from "zod";
 import { ENTITY_KINDS } from "./entities";
 
+/**
+ * Content-safety verdict that rides the concept and summarizer calls. The
+ * product writes explicit fiction on request, so this is scoped strictly to
+ * provider-AUP / illegal categories — never heat level.
+ */
+export const moderationVerdictSchema = z.object({
+  flagged: z.boolean().default(false),
+  category: z
+    .enum(["minors", "nonconsent", "real_person", "hate_incitement", "self_harm", "other"])
+    .optional(),
+  excerpt: z.string().max(500).optional(),
+  reason: z.string().max(300).optional(),
+});
+export type ModerationVerdict = z.infer<typeof moderationVerdictSchema>;
+
 export const conceptSchema = z.object({
   title: z.string(),
   logline: z.string(),
@@ -19,6 +34,7 @@ export const conceptSchema = z.object({
       }),
     )
     .max(10),
+  moderation: moderationVerdictSchema.default({ flagged: false }),
 });
 export type BookConcept = z.infer<typeof conceptSchema>;
 
@@ -129,6 +145,7 @@ export const chapterSummarySchema = z.object({
     .max(10)
     .default([]),
   timelineNote: z.string().optional(),
+  moderation: moderationVerdictSchema.default({ flagged: false }),
 });
 export type ChapterSummary = z.infer<typeof chapterSummarySchema>;
 

--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -48,6 +48,11 @@ export default function PrivacyPage() {
           <strong>Infrastructure</strong> — Vercel (hosting, file storage), Neon (database), Clerk
           (authentication), Stripe (payments).
         </li>
+        <li>
+          <strong>Google Analytics</strong> — anonymous usage measurement (pages visited, rough
+          location, device type), so we can see what to improve. It never receives your manuscripts
+          or account content.
+        </li>
       </ul>
       <p>
         We do not sell personal data, run third-party advertising trackers, or share your
@@ -56,17 +61,20 @@ export default function PrivacyPage() {
 
       <h2>Cookies</h2>
       <p>
-        We use only the cookies required for sign-in sessions (set by Clerk) and your theme
-        preference. There are no advertising or cross-site tracking cookies, which is why there is
-        no cookie banner.
+        We use cookies for sign-in sessions (set by Clerk), your theme preference, and Google
+        Analytics measurement (the <code>_ga</code> family). There are no advertising cookies. You
+        can block analytics cookies in your browser or with Google&rsquo;s{" "}
+        <a href="https://tools.google.com/dlpage/gaoptout">opt-out add-on</a> without affecting the
+        product.
       </p>
 
       <h2>Retention and deletion</h2>
       <p>
-        Your content is kept while your account exists. Deleting a project removes its manuscript,
-        story bible, and generated files. Deleting your account removes your account record and all
-        projects; transaction records are retained as required for tax and accounting. To delete
-        your account, use your account menu or email us.
+        Your content is kept while your account exists. We may review content when required to
+        enforce our terms or comply with law; such review is limited to that purpose. Deleting a
+        project removes its manuscript, story bible, and generated files. Deleting your account
+        removes your account record and all projects; transaction records are retained as required
+        for tax and accounting. To delete your account, use your account menu or email us.
       </p>
 
       <h2>Your rights</h2>

--- a/src/app/api/chapters/[chapterId]/edits/route.ts
+++ b/src/app/api/chapters/[chapterId]/edits/route.ts
@@ -9,7 +9,7 @@ import { EDITOR_SYSTEM_PROMPT } from "@/ai/prompts/editor";
 import { selectionEditSchema } from "@/ai/schemas";
 import { getDb, schema } from "@/db";
 import { getChapterById, getChapterOwnership } from "@/db/queries/books";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { contextWindow } from "@/lib/editor/anchors";
 import { toSuggestionDTO } from "@/lib/editor/types";
@@ -61,6 +61,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ chapterId: str
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/chapters/[chapterId]/regenerate/route.ts
+++ b/src/app/api/chapters/[chapterId]/regenerate/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "@/db";
 import { getChapterOwnership } from "@/db/queries/books";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { estimateBookCost } from "@/ai/estimate";
 import { generateChapter } from "@/workflows/generate-chapter";
@@ -25,6 +25,15 @@ export async function POST(_req: Request, ctx: { params: Promise<{ chapterId: st
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/chapters/[chapterId]/review/route.ts
+++ b/src/app/api/chapters/[chapterId]/review/route.ts
@@ -5,7 +5,7 @@ import { reviewChapter } from "@/ai/agents/editor";
 import { type QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
 import { getChapterById, getChapterOwnership } from "@/db/queries/books";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { resolveAnchor } from "@/lib/editor/anchors";
 import { toSuggestionDTO } from "@/lib/editor/types";
@@ -26,6 +26,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ chapterId: str
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/content-tools/[toolId]/route.ts
+++ b/src/app/api/content-tools/[toolId]/route.ts
@@ -5,7 +5,7 @@ import { ContentToolError, getContentTool } from "@/ai/content-tools/registry";
 import { type QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
 import { getChapterOwnership } from "@/db/queries/books";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 
 export const maxDuration = 120;
@@ -23,6 +23,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ toolId: string
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/credits/checkout/route.ts
+++ b/src/app/api/credits/checkout/route.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { getPack } from "@/lib/billing/credits";
 import { getStripe, stripeConfigured } from "@/lib/payments/stripe";
 
@@ -44,6 +44,15 @@ export async function POST(req: Request) {
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/entities/[entityId]/portrait/route.ts
+++ b/src/app/api/entities/[entityId]/portrait/route.ts
@@ -6,7 +6,7 @@ import { gatewayOptions, metered } from "@/ai/metering";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
 import { getEntityForPortrait } from "@/db/queries/entities";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { assertCreditsForUsd, InsufficientCreditsError } from "@/lib/billing/credits";
 import { PORTRAIT_KINDS, PORTRAIT_USD, portraitPrompt } from "@/lib/bible/portraits";
 import type { EntityKind } from "@/ai/schemas/entities";
@@ -29,6 +29,15 @@ export async function POST(_req: Request, ctx: { params: Promise<{ entityId: str
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/projects/[projectId]/cover/route.ts
+++ b/src/app/api/projects/[projectId]/cover/route.ts
@@ -5,7 +5,7 @@ import { and, eq } from "drizzle-orm";
 import { gatewayOptions, metered } from "@/ai/metering";
 import { MODELS, type QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import {
   assertCreditsForUsd,
   creditsForUsd,
@@ -44,6 +44,15 @@ export async function POST(_req: Request, ctx: { params: Promise<{ projectId: st
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/api/projects/[projectId]/generate/route.ts
+++ b/src/app/api/projects/[projectId]/generate/route.ts
@@ -2,7 +2,7 @@ import { start, getRun } from "workflow/api";
 import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "@/db";
-import { requireUser, UnauthorizedError } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError, UnauthorizedError } from "@/lib/auth";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { generateBook } from "@/workflows/generate-book";
 import type { GenerationConfig } from "@/lib/run-events";
@@ -29,6 +29,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       return Response.json({ error: "Not signed in" }, { status: 401 });
+    }
+    throw error;
+  }
+
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) {
+      return Response.json({ error: error.message }, { status: 403 });
     }
     throw error;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Fraunces, Geist_Mono, Instrument_Sans, Literata } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import Script from "next/script";
 import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SkipLink } from "@/components/ui/skip-link";
@@ -67,6 +68,17 @@ export default function RootLayout({
           {clerkEnabled ? <ClerkProvider>{children}</ClerkProvider> : children}
         </ThemeProvider>
         <Analytics />
+        {/* Google Analytics (G-8JGW12KNXP) — disclosed in /privacy. */}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-8JGW12KNXP"
+          strategy="afterInteractive"
+        />
+        <Script id="ga-init" strategy="afterInteractive">{`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-8JGW12KNXP');
+        `}</Script>
       </body>
     </html>
   );

--- a/src/components/wizard/new-book-wizard.tsx
+++ b/src/components/wizard/new-book-wizard.tsx
@@ -204,7 +204,11 @@ export function NewBookWizard() {
       // Clear the draft first — a successful action redirects away immediately.
       window.localStorage.removeItem(WIZARD_DRAFT_KEY);
       try {
-        await startBook(payload);
+        const result = await startBook(payload);
+        if (result?.error) {
+          window.localStorage.setItem(WIZARD_DRAFT_KEY, serializeDraft(state));
+          setError(result.error);
+        }
       } catch {
         window.localStorage.setItem(WIZARD_DRAFT_KEY, serializeDraft(state));
         setError("The book could not be started. Your brief is saved — please try again.");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import {
   bigint,
+  boolean,
   index,
   integer,
   jsonb,
@@ -23,6 +24,11 @@ export const users = pgTable("users", {
   email: text("email").notNull(),
   name: text("name"),
   imageUrl: text("image_url"),
+  role: text("role", { enum: ["user", "admin"] })
+    .default("user")
+    .notNull(),
+  /** Suspension blocks spend paths only; reading and exporting always work. */
+  suspended: boolean("suspended").default(false).notNull(),
   ...timestamps,
 });
 
@@ -376,6 +382,37 @@ export const continuityIssues = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (t) => [index("idx_continuity_book").on(t.bookId, t.status)],
+);
+
+/**
+ * Quiet content-safety review. Rows are written by the moderation checks that
+ * ride the concept and summarizer calls; nothing here is ever shown to the
+ * author. "Inappropriate" means provider-AUP / illegal categories only — the
+ * product deliberately writes explicit fiction when its settings ask for it,
+ * so heat level alone is never a flag.
+ */
+export const moderationFlags = pgTable(
+  "moderation_flags",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    chapterNumber: integer("chapter_number"),
+    source: text("source", { enum: ["brief", "chapter"] }).notNull(),
+    category: text("category").notNull(),
+    severity: text("severity", { enum: ["review", "urgent"] })
+      .default("review")
+      .notNull(),
+    excerpt: text("excerpt"),
+    detail: text("detail"),
+    status: text("status", { enum: ["open", "dismissed", "actioned"] })
+      .default("open")
+      .notNull(),
+    reviewedBy: text("reviewed_by"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => [index("idx_flags_status").on(t.status, t.createdAt)],
 );
 
 export const contentToolRuns = pgTable(

--- a/src/lib/actions/projects.ts
+++ b/src/lib/actions/projects.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { start } from "workflow/api";
 import { z } from "zod";
 import { getDb, schema } from "@/db";
-import { assertNotSuspended, requireUser } from "@/lib/auth";
+import { assertNotSuspended, requireUser, SuspendedError } from "@/lib/auth";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { generateBook } from "@/workflows/generate-book";
 import { isActiveRunConflict } from "@/lib/run-conflict";
@@ -106,9 +106,16 @@ async function startGenerationRun(
  * The wizard's submit: creates the project and immediately starts the
  * full-book generation workflow, then lands the author on the Write stage.
  */
-export async function startBook(input: unknown) {
+export async function startBook(input: unknown): Promise<{ error: string } | void> {
   const { userId } = await requireUser();
-  await assertNotSuspended(userId);
+  // Server-action throw messages are redacted in production, so suspension is
+  // returned as data — the wizard shows it verbatim.
+  try {
+    await assertNotSuspended(userId);
+  } catch (error) {
+    if (error instanceof SuspendedError) return { error: error.message };
+    throw error;
+  }
   const data = startBookSchema.parse(input);
 
   const db = getDb();

--- a/src/lib/actions/projects.ts
+++ b/src/lib/actions/projects.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { start } from "workflow/api";
 import { z } from "zod";
 import { getDb, schema } from "@/db";
-import { requireUser } from "@/lib/auth";
+import { assertNotSuspended, requireUser } from "@/lib/auth";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { generateBook } from "@/workflows/generate-book";
 import { isActiveRunConflict } from "@/lib/run-conflict";
@@ -108,6 +108,7 @@ async function startGenerationRun(
  */
 export async function startBook(input: unknown) {
   const { userId } = await requireUser();
+  await assertNotSuspended(userId);
   const data = startBookSchema.parse(input);
 
   const db = getDb();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,20 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class ForbiddenError extends Error {
+  constructor() {
+    super("Not allowed");
+    this.name = "ForbiddenError";
+  }
+}
+
+export class SuspendedError extends Error {
+  constructor() {
+    super("This account is suspended — contact support@sopher.ai");
+    this.name = "SuspendedError";
+  }
+}
+
 const DEV_USER_ID = "dev-user";
 
 async function devFallbackUser(): Promise<{ userId: string }> {
@@ -84,4 +98,35 @@ export async function requireUser(): Promise<{ userId: string }> {
   }
 
   return { userId };
+}
+
+/**
+ * Admin gate. Role lives on the users row (bootstrapped by migration for the
+ * founder account and the dev identity); everything admin-shaped calls this
+ * and treats failure as 404, so the surface stays quiet.
+ */
+export async function requireAdmin(): Promise<{ userId: string }> {
+  const { userId } = await requireUser();
+  const db = getDb();
+  const [row] = await db
+    .select({ role: schema.users.role })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  if (row?.role !== "admin") throw new ForbiddenError();
+  return { userId };
+}
+
+/**
+ * Suspension blocks the spend paths — generation, edits, image work, checkout
+ * — but never reading or exporting: a suspended author keeps their work.
+ */
+export async function assertNotSuspended(userId: string): Promise<void> {
+  const db = getDb();
+  const [row] = await db
+    .select({ suspended: schema.users.suspended })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  if (row?.suspended) throw new SuspendedError();
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -32,7 +32,11 @@ async function devFallbackUser(): Promise<{ userId: string }> {
   const db = getDb();
   await db
     .insert(schema.users)
-    .values({ id: DEV_USER_ID, email: "dev@sopher.ai", name: "Studio Guest" })
+    // Admin role: the dev identity exists precisely so local dev and DB-gated
+    // e2e can exercise every surface, admin included. The migration promotes
+    // pre-existing rows; this covers a fresh database where the row is born
+    // after the migration ran.
+    .values({ id: DEV_USER_ID, email: "dev@sopher.ai", name: "Studio Guest", role: "admin" })
     .onConflictDoNothing();
   // Same welcome grant real users get, so local dev exercises the same
   // credit-gated paths instead of instantly suspending on a zero balance.

--- a/src/lib/moderation.test.ts
+++ b/src/lib/moderation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { moderationVerdictSchema, chapterSummarySchema, conceptSchema } from "@/ai/schemas";
+import { MODERATION_PROMPT } from "./moderation";
+
+describe("moderation verdict schema", () => {
+  it("defaults to unflagged so the model must opt in", () => {
+    expect(moderationVerdictSchema.parse({})).toEqual({ flagged: false });
+  });
+
+  it("rides the summarizer schema with a safe default", () => {
+    const parsed = chapterSummarySchema.parse({ summary: "s", newFacts: [] });
+    expect(parsed.moderation.flagged).toBe(false);
+  });
+
+  it("rides the concept schema with a safe default", () => {
+    const parsed = conceptSchema.parse({
+      title: "t",
+      logline: "l",
+      synopsis: "s",
+      themes: [],
+      setting: "x",
+      centralConflict: "c",
+      uniqueElements: [],
+      characters: [],
+    });
+    expect(parsed.moderation.flagged).toBe(false);
+  });
+
+  it("accepts a full flag", () => {
+    const v = moderationVerdictSchema.parse({
+      flagged: true,
+      category: "real_person",
+      excerpt: "…",
+      reason: "names a real person in sexual content",
+    });
+    expect(v.category).toBe("real_person");
+  });
+});
+
+describe("moderation prompt scope", () => {
+  it("names every category and explicitly exempts adult fiction", () => {
+    for (const term of ["minors", "nonconsent", "real_person", "hate_incitement", "self_harm"]) {
+      expect(MODERATION_PROMPT).toContain(term);
+    }
+    expect(MODERATION_PROMPT).toContain("NOT flags");
+  });
+});

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -22,9 +22,10 @@ export async function recordModerationFlag(input: {
         chapterNumber: input.chapterNumber,
         source: input.source,
         category: verdict.category ?? "other",
-        // Minors involved in sexual content is the one category that always
-        // escalates; everything else starts as ordinary review.
-        severity: verdict.category === "minors" ? "urgent" : "review",
+        // Minors always escalates — and so does a flag with NO category, since
+        // an unclassified flag cannot rule the worst case out. An explicit
+        // "other" stays ordinary review.
+        severity: verdict.category === "minors" || !verdict.category ? "urgent" : "review",
         excerpt: verdict.excerpt?.slice(0, 500),
         detail: verdict.reason?.slice(0, 300),
       });

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -1,0 +1,40 @@
+import { getDb, schema } from "@/db";
+import type { ModerationVerdict } from "@/ai/schemas";
+
+/**
+ * Records a quiet moderation flag. Never throws — a moderation bookkeeping
+ * failure must not fail the writing pipeline — and never surfaces anything to
+ * the author. Flags are reviewed in the admin dashboard only.
+ */
+export async function recordModerationFlag(input: {
+  projectId: string;
+  source: "brief" | "chapter";
+  chapterNumber?: number;
+  verdict: ModerationVerdict;
+}): Promise<void> {
+  const { verdict } = input;
+  if (!verdict.flagged) return;
+  try {
+    await getDb()
+      .insert(schema.moderationFlags)
+      .values({
+        projectId: input.projectId,
+        chapterNumber: input.chapterNumber,
+        source: input.source,
+        category: verdict.category ?? "other",
+        // Minors involved in sexual content is the one category that always
+        // escalates; everything else starts as ordinary review.
+        severity: verdict.category === "minors" ? "urgent" : "review",
+        excerpt: verdict.excerpt?.slice(0, 500),
+        detail: verdict.reason?.slice(0, 300),
+      });
+  } catch (error) {
+    console.warn("[moderation] flag write failed:", error);
+  }
+}
+
+/** The prompt fragment shared by the concept and summarizer calls. */
+export const MODERATION_PROMPT = [
+  `Separately, set the moderation field: flag ONLY if the text contains sexual content involving minors (category "minors"), non-consensual sexual content presented approvingly ("nonconsent"), sexual or defamatory content about real identifiable people ("real_person"), incitement or glorification of real-world violence or hatred against protected groups ("hate_incitement"), or instructions facilitating self-harm ("self_harm").`,
+  `Fictional violence, dark themes, and explicit adult content between adults are NOT flags — this is a fiction product with author-controlled content settings. When flagged, quote the shortest relevant excerpt and state the reason in one sentence.`,
+].join(" ");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,8 @@ import type { NextRequest } from "next/server";
 import { devAuthAllowed } from "@/lib/clerk";
 
 const isProtected = createRouteMatcher([
+  "/admin(.*)",
+  "/api/admin(.*)",
   "/studio(.*)",
   "/projects(.*)",
   "/api/usage(.*)",


### PR DESCRIPTION
First of two PRs for the admin dashboard — the platform layer.

## Roles & suspension

`users.role` (migration bootstraps `cheesejaguar@gmail.com` + the dev identity as admin) and `users.suspended`. `requireAdmin()` gates admin surfaces; callers treat failure as **404**, so the admin surface's existence stays quiet. Suspension blocks every **spend** path — generation, regeneration, edits, review, content tools, portraits, covers, checkout — with a 403 pointing at support, but deliberately never blocks reading or exporting: a suspended author keeps their work.

## Quiet moderation — zero new LLM calls

A moderation verdict rides the existing concept and summarizer calls, exactly the pattern the entity tracker proved. The scope line matters: this product writes explicit adult fiction when its settings ask for it, so **heat level is never a flag**. Flags fire only on provider-AUP/illegal categories — sexual content involving minors (auto-escalates to `urgent`), non-consensual content presented approvingly, sexual/defamatory content about real identifiable people, hate/violence incitement, self-harm instruction.

Verdicts land in a new `moderation_flags` table. The author sees nothing, generation continues normally, and the flag writer swallows its own failures — moderation bookkeeping can never fail the writing pipeline.

## Google Analytics

`G-8JGW12KNXP` via `next/script` (afterInteractive), alongside the existing Vercel Analytics. This forced honesty edits to the privacy policy: the cookies section previously **claimed no analytics cookies existed** — it now discloses the `_ga` family with the opt-out link, lists Google Analytics as a processor, and discloses that content may be reviewed to enforce the terms (covering admin manuscript access from PR B).

## Verification

316 unit tests (moderation schema defaults — the model must opt *in* to flagging; prompt names every category and exempts adult fiction). Migration reviewed: additive columns + backfill + new table. Full gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth, billing-adjacent routes, and content pipelines across many endpoints; migration grants admin by email/id—verify bootstrap targets in each environment.
> 
> **Overview**
> Adds the **platform layer** for an upcoming admin dashboard: user **roles** and **suspension**, **quiet content moderation**, and **Google Analytics**, plus matching privacy disclosures.
> 
> **Database:** New `moderation_flags` table; `users` gains `role` (default `user`) and `suspended` (default `false`). Migration bootstraps admin on the founder email and `dev-user`.
> 
> **Auth:** `requireAdmin()` checks `users.role`; `assertNotSuspended()` blocks spend paths with **403** while read/export stay allowed. Middleware now treats `/admin` and `/api/admin` as protected.
> 
> **Suspension** is wired into generation, chapter edits/regenerate/review, content tools, portraits, covers, credit checkout, and `startBook`.
> 
> **Moderation** adds a `moderation` verdict to concept and chapter-summary schemas (defaults unflagged). `MODERATION_PROMPT` rides existing concept refine and summarizer calls—no extra LLM requests. Flagged briefs/chapters call `recordModerationFlag` (failures swallowed); authors are not notified; `minors` maps to `urgent` severity.
> 
> **Analytics:** Google Analytics (`G-8JGW12KNXP`) via `next/script`; privacy page updated for GA cookies, processor list, and terms-enforcement content review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c8ff5d0478dce9eb3a414c066c9822899eff53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->