### PR TITLE
Admin dashboard: users, purchases, books, moderation queue, run debugger, metrics

### DIFF
--- a/e2e/studio.spec.ts
+++ b/e2e/studio.spec.ts
@@ -93,3 +93,38 @@ test.describe("project management", () => {
     await page.keyboard.press("Escape");
   });
 });
+
+test.describe("admin dashboard", () => {
+  // dev-user is admin (bootstrapped by migration / dev fallback insert).
+  test("overview renders KPIs", async ({ page }, testInfo) => {
+    await page.goto("/admin");
+    const main = page.locator("#main-content");
+    await expect(main.getByRole("heading", { name: "Overview" })).toBeVisible({
+      timeout: 20_000,
+    });
+    for (const kpi of ["Users", "Revenue", "Credit liability", "Open flags"]) {
+      await expect(main.getByText(kpi, { exact: true })).toBeVisible();
+    }
+    await axeCheck(page);
+    await fullPageScreenshot(page, testInfo, "admin-overview");
+  });
+
+  test("users table lists accounts and links to detail", async ({ page }) => {
+    await page.goto("/admin/users");
+    const main = page.locator("#main-content");
+    await expect(main.getByRole("heading", { name: "Users" })).toBeVisible({ timeout: 20_000 });
+    const devUser = main.getByRole("link", { name: "dev@sopher.ai" });
+    await expect(devUser).toBeVisible();
+    await devUser.click();
+    await expect(page.getByRole("button", { name: "Adjust credits" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Suspend|Unsuspend/ })).toBeVisible();
+  });
+
+  test("flag queue renders its empty state", async ({ page }) => {
+    await page.goto("/admin/flags");
+    await expect(page.getByRole("heading", { name: "Moderation flags" })).toBeVisible({
+      timeout: 20_000,
+    });
+    await axeCheck(page);
+  });
+});

--- a/src/app/(admin)/admin/books/[projectId]/page.tsx
+++ b/src/app/(admin)/admin/books/[projectId]/page.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { markdownToHtml } from "@/lib/export/assemble";
+import { getAdminBook } from "@/db/queries/admin";
+
+export const metadata = { title: "Book — admin" };
+
+/**
+ * Read-only manuscript view for moderation review. This is the author's
+ * private work — the banner keeps that fact in the reviewer's face, and there
+ * are deliberately no edit affordances of any kind.
+ */
+export default async function AdminBookView({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = await params;
+  const book = await getAdminBook(projectId);
+  if (!book) notFound();
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="font-display text-2xl font-semibold tracking-tight">{book.title}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          by{" "}
+          <Link href={`/admin/users/${book.userId}`} className="text-primary hover:underline">
+            {book.email}
+          </Link>{" "}
+          · {book.genre ?? "no genre"} · {book.status}
+        </p>
+      </header>
+
+      <p className="rounded-md border border-ember/40 bg-ember/5 px-4 py-2.5 text-sm">
+        This is the author&rsquo;s private work, shown read-only for terms enforcement. Access is
+        disclosed in the privacy policy.
+      </p>
+
+      {book.flags.length > 0 ? (
+        <section aria-labelledby="b-flags" className="space-y-2">
+          <h2 id="b-flags" className="font-sans font-semibold">
+            Flags on this book
+          </h2>
+          <ul className="space-y-2">
+            {book.flags.map((flag) => (
+              <li
+                key={flag.id}
+                className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm"
+              >
+                <p className="flex flex-wrap items-center gap-2">
+                  <Badge variant={flag.severity === "urgent" ? "destructive" : "outline"}>
+                    {flag.category}
+                  </Badge>
+                  <span className="text-muted-foreground">
+                    {flag.source}
+                    {flag.chapterNumber ? ` · ch. ${flag.chapterNumber}` : ""} · {flag.status}
+                  </span>
+                </p>
+                {flag.excerpt ? <p className="mt-1.5 italic">“{flag.excerpt}”</p> : null}
+                {flag.detail ? <p className="mt-1 text-muted-foreground">{flag.detail}</p> : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section aria-label="Manuscript" className="space-y-8">
+        {book.chapters.map((chapter) => (
+          <article key={chapter.id} className="paper-surface px-6 py-8 sm:px-10">
+            <h2 className="font-display text-lg font-semibold text-paper-foreground">
+              Chapter {chapter.chapterNumber}
+              {chapter.title ? ` — ${chapter.title}` : ""}
+              <span className="ml-2 font-mono text-xs font-normal text-paper-muted">
+                {chapter.wordCount.toLocaleString()} words
+              </span>
+            </h2>
+            <div
+              className="prose-manuscript mt-4 [content-visibility:auto]"
+              // Same escaped-HTML renderer as the author-facing reading view.
+              dangerouslySetInnerHTML={{ __html: markdownToHtml(chapter.content) }}
+            />
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/books/page.tsx
+++ b/src/app/(admin)/admin/books/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { RelativeTime } from "@/components/relative-time";
+import { listAllBooks } from "@/db/queries/admin";
+
+export const metadata = { title: "Books — admin" };
+
+export default async function AdminBooks() {
+  const books = await listAllBooks();
+
+  return (
+    <div className="space-y-4">
+      <h1 className="font-display text-2xl font-semibold tracking-tight">Books</h1>
+      <Table aria-label="All books">
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Title</TableHead>
+            <TableHead scope="col">Author</TableHead>
+            <TableHead scope="col">Genre</TableHead>
+            <TableHead scope="col">Status</TableHead>
+            <TableHead scope="col" className="text-right">
+              Chapters
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Words
+            </TableHead>
+            <TableHead scope="col">Flags</TableHead>
+            <TableHead scope="col">Updated</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {books.map((book) => (
+            <TableRow key={book.projectId}>
+              <TableCell>
+                <Link
+                  href={`/admin/books/${book.projectId}`}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {book.title}
+                </Link>
+              </TableCell>
+              <TableCell>
+                <Link
+                  href={`/admin/users/${book.userId}`}
+                  className="text-muted-foreground hover:underline"
+                >
+                  {book.email}
+                </Link>
+              </TableCell>
+              <TableCell className="text-muted-foreground">{book.genre ?? "—"}</TableCell>
+              <TableCell>
+                <Badge variant="outline">{book.status}</Badge>
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">{book.chapters}</TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {book.words.toLocaleString()}
+              </TableCell>
+              <TableCell>
+                {book.openFlags > 0 ? (
+                  <Badge variant="destructive">{book.openFlags}</Badge>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                <RelativeTime iso={book.updatedAt.toISOString()} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/flags/page.tsx
+++ b/src/app/(admin)/admin/flags/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { FlagActions } from "@/components/admin/flag-actions";
+import { RelativeTime } from "@/components/relative-time";
+import { listFlags } from "@/db/queries/admin";
+
+export const metadata = { title: "Flags — admin" };
+
+const STATUSES = ["open", "dismissed", "actioned"] as const;
+
+/**
+ * The moderation queue. Everything here was flagged quietly — the author never
+ * saw anything, generation never stopped. Dismiss clears false positives;
+ * Actioned records that a human dealt with it (suspension, if warranted, is a
+ * separate deliberate step on the user page).
+ */
+export default async function AdminFlags({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const { status } = await searchParams;
+  const active = (STATUSES as readonly string[]).includes(status ?? "")
+    ? (status as (typeof STATUSES)[number])
+    : "open";
+  const flags = await listFlags(active);
+
+  return (
+    <div className="space-y-4">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="font-display text-2xl font-semibold tracking-tight">Moderation flags</h1>
+        <nav aria-label="Flag status filter" className="flex gap-1">
+          {STATUSES.map((s) => (
+            <Link
+              key={s}
+              href={`/admin/flags?status=${s}`}
+              aria-current={s === active ? "page" : undefined}
+              className={`rounded-md px-3 py-1 text-sm capitalize ${
+                s === active
+                  ? "bg-accent font-medium text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {s}
+            </Link>
+          ))}
+        </nav>
+      </header>
+
+      {flags.length === 0 ? (
+        <p className="rounded-xl border border-border bg-card px-6 py-12 text-center text-sm text-muted-foreground">
+          No {active} flags. Quiet is good.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {flags.map((flag) => (
+            <li key={flag.id} className="rounded-xl border border-border bg-card p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 space-y-1.5">
+                  <p className="flex flex-wrap items-center gap-2">
+                    <Badge variant={flag.severity === "urgent" ? "destructive" : "outline"}>
+                      {flag.category}
+                    </Badge>
+                    {flag.severity === "urgent" ? (
+                      <Badge variant="destructive">urgent</Badge>
+                    ) : null}
+                    <span className="text-sm text-muted-foreground">
+                      {flag.source}
+                      {flag.chapterNumber ? ` · chapter ${flag.chapterNumber}` : ""} ·{" "}
+                      <RelativeTime iso={flag.createdAt.toISOString()} />
+                    </span>
+                  </p>
+                  <p className="text-sm">
+                    <Link
+                      href={`/admin/books/${flag.projectId}`}
+                      className="font-medium text-primary hover:underline"
+                    >
+                      {flag.title}
+                    </Link>{" "}
+                    <span className="text-muted-foreground">by {flag.email}</span>
+                  </p>
+                  {flag.excerpt ? (
+                    <p className="text-sm italic text-muted-foreground">“{flag.excerpt}”</p>
+                  ) : null}
+                  {flag.detail ? <p className="text-sm">{flag.detail}</p> : null}
+                  {flag.reviewedBy ? (
+                    <p className="font-mono text-xs text-muted-foreground">
+                      reviewed by {flag.reviewedBy}
+                    </p>
+                  ) : null}
+                </div>
+                {flag.status === "open" ? <FlagActions flagId={flag.id} /> : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/loading.tsx
+++ b/src/app/(admin)/admin/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Suspense boundary for every admin page (cacheComponents requires one). */
+export default function AdminLoading() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <div className="space-y-2">
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import { Suspense } from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatCredits, formatUsd } from "@/components/usage/format";
+import { getOverviewKpis } from "@/db/queries/admin";
+import { CREDIT_MARKUP } from "@/lib/billing/credits-shared";
+
+export const metadata = { title: "Admin — sopher.ai" };
+
+function Kpi({ label, value, note }: { label: string; value: string; note?: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-1">
+        <CardTitle className="font-mono text-[0.68rem] font-normal tracking-[0.14em] text-muted-foreground uppercase">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="font-display text-2xl font-semibold tabular-nums">{value}</p>
+        {note ? <p className="mt-0.5 text-xs text-muted-foreground">{note}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+async function Kpis() {
+  const kpis = await getOverviewKpis();
+  const revenueUsd = kpis.money.revenueUsd; // purchases at face value
+  const cogs = kpis.money.cogsUsd;
+  const margin = revenueUsd > 0 ? ((revenueUsd - cogs) / revenueUsd) * 100 : null;
+
+  return (
+    <>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Kpi
+          label="Users"
+          value={String(kpis.users.total)}
+          note={`${kpis.users.new7d} new this week${kpis.users.suspended ? ` · ${kpis.users.suspended} suspended` : ""}`}
+        />
+        <Kpi
+          label="Books"
+          value={String(kpis.books.total)}
+          note={`${kpis.books.completed7d} completed this week · ${Number(kpis.books.words).toLocaleString()} words total`}
+        />
+        <Kpi label="Revenue" value={formatUsd(revenueUsd)} note="credit purchases at face value" />
+        <Kpi
+          label="Metered COGS"
+          value={formatUsd(cogs)}
+          note={margin !== null ? `${margin.toFixed(1)}% gross margin` : "no revenue yet"}
+        />
+        <Kpi
+          label="Credit liability"
+          value={formatCredits(kpis.money.liabilityCredits)}
+          note={`≈ ${formatUsd(kpis.money.liabilityCredits / CREDIT_MARKUP)} of work owed`}
+        />
+        <Kpi
+          label="Granted credits"
+          value={formatCredits(kpis.money.grantedCredits)}
+          note="welcome grants + adjustments"
+        />
+        <Kpi
+          label="Runs"
+          value={String(kpis.runs.active)}
+          note={`active now · ${kpis.runs.failed7d} failed this week`}
+        />
+        <Kpi label="Open flags" value={String(kpis.flags.open)} note="moderation queue" />
+      </div>
+      <div className="flex flex-wrap gap-4 text-sm">
+        <a
+          className="text-primary hover:underline"
+          href="https://analytics.google.com/analytics/web/"
+        >
+          Google Analytics →
+        </a>
+        <a
+          className="text-primary hover:underline"
+          href="https://vercel.com/cheesejaguar-2353s-projects/sopher-ai/analytics"
+        >
+          Vercel Analytics →
+        </a>
+        <a className="text-primary hover:underline" href="https://dashboard.stripe.com">
+          Stripe →
+        </a>
+        <Link className="text-primary hover:underline" href="/admin/runs">
+          Debug runs →
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export default function AdminOverview() {
+  return (
+    <div className="space-y-6">
+      <h1 className="font-display text-2xl font-semibold tracking-tight">Overview</h1>
+      <Suspense
+        fallback={
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 8 }, (_, i) => (
+              <Skeleton key={i} className="h-28 rounded-xl" />
+            ))}
+          </div>
+        }
+      >
+        <Kpis />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/purchases/page.tsx
+++ b/src/app/(admin)/admin/purchases/page.tsx
@@ -80,7 +80,7 @@ export default async function AdminPurchases() {
         <TableFooter>
           <TableRow>
             <TableCell colSpan={4}>Purchased credits (face value)</TableCell>
-            <TableCell className="text-right font-mono tabular-nums">{total.toFixed(2)}</TableCell>
+            <TableCell className="text-right font-mono tabular-nums">{purchasedTotal.toFixed(2)}</TableCell>
             <TableCell />
           </TableRow>
         </TableFooter>

--- a/src/app/(admin)/admin/purchases/page.tsx
+++ b/src/app/(admin)/admin/purchases/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { RelativeTime } from "@/components/relative-time";
+import { listPurchases } from "@/db/queries/admin";
+
+export const metadata = { title: "Purchases — admin" };
+
+function stripeLink(ref: string | null): string | null {
+  if (!ref) return null;
+  if (ref.startsWith("cs_")) return `https://dashboard.stripe.com/checkout/sessions/${ref}`;
+  if (ref.startsWith("refund:")) return null;
+  return null;
+}
+
+export default async function AdminPurchases() {
+  const rows = await listPurchases();
+  const total = rows
+    .filter((r) => r.kind === "purchase")
+    .reduce((acc, r) => acc + Number(r.amount), 0);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="font-display text-2xl font-semibold tracking-tight">Purchases</h1>
+      <Table aria-label="Purchases, refunds and adjustments">
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">When</TableHead>
+            <TableHead scope="col">User</TableHead>
+            <TableHead scope="col">Kind</TableHead>
+            <TableHead scope="col">Detail</TableHead>
+            <TableHead scope="col" className="text-right">
+              Credits
+            </TableHead>
+            <TableHead scope="col">Ref</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => {
+            const link = stripeLink(row.externalRef);
+            return (
+              <TableRow key={row.id}>
+                <TableCell className="text-muted-foreground">
+                  <RelativeTime iso={row.createdAt.toISOString()} />
+                </TableCell>
+                <TableCell>
+                  <Link
+                    href={`/admin/users/${row.userId}`}
+                    className="text-primary hover:underline"
+                  >
+                    {row.email}
+                  </Link>
+                </TableCell>
+                <TableCell>{row.kind}</TableCell>
+                <TableCell className="text-muted-foreground">{row.description}</TableCell>
+                <TableCell
+                  className={`text-right font-mono tabular-nums ${Number(row.amount) < 0 ? "text-destructive" : ""}`}
+                >
+                  {Number(row.amount) > 0 ? "+" : ""}
+                  {Number(row.amount).toFixed(2)}
+                </TableCell>
+                <TableCell className="max-w-40 truncate font-mono text-xs text-muted-foreground">
+                  {link ? (
+                    <a href={link} className="text-primary hover:underline">
+                      {row.externalRef}
+                    </a>
+                  ) : (
+                    (row.externalRef ?? "—")
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={4}>Purchased credits (face value)</TableCell>
+            <TableCell className="text-right font-mono tabular-nums">{total.toFixed(2)}</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/purchases/page.tsx
+++ b/src/app/(admin)/admin/purchases/page.tsx
@@ -80,7 +80,9 @@ export default async function AdminPurchases() {
         <TableFooter>
           <TableRow>
             <TableCell colSpan={4}>Purchased credits (face value)</TableCell>
-            <TableCell className="text-right font-mono tabular-nums">{purchasedTotal.toFixed(2)}</TableCell>
+            <TableCell className="text-right font-mono tabular-nums">
+              {purchasedTotal.toFixed(2)}
+            </TableCell>
             <TableCell />
           </TableRow>
         </TableFooter>

--- a/src/app/(admin)/admin/purchases/page.tsx
+++ b/src/app/(admin)/admin/purchases/page.tsx
@@ -22,10 +22,7 @@ function stripeLink(ref: string | null): string | null {
 }
 
 export default async function AdminPurchases() {
-  const rows = await listPurchases();
-  const total = rows
-    .filter((r) => r.kind === "purchase")
-    .reduce((acc, r) => acc + Number(r.amount), 0);
+  const { rows, purchasedTotal } = await listPurchases();
 
   return (
     <div className="space-y-4">

--- a/src/app/(admin)/admin/runs/[runId]/page.tsx
+++ b/src/app/(admin)/admin/runs/[runId]/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { getRunEvents } from "@/db/queries/admin";
+
+export const metadata = { title: "Run — admin" };
+
+/**
+ * The debug view: the run's persisted event log in seq order — the server-side
+ * truth of what the author's screen showed. Pair with
+ * `npx workflow inspect run <workflowRunId>` for step-level detail.
+ */
+export default async function AdminRunDetail({ params }: { params: Promise<{ runId: string }> }) {
+  const { runId } = await params;
+  const data = await getRunEvents(runId);
+  if (!data) notFound();
+  const { run, events } = data;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="font-display text-2xl font-semibold tracking-tight">Run · {run.title}</h1>
+        <p className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          {run.email} · {run.kind} ·{" "}
+          <Badge variant={run.status === "failed" ? "destructive" : "outline"}>{run.status}</Badge>
+          <Link href={`/admin/books/${run.projectId}`} className="text-primary hover:underline">
+            view book
+          </Link>
+        </p>
+        {run.error ? (
+          <p className="mt-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+            {run.error}
+          </p>
+        ) : null}
+        {run.workflowRunId ? (
+          <p className="mt-2 font-mono text-xs text-muted-foreground">
+            npx workflow inspect run {run.workflowRunId} --backend vercel --project sopher-ai --team
+            cheesejaguar-2353s-projects
+          </p>
+        ) : null}
+      </header>
+
+      <section aria-label="Event log">
+        <ol className="space-y-1 font-mono text-xs">
+          {events.map((event) => (
+            <li key={event.seq} className="flex gap-3 rounded px-2 py-1 odd:bg-muted/40">
+              <span className="w-10 shrink-0 text-right text-muted-foreground tabular-nums">
+                {event.seq}
+              </span>
+              <span className="w-16 shrink-0 text-muted-foreground">{event.type}</span>
+              <span className="min-w-0 break-all whitespace-pre-wrap">
+                {JSON.stringify(event.payload)}
+              </span>
+            </li>
+          ))}
+          {events.length === 0 ? (
+            <li className="px-2 py-4 text-muted-foreground">No events persisted.</li>
+          ) : null}
+        </ol>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/runs/page.tsx
+++ b/src/app/(admin)/admin/runs/page.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CancelRunButton } from "@/components/admin/cancel-run-button";
+import { RelativeTime } from "@/components/relative-time";
+import { formatUsd } from "@/components/usage/format";
+import { listRuns } from "@/db/queries/admin";
+
+export const metadata = { title: "Runs — admin" };
+
+const ACTIVE = new Set(["queued", "running", "awaiting_input"]);
+
+export default async function AdminRuns() {
+  const runs = await listRuns();
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <h1 className="font-display text-2xl font-semibold tracking-tight">Generation runs</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Stuck = awaiting input for 24h+ or running for 2h+. The event log shows exactly what the
+          author saw.
+        </p>
+      </header>
+      <Table aria-label="Recent generation runs">
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">When</TableHead>
+            <TableHead scope="col">Book</TableHead>
+            <TableHead scope="col">User</TableHead>
+            <TableHead scope="col">Kind</TableHead>
+            <TableHead scope="col">Status</TableHead>
+            <TableHead scope="col" className="text-right">
+              Cost
+            </TableHead>
+            <TableHead scope="col">Error</TableHead>
+            <TableHead scope="col">
+              <span className="sr-only">Actions</span>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {runs.map((run) => (
+            <TableRow key={run.id} className={run.stuck ? "bg-ember/5" : undefined}>
+              <TableCell className="whitespace-nowrap text-muted-foreground">
+                <Link href={`/admin/runs/${run.id}`} className="text-primary hover:underline">
+                  <RelativeTime iso={run.createdAt.toISOString()} />
+                </Link>
+              </TableCell>
+              <TableCell className="max-w-48 truncate">{run.title}</TableCell>
+              <TableCell className="max-w-48 truncate text-muted-foreground">
+                <Link href={`/admin/users/${run.userId}`} className="hover:underline">
+                  {run.email}
+                </Link>
+              </TableCell>
+              <TableCell>{run.kind}</TableCell>
+              <TableCell>
+                <Badge
+                  variant={
+                    run.status === "failed" || run.stuck
+                      ? "destructive"
+                      : ACTIVE.has(run.status)
+                        ? "default"
+                        : "outline"
+                  }
+                >
+                  {run.status}
+                  {run.stuck ? " · stuck" : ""}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {formatUsd(run.usd)}
+              </TableCell>
+              <TableCell
+                className="max-w-64 truncate text-muted-foreground"
+                title={run.error ?? ""}
+              >
+                {run.error ?? "—"}
+              </TableCell>
+              <TableCell>
+                {ACTIVE.has(run.status) ? <CancelRunButton runId={run.id} /> : null}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/users/[userId]/page.tsx
+++ b/src/app/(admin)/admin/users/[userId]/page.tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { UserActions } from "@/components/admin/user-actions";
+import { RelativeTime } from "@/components/relative-time";
+import { formatCredits, formatUsd } from "@/components/usage/format";
+import { getUserDetail } from "@/db/queries/admin";
+import { requireAdmin } from "@/lib/auth";
+
+export const metadata = { title: "User — admin" };
+
+export default async function AdminUserDetail({ params }: { params: Promise<{ userId: string }> }) {
+  const { userId } = await params;
+  const { userId: adminId } = await requireAdmin();
+  const detail = await getUserDetail(userId);
+  if (!detail) notFound();
+  const { user, ledger, projects, runs, balance, callStats } = detail;
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="font-display text-2xl font-semibold tracking-tight">{user.email}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {user.name ?? "No name"} · joined <RelativeTime iso={user.createdAt.toISOString()} />
+            {user.role === "admin" ? " · admin" : ""}
+            {user.suspended ? " · SUSPENDED" : ""}
+          </p>
+          <p className="mt-1 font-mono text-sm tabular-nums">
+            {formatCredits(balance)} balance · {formatUsd(callStats.usd)} metered over{" "}
+            {callStats.calls} calls
+          </p>
+        </div>
+        <UserActions
+          userId={user.id}
+          email={user.email}
+          suspended={user.suspended}
+          isSelf={user.id === adminId}
+        />
+      </header>
+
+      <section aria-labelledby="u-projects" className="space-y-2">
+        <h2 id="u-projects" className="font-sans font-semibold">
+          Books · {projects.length}
+        </h2>
+        <Table aria-label="User's books">
+          <TableHeader>
+            <TableRow>
+              <TableHead scope="col">Title</TableHead>
+              <TableHead scope="col">Genre</TableHead>
+              <TableHead scope="col">Status</TableHead>
+              <TableHead scope="col" className="text-right">
+                Words
+              </TableHead>
+              <TableHead scope="col">Updated</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {projects.map((project) => (
+              <TableRow key={project.id}>
+                <TableCell>
+                  <Link
+                    href={`/admin/books/${project.id}`}
+                    className="text-primary hover:underline"
+                  >
+                    {project.title}
+                  </Link>
+                </TableCell>
+                <TableCell className="text-muted-foreground">{project.genre ?? "—"}</TableCell>
+                <TableCell>
+                  <Badge variant="outline">{project.status}</Badge>
+                </TableCell>
+                <TableCell className="text-right font-mono tabular-nums">
+                  {project.words.toLocaleString()}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  <RelativeTime iso={project.updatedAt.toISOString()} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section aria-labelledby="u-runs" className="space-y-2">
+        <h2 id="u-runs" className="font-sans font-semibold">
+          Recent runs
+        </h2>
+        <Table aria-label="User's runs">
+          <TableHeader>
+            <TableRow>
+              <TableHead scope="col">When</TableHead>
+              <TableHead scope="col">Kind</TableHead>
+              <TableHead scope="col">Status</TableHead>
+              <TableHead scope="col">Error</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {runs.map((run) => (
+              <TableRow key={run.id}>
+                <TableCell className="text-muted-foreground">
+                  <Link href={`/admin/runs/${run.id}`} className="hover:underline">
+                    <RelativeTime iso={run.createdAt.toISOString()} />
+                  </Link>
+                </TableCell>
+                <TableCell>{run.kind}</TableCell>
+                <TableCell>
+                  <Badge variant={run.status === "failed" ? "destructive" : "outline"}>
+                    {run.status}
+                  </Badge>
+                </TableCell>
+                <TableCell
+                  className="max-w-md truncate text-muted-foreground"
+                  title={run.error ?? ""}
+                >
+                  {run.error ?? "—"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section aria-labelledby="u-ledger" className="space-y-2">
+        <h2 id="u-ledger" className="font-sans font-semibold">
+          Ledger
+        </h2>
+        <Table aria-label="Credit ledger">
+          <TableHeader>
+            <TableRow>
+              <TableHead scope="col">When</TableHead>
+              <TableHead scope="col">Kind</TableHead>
+              <TableHead scope="col">Detail</TableHead>
+              <TableHead scope="col" className="text-right">
+                Credits
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {ledger.map((entry) => (
+              <TableRow key={entry.id}>
+                <TableCell className="text-muted-foreground">
+                  <RelativeTime iso={entry.createdAt.toISOString()} />
+                </TableCell>
+                <TableCell>{entry.kind}</TableCell>
+                <TableCell className="text-muted-foreground">{entry.description}</TableCell>
+                <TableCell
+                  className={`text-right font-mono tabular-nums ${Number(entry.amount) < 0 ? "text-muted-foreground" : "text-ai"}`}
+                >
+                  {Number(entry.amount) > 0 ? "+" : ""}
+                  {Number(entry.amount).toFixed(2)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCredits, formatUsd } from "@/components/usage/format";
+import { listUsersWithStats } from "@/db/queries/admin";
+import { RelativeTime } from "@/components/relative-time";
+
+export const metadata = { title: "Users — admin" };
+
+export default async function AdminUsers() {
+  const users = await listUsersWithStats();
+
+  return (
+    <div className="space-y-4">
+      <h1 className="font-display text-2xl font-semibold tracking-tight">Users</h1>
+      <Table aria-label="All users">
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">User</TableHead>
+            <TableHead scope="col">Joined</TableHead>
+            <TableHead scope="col" className="text-right">
+              Balance
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Metered
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Books
+            </TableHead>
+            <TableHead scope="col">Last activity</TableHead>
+            <TableHead scope="col">Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map((user) => (
+            <TableRow key={user.id}>
+              <TableCell>
+                <Link
+                  href={`/admin/users/${user.id}`}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {user.email}
+                </Link>
+                {user.name ? (
+                  <span className="ml-2 text-xs text-muted-foreground">{user.name}</span>
+                ) : null}
+                {user.role === "admin" ? (
+                  <Badge variant="outline" className="ml-2 text-[0.65rem]">
+                    admin
+                  </Badge>
+                ) : null}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                <RelativeTime iso={user.createdAt.toISOString()} />
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {formatCredits(user.balance)}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {formatUsd(user.meteredUsd)}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {user.projectCount}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {user.lastActivity ? (
+                  <RelativeTime iso={new Date(user.lastActivity).toISOString()} />
+                ) : (
+                  "—"
+                )}
+              </TableCell>
+              <TableCell>
+                {user.suspended ? <Badge variant="destructive">Suspended</Badge> : null}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { Feather } from "lucide-react";
+
+import { requireAdmin } from "@/lib/auth";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ThemeToggle } from "@/components/studio/theme-toggle";
+
+const LINKS = [
+  { href: "/admin", label: "Overview" },
+  { href: "/admin/users", label: "Users" },
+  { href: "/admin/purchases", label: "Purchases" },
+  { href: "/admin/books", label: "Books" },
+  { href: "/admin/flags", label: "Flags" },
+  { href: "/admin/runs", label: "Runs" },
+] as const;
+
+/**
+ * The admin shell. requireAdmin() failing renders a plain 404 — the surface's
+ * existence is not advertised to non-admins. The guard is an uncached DB read,
+ * so with cacheComponents the ENTIRE shell (nav included — nothing may leak
+ * into static HTML) renders inside the Suspense boundary around it.
+ */
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto w-full max-w-7xl space-y-4 px-6 py-8">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      }
+    >
+      <GuardedShell>{children}</GuardedShell>
+    </Suspense>
+  );
+}
+
+async function GuardedShell({ children }: { children: React.ReactNode }) {
+  try {
+    await requireAdmin();
+  } catch {
+    notFound();
+  }
+
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
+        <div className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between gap-6 px-6">
+          <Link
+            href="/admin"
+            className="flex items-center gap-2 font-display text-lg font-semibold tracking-tight"
+          >
+            <Feather aria-hidden="true" className="size-4 text-ember" />
+            sopher.ai{" "}
+            <span className="inline-flex items-center gap-1 font-mono text-xs text-muted-foreground">
+              <span aria-hidden="true" className="size-1.5 rounded-full bg-ember" />
+              admin
+            </span>
+          </Link>
+          <nav aria-label="Admin">
+            <ul className="flex items-center gap-1">
+              {LINKS.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="inline-flex h-8 items-center rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <div className="flex items-center gap-3">
+            <Link href="/studio" className="text-sm text-muted-foreground hover:text-foreground">
+              Studio
+            </Link>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+      <main id="main-content" tabIndex={-1} className="mx-auto w-full max-w-7xl flex-1 px-6 py-8">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/components/admin/cancel-run-button.tsx
+++ b/src/components/admin/cancel-run-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { adminCancelRun } from "@/lib/actions/admin";
+
+export function CancelRunButton({ runId }: { runId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Button
+        variant="destructive"
+        size="sm"
+        className="h-7 px-2 text-xs"
+        disabled={pending}
+        onClick={() => {
+          setError(null);
+          startTransition(async () => {
+            try {
+              await adminCancelRun(runId);
+              router.refresh();
+            } catch {
+              setError("Cancel failed");
+            }
+          });
+        }}
+      >
+        {pending ? "Cancelling…" : "Cancel run"}
+      </Button>
+      {error ? (
+        <span role="alert" className="text-xs text-destructive">
+          {error}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/admin/flag-actions.tsx
+++ b/src/components/admin/flag-actions.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { adminSetFlagStatus } from "@/lib/actions/admin";
+
+export function FlagActions({ flagId }: { flagId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function settle(status: "dismissed" | "actioned") {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await adminSetFlagStatus(flagId, status);
+        router.refresh();
+      } catch {
+        setError("Update failed");
+      }
+    });
+  }
+
+  return (
+    <span className="flex items-center gap-1.5">
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 px-2 text-xs"
+        disabled={pending}
+        onClick={() => settle("dismissed")}
+      >
+        Dismiss
+      </Button>
+      <Button
+        variant="destructive"
+        size="sm"
+        className="h-7 px-2 text-xs"
+        disabled={pending}
+        onClick={() => settle("actioned")}
+      >
+        Actioned
+      </Button>
+      {error ? (
+        <span role="alert" className="text-xs text-destructive">
+          {error}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/admin/user-actions.tsx
+++ b/src/components/admin/user-actions.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ShieldOff, ShieldCheck, Wallet } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { adminAdjustCredits, adminSetSuspended } from "@/lib/actions/admin";
+
+/** Credit adjustment + suspension controls on the admin user page. */
+export function UserActions({
+  userId,
+  email,
+  suspended,
+  isSelf,
+}: {
+  userId: string;
+  email: string;
+  suspended: boolean;
+  isSelf: boolean;
+}) {
+  const router = useRouter();
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function adjust(formData: FormData) {
+    setError(null);
+    const credits = Number(formData.get("credits"));
+    const reason = String(formData.get("reason") ?? "").trim();
+    startTransition(async () => {
+      try {
+        await adminAdjustCredits({ userId, credits, reason });
+        setAdjustOpen(false);
+        router.refresh();
+      } catch {
+        setError("Adjustment failed — check the values.");
+      }
+    });
+  }
+
+  function toggleSuspension() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        await adminSetSuspended(userId, !suspended);
+        router.refresh();
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : "Could not update suspension");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Dialog open={adjustOpen} onOpenChange={setAdjustOpen}>
+        <DialogTrigger render={<Button variant="outline" size="sm" />}>
+          <Wallet aria-hidden="true" className="size-3.5" />
+          Adjust credits
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Adjust credits for {email}</DialogTitle>
+            <DialogDescription>
+              Positive grants, negative claws back. Lands in the append-only ledger with your admin
+              id in the reference.
+            </DialogDescription>
+          </DialogHeader>
+          <form action={adjust} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="adj-credits">Credits</Label>
+              <Input
+                id="adj-credits"
+                name="credits"
+                type="number"
+                step="0.1"
+                min={-1000}
+                max={1000}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="adj-reason">Reason (recorded in the ledger)</Label>
+              <Input id="adj-reason" name="reason" required minLength={3} maxLength={300} />
+            </div>
+            {error ? (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            ) : null}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setAdjustOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending}>
+                {pending ? "Applying…" : "Apply"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Button
+        variant={suspended ? "outline" : "destructive"}
+        size="sm"
+        onClick={toggleSuspension}
+        disabled={pending || (isSelf && !suspended)}
+        title={isSelf && !suspended ? "You cannot suspend your own account" : undefined}
+      >
+        {suspended ? (
+          <>
+            <ShieldCheck aria-hidden="true" className="size-3.5" /> Unsuspend
+          </>
+        ) : (
+          <>
+            <ShieldOff aria-hidden="true" className="size-3.5" /> Suspend
+          </>
+        )}
+      </Button>
+      {error && !adjustOpen ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/db/queries/admin.ts
+++ b/src/db/queries/admin.ts
@@ -1,0 +1,361 @@
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
+
+/**
+ * Admin aggregates. Every function here is called ONLY behind requireAdmin();
+ * they read across all users by design. Single-pass SQL, no N+1.
+ */
+
+// Time cutoffs live in SQL: cacheComponents forbids Date.now() in a server
+// component before its first uncached data access.
+const weekAgoSql = sql`now() - interval '7 days'`;
+
+export async function getOverviewKpis() {
+  const db = getDb();
+
+  const [users, books, money, runs, flags] = await Promise.all([
+    db
+      .select({
+        total: sql<number>`count(*)::int`,
+        new7d: sql<number>`count(*) filter (where ${schema.users.createdAt} >= ${weekAgoSql})::int`,
+        suspended: sql<number>`count(*) filter (where ${schema.users.suspended})::int`,
+      })
+      .from(schema.users),
+    db
+      .select({
+        total: sql<number>`count(*)::int`,
+        completed7d: sql<number>`count(*) filter (where ${schema.projects.status} = 'complete' and ${schema.projects.updatedAt} >= ${weekAgoSql})::int`,
+        words: sql<number>`coalesce((select sum(c.word_count) from chapters c), 0)::bigint`,
+      })
+      .from(schema.projects),
+    db
+      .select({
+        // Revenue = money actually collected (purchases at face value).
+        revenueCredits: sql<string>`coalesce(sum(${schema.creditLedger.amount}) filter (where ${schema.creditLedger.kind} = 'purchase'), 0)`,
+        // Liability = what the ledger still owes users in work.
+        liabilityCredits: sql<string>`coalesce(sum(${schema.creditLedger.amount}), 0)`,
+        grantedCredits: sql<string>`coalesce(sum(${schema.creditLedger.amount}) filter (where ${schema.creditLedger.kind} in ('grant', 'adjustment')), 0)`,
+      })
+      .from(schema.creditLedger),
+    db
+      .select({
+        active: sql<number>`count(*) filter (where ${schema.generationRuns.status} in ('queued','running','awaiting_input'))::int`,
+        failed7d: sql<number>`count(*) filter (where ${schema.generationRuns.status} = 'failed' and ${schema.generationRuns.createdAt} >= ${weekAgoSql})::int`,
+      })
+      .from(schema.generationRuns),
+    db
+      .select({
+        open: sql<number>`count(*) filter (where ${schema.moderationFlags.status} = 'open')::int`,
+      })
+      .from(schema.moderationFlags),
+  ]);
+
+  const [cogs] = await getDb()
+    .select({ usd: sql<string>`coalesce(sum(${schema.llmCalls.usd}), 0)` })
+    .from(schema.llmCalls);
+
+  return {
+    users: users[0],
+    books: books[0],
+    money: {
+      revenueUsd: Number(money[0].revenueCredits), // 1 purchase credit == $1 paid pre-bonus? bonus credits inflate; revenue tracked at credit face value
+      liabilityCredits: Number(money[0].liabilityCredits),
+      grantedCredits: Number(money[0].grantedCredits),
+      cogsUsd: Number(cogs.usd),
+    },
+    runs: runs[0],
+    flags: flags[0],
+  };
+}
+
+export async function listUsersWithStats() {
+  const db = getDb();
+  const users = await db.select().from(schema.users).orderBy(desc(schema.users.createdAt));
+  if (users.length === 0) return [];
+  const ids = users.map((u) => u.id);
+
+  const [balances, spends, projects] = await Promise.all([
+    db
+      .select({
+        userId: schema.creditLedger.userId,
+        balance: sql<string>`coalesce(sum(${schema.creditLedger.amount}), 0)`,
+      })
+      .from(schema.creditLedger)
+      .where(inArray(schema.creditLedger.userId, ids))
+      .groupBy(schema.creditLedger.userId),
+    db
+      .select({
+        userId: schema.llmCalls.userId,
+        usd: sql<string>`coalesce(sum(${schema.llmCalls.usd}), 0)`,
+        lastAt: sql<string>`max(${schema.llmCalls.createdAt})`,
+      })
+      .from(schema.llmCalls)
+      .where(inArray(schema.llmCalls.userId, ids))
+      .groupBy(schema.llmCalls.userId),
+    db
+      .select({
+        userId: schema.projects.userId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(schema.projects)
+      .where(inArray(schema.projects.userId, ids))
+      .groupBy(schema.projects.userId),
+  ]);
+
+  const byId = <T extends { userId: string }>(rows: T[]) => new Map(rows.map((r) => [r.userId, r]));
+  const balanceMap = byId(balances);
+  const spendMap = byId(spends);
+  const projectMap = byId(projects);
+
+  return users.map((user) => ({
+    ...user,
+    balance: Number(balanceMap.get(user.id)?.balance ?? 0),
+    meteredUsd: Number(spendMap.get(user.id)?.usd ?? 0),
+    lastActivity: spendMap.get(user.id)?.lastAt ?? null,
+    projectCount: projectMap.get(user.id)?.count ?? 0,
+  }));
+}
+
+export async function getUserDetail(userId: string) {
+  const db = getDb();
+  const [user] = await db.select().from(schema.users).where(eq(schema.users.id, userId)).limit(1);
+  if (!user) return null;
+
+  const [ledger, projects, runs, callStats] = await Promise.all([
+    db
+      .select()
+      .from(schema.creditLedger)
+      .where(eq(schema.creditLedger.userId, userId))
+      .orderBy(desc(schema.creditLedger.createdAt))
+      .limit(50),
+    db
+      .select({
+        id: schema.projects.id,
+        title: schema.projects.title,
+        genre: schema.projects.genre,
+        status: schema.projects.status,
+        updatedAt: schema.projects.updatedAt,
+        words: sql<number>`coalesce((select sum(c.word_count) from chapters c join books b on b.id = c.book_id where b.project_id = "projects"."id"), 0)::int`,
+      })
+      .from(schema.projects)
+      .where(eq(schema.projects.userId, userId))
+      .orderBy(desc(schema.projects.updatedAt)),
+    db
+      .select()
+      .from(schema.generationRuns)
+      .where(eq(schema.generationRuns.userId, userId))
+      .orderBy(desc(schema.generationRuns.createdAt))
+      .limit(20),
+    db
+      .select({
+        calls: sql<number>`count(*)::int`,
+        usd: sql<string>`coalesce(sum(${schema.llmCalls.usd}), 0)`,
+      })
+      .from(schema.llmCalls)
+      .where(eq(schema.llmCalls.userId, userId)),
+  ]);
+
+  return {
+    user,
+    ledger,
+    projects,
+    runs,
+    balance: ledger.reduce((acc, e) => acc + Number(e.amount), 0),
+    callStats: { calls: callStats[0].calls, usd: Number(callStats[0].usd) },
+  };
+}
+
+export async function listPurchases() {
+  const db = getDb();
+  return db
+    .select({
+      id: schema.creditLedger.id,
+      createdAt: schema.creditLedger.createdAt,
+      kind: schema.creditLedger.kind,
+      amount: schema.creditLedger.amount,
+      description: schema.creditLedger.description,
+      externalRef: schema.creditLedger.externalRef,
+      userId: schema.creditLedger.userId,
+      email: schema.users.email,
+    })
+    .from(schema.creditLedger)
+    .innerJoin(schema.users, eq(schema.users.id, schema.creditLedger.userId))
+    .where(inArray(schema.creditLedger.kind, ["purchase", "refund", "adjustment"]))
+    .orderBy(desc(schema.creditLedger.createdAt))
+    .limit(200);
+}
+
+export async function listAllBooks() {
+  const db = getDb();
+  return db
+    .select({
+      projectId: schema.projects.id,
+      title: schema.books.title,
+      genre: schema.projects.genre,
+      status: schema.projects.status,
+      updatedAt: schema.projects.updatedAt,
+      email: schema.users.email,
+      userId: schema.users.id,
+      words: sql<number>`coalesce((select sum(c.word_count) from chapters c where c.book_id = "books"."id"), 0)::int`,
+      chapters: sql<number>`(select count(*)::int from chapters c where c.book_id = "books"."id")`,
+      openFlags: sql<number>`(select count(*)::int from moderation_flags f where f.project_id = "projects"."id" and f.status = 'open')`,
+    })
+    .from(schema.books)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.books.projectId))
+    .innerJoin(schema.users, eq(schema.users.id, schema.projects.userId))
+    .orderBy(desc(schema.projects.updatedAt))
+    .limit(200);
+}
+
+export async function listFlags(status?: "open" | "dismissed" | "actioned") {
+  const db = getDb();
+  return db
+    .select({
+      id: schema.moderationFlags.id,
+      createdAt: schema.moderationFlags.createdAt,
+      source: schema.moderationFlags.source,
+      chapterNumber: schema.moderationFlags.chapterNumber,
+      category: schema.moderationFlags.category,
+      severity: schema.moderationFlags.severity,
+      excerpt: schema.moderationFlags.excerpt,
+      detail: schema.moderationFlags.detail,
+      status: schema.moderationFlags.status,
+      reviewedBy: schema.moderationFlags.reviewedBy,
+      projectId: schema.moderationFlags.projectId,
+      title: schema.projects.title,
+      email: schema.users.email,
+      userId: schema.users.id,
+    })
+    .from(schema.moderationFlags)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.moderationFlags.projectId))
+    .innerJoin(schema.users, eq(schema.users.id, schema.projects.userId))
+    .where(status ? eq(schema.moderationFlags.status, status) : undefined)
+    .orderBy(
+      // urgent first within open; newest first otherwise
+      sql`case when ${schema.moderationFlags.severity} = 'urgent' then 0 else 1 end`,
+      desc(schema.moderationFlags.createdAt),
+    )
+    .limit(200);
+}
+
+const STUCK_AWAITING_MS = 24 * 3_600_000;
+const STUCK_RUNNING_MS = 2 * 3_600_000;
+
+export async function listRuns() {
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.generationRuns.id,
+      createdAt: schema.generationRuns.createdAt,
+      startedAt: schema.generationRuns.startedAt,
+      kind: schema.generationRuns.kind,
+      status: schema.generationRuns.status,
+      error: schema.generationRuns.error,
+      workflowRunId: schema.generationRuns.workflowRunId,
+      projectId: schema.generationRuns.projectId,
+      title: schema.projects.title,
+      email: schema.users.email,
+      userId: schema.users.id,
+      usd: sql<string>`coalesce((select sum(l.usd) from llm_calls l where l.run_id = "generation_runs"."id"), 0)`,
+    })
+    .from(schema.generationRuns)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.generationRuns.projectId))
+    .innerJoin(schema.users, eq(schema.users.id, schema.generationRuns.userId))
+    .orderBy(desc(schema.generationRuns.createdAt))
+    .limit(100);
+
+  const now = Date.now();
+  return rows.map((run) => {
+    const since = new Date(run.startedAt ?? run.createdAt).getTime();
+    return {
+      ...run,
+      usd: Number(run.usd),
+      stuck:
+        (run.status === "awaiting_input" && now - since > STUCK_AWAITING_MS) ||
+        (run.status === "running" && now - since > STUCK_RUNNING_MS),
+    };
+  });
+}
+
+export async function getRunEvents(runId: string) {
+  const db = getDb();
+  const [run] = await db
+    .select({
+      id: schema.generationRuns.id,
+      status: schema.generationRuns.status,
+      kind: schema.generationRuns.kind,
+      error: schema.generationRuns.error,
+      workflowRunId: schema.generationRuns.workflowRunId,
+      createdAt: schema.generationRuns.createdAt,
+      title: schema.projects.title,
+      email: schema.users.email,
+      projectId: schema.projects.id,
+    })
+    .from(schema.generationRuns)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.generationRuns.projectId))
+    .innerJoin(schema.users, eq(schema.users.id, schema.generationRuns.userId))
+    .where(eq(schema.generationRuns.id, runId))
+    .limit(1);
+  if (!run) return null;
+
+  const events = await db
+    .select({
+      seq: schema.generationEvents.seq,
+      type: schema.generationEvents.type,
+      payload: schema.generationEvents.payload,
+      createdAt: schema.generationEvents.createdAt,
+    })
+    .from(schema.generationEvents)
+    .where(eq(schema.generationEvents.runId, runId))
+    .orderBy(schema.generationEvents.seq);
+
+  return { run, events };
+}
+
+export async function getAdminBook(projectId: string) {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      projectId: schema.projects.id,
+      title: schema.books.title,
+      synopsis: schema.books.synopsis,
+      genre: schema.projects.genre,
+      status: schema.projects.status,
+      email: schema.users.email,
+      userId: schema.users.id,
+      bookId: schema.books.id,
+    })
+    .from(schema.projects)
+    .innerJoin(schema.books, eq(schema.books.projectId, schema.projects.id))
+    .innerJoin(schema.users, eq(schema.users.id, schema.projects.userId))
+    .where(eq(schema.projects.id, projectId))
+    .limit(1);
+  if (!row) return null;
+
+  const [chapters, flags] = await Promise.all([
+    db
+      .select({
+        id: schema.chapters.id,
+        chapterNumber: schema.chapters.chapterNumber,
+        title: schema.chapters.title,
+        content: schema.chapters.content,
+        wordCount: schema.chapters.wordCount,
+      })
+      .from(schema.chapters)
+      .where(
+        and(
+          eq(schema.chapters.bookId, row.bookId),
+          gte(sql`length(${schema.chapters.content})`, 1),
+        ),
+      )
+      .orderBy(schema.chapters.chapterNumber),
+    db
+      .select()
+      .from(schema.moderationFlags)
+      .where(eq(schema.moderationFlags.projectId, projectId))
+      .orderBy(desc(schema.moderationFlags.createdAt)),
+  ]);
+
+  return { ...row, chapters, flags };
+}

--- a/src/db/queries/admin.ts
+++ b/src/db/queries/admin.ts
@@ -122,13 +122,18 @@ export async function getUserDetail(userId: string) {
   const [user] = await db.select().from(schema.users).where(eq(schema.users.id, userId)).limit(1);
   if (!user) return null;
 
-  const [ledger, projects, runs, callStats] = await Promise.all([
+  const [ledger, balanceRow, projects, runs, callStats] = await Promise.all([
     db
       .select()
       .from(schema.creditLedger)
       .where(eq(schema.creditLedger.userId, userId))
       .orderBy(desc(schema.creditLedger.createdAt))
       .limit(50),
+    // Balance over the WHOLE ledger — the 50-row page above is display only.
+    db
+      .select({ balance: sql<string>`coalesce(sum(${schema.creditLedger.amount}), 0)` })
+      .from(schema.creditLedger)
+      .where(eq(schema.creditLedger.userId, userId)),
     db
       .select({
         id: schema.projects.id,
@@ -161,14 +166,19 @@ export async function getUserDetail(userId: string) {
     ledger,
     projects,
     runs,
-    balance: ledger.reduce((acc, e) => acc + Number(e.amount), 0),
+    balance: Number(balanceRow[0]?.balance ?? 0),
     callStats: { calls: callStats[0].calls, usd: Number(callStats[0].usd) },
   };
 }
 
 export async function listPurchases() {
   const db = getDb();
-  return db
+  const [totals] = await db
+    .select({
+      purchased: sql<string>`coalesce(sum(${schema.creditLedger.amount}) filter (where ${schema.creditLedger.kind} = 'purchase'), 0)`,
+    })
+    .from(schema.creditLedger);
+  const rows = await db
     .select({
       id: schema.creditLedger.id,
       createdAt: schema.creditLedger.createdAt,
@@ -184,6 +194,7 @@ export async function listPurchases() {
     .where(inArray(schema.creditLedger.kind, ["purchase", "refund", "adjustment"]))
     .orderBy(desc(schema.creditLedger.createdAt))
     .limit(200);
+  return { rows, purchasedTotal: Number(totals.purchased) };
 }
 
 export async function listAllBooks() {

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -30,7 +30,7 @@ export async function adminAdjustCredits(input: unknown): Promise<void> {
     description: `Adjustment: ${data.reason}`,
     // The acting admin travels in the idempotency ref — audit and uniqueness.
     externalRef: `admin:${adminId}:${crypto.randomUUID()}`,
-    kind: "grant",
+    kind: "adjustment",
   });
   revalidatePath(`/admin/users/${data.userId}`);
   revalidatePath("/admin");

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "@/db";
+import { requireAdmin } from "@/lib/auth";
+import { grantCredits } from "@/lib/billing/credits";
+
+/**
+ * Admin actions. Every mutation is (a) behind requireAdmin, (b) auditable —
+ * credit changes land in the append-only ledger with the acting admin in the
+ * ref, flag reviews record the reviewer — and (c) reversible except where the
+ * underlying system is (a cancelled run is cancelled).
+ */
+
+const adjustSchema = z.object({
+  userId: z.string().min(1),
+  credits: z.number().finite().min(-1000).max(1000),
+  reason: z.string().min(3).max(300),
+});
+
+export async function adminAdjustCredits(input: unknown): Promise<void> {
+  const { userId: adminId } = await requireAdmin();
+  const data = adjustSchema.parse(input);
+  await grantCredits({
+    userId: data.userId,
+    credits: data.credits,
+    description: `Adjustment: ${data.reason}`,
+    // The acting admin travels in the idempotency ref — audit and uniqueness.
+    externalRef: `admin:${adminId}:${crypto.randomUUID()}`,
+    kind: "grant",
+  });
+  revalidatePath(`/admin/users/${data.userId}`);
+  revalidatePath("/admin");
+}
+
+export async function adminSetSuspended(userId: string, suspended: boolean): Promise<void> {
+  const { userId: adminId } = await requireAdmin();
+  // An admin cannot suspend themselves — trivially reversible otherwise, but
+  // locking the only key in the car is not a state worth allowing.
+  if (userId === adminId && suspended) throw new Error("You cannot suspend your own account");
+  const db = getDb();
+  await db
+    .update(schema.users)
+    .set({ suspended, updatedAt: new Date() })
+    .where(eq(schema.users.id, userId));
+  revalidatePath(`/admin/users/${userId}`);
+  revalidatePath("/admin/users");
+}
+
+export async function adminSetFlagStatus(
+  flagId: string,
+  status: "dismissed" | "actioned",
+): Promise<void> {
+  const { userId: adminId } = await requireAdmin();
+  if (!z.uuid().safeParse(flagId).success) throw new Error("Flag not found");
+  await getDb()
+    .update(schema.moderationFlags)
+    .set({ status, reviewedBy: adminId })
+    .where(eq(schema.moderationFlags.id, flagId));
+  revalidatePath("/admin/flags");
+}
+
+/** Cancels a stuck run: workflow first (best effort), then the DB state. */
+export async function adminCancelRun(runId: string): Promise<void> {
+  await requireAdmin();
+  if (!z.uuid().safeParse(runId).success) throw new Error("Run not found");
+  const db = getDb();
+  const [run] = await db
+    .select({
+      id: schema.generationRuns.id,
+      status: schema.generationRuns.status,
+      projectId: schema.generationRuns.projectId,
+      workflowRunId: schema.generationRuns.workflowRunId,
+    })
+    .from(schema.generationRuns)
+    .where(eq(schema.generationRuns.id, runId))
+    .limit(1);
+  if (!run) throw new Error("Run not found");
+  if (!["queued", "running", "awaiting_input"].includes(run.status)) return;
+
+  if (run.workflowRunId) {
+    try {
+      const { getRun } = await import("workflow/api");
+      await getRun(run.workflowRunId).cancel();
+    } catch (error) {
+      // The workflow may already be dead — the DB state is what users see.
+      console.warn("[admin] workflow cancel failed:", error);
+    }
+  }
+
+  await db
+    .update(schema.generationRuns)
+    .set({ status: "cancelled", completedAt: new Date() })
+    .where(
+      and(
+        eq(schema.generationRuns.id, runId),
+        inArray(schema.generationRuns.status, ["queued", "running", "awaiting_input"]),
+      ),
+    );
+  await db
+    .update(schema.projects)
+    .set({ status: "draft", updatedAt: new Date() })
+    .where(and(eq(schema.projects.id, run.projectId), eq(schema.projects.status, "generating")));
+  revalidatePath("/admin/runs");
+}

--- a/src/lib/billing/credits.ts
+++ b/src/lib/billing/credits.ts
@@ -52,7 +52,7 @@ export async function grantCredits(input: {
   credits: number;
   description: string;
   externalRef: string;
-  kind?: "purchase" | "refund" | "grant";
+  kind?: "purchase" | "refund" | "grant" | "adjustment";
 }): Promise<boolean> {
   const inserted = await getDb()
     .insert(schema.creditLedger)


### PR DESCRIPTION
Second half of the admin build (platform landed in #132).

## The surface

Route group `(admin)/admin`, guarded by `requireAdmin()` → **plain 404** for everyone else. The entire shell — nav included — renders inside the guard's Suspense boundary, so nothing about the admin surface leaks into static HTML.

- **Overview** — users/books KPIs, revenue vs metered COGS with gross margin, and **outstanding credit liability** (the sum of all unspent credits — the accounting number). Deep links to GA, Vercel Analytics, Stripe.
- **Users** — cross-user table + detail with ledger, projects, runs. Actions: **credit adjustments** (append-only ledger entries with the acting admin's id in the idempotency ref) and **suspend/unsuspend**, with a can't-suspend-yourself guard.
- **Purchases** — purchase/refund/adjustment ledger across users, Stripe checkout-session deep links, face-value totals.
- **Books** — every book with open-flag badges; a **read-only manuscript view** for terms enforcement, bannered as the author's private work, rendered through the same escaped-HTML pipeline as the author-facing reading view, zero edit affordances.
- **Flags** — the moderation queue, urgent-first. Dismiss / Actioned record the reviewer; suspension deliberately stays a separate step on the user page.
- **Runs** — cross-user runs with **stuck detection** (awaiting input 24h+ / running 2h+), per-run cost, admin cancel (workflow first, DB second), and an **event-log viewer** reading `generation_events` in seq order — the server-side truth of what the author saw, with the `workflow inspect` command printed for step-level digging.

## What e2e caught before the bots did

- **Drizzle renders `${schema.x.y}` unqualified inside `sql`` fragments** — every correlated subquery produced ambiguous columns and failed at runtime. All now explicit table-qualified SQL.
- The header's ember "admin" label failed AA contrast at small size — muted text with an ember dot now.
- Plus the cacheComponents pair: the layout's own guard is uncached DB access (whole shell now under Suspense), and `Date.now()` before first data access (time cutoffs moved into SQL `now() - interval`).

## Verification

Local e2e **34/34** including three admin specs under the axe gate (overview KPIs, users table → detail with actions, flag queue empty state). 316 unit tests; typecheck/lint/format/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces privileged cross-user reads (manuscripts, ledgers) and mutations (credits, suspension, run cancel, flag review); correctness of `requireAdmin` on every path is security-critical.
> 
> **Overview**
> Adds a full **admin** route group under `(admin)/admin`, gated by `requireAdmin()` with a **404** for non-admins so the shell never appears in static HTML. The layout wraps the entire nav and content in **Suspense** around the guard.
> 
> **Overview** loads cross-tenant KPIs (users, books, revenue vs metered COGS, credit liability, open flags) via new `src/db/queries/admin.ts` aggregates, with links to external analytics and Stripe.
> 
> **Users** lists accounts with balances and metered spend; detail pages show ledger, books, and runs, plus **Adjust credits** and **Suspend/Unsuspend** through `src/lib/actions/admin.ts` (ledger refs include the acting admin id; self-suspend is blocked).
> 
> **Purchases**, **Books** (table with open-flag counts), **Flags** (status-filtered queue with Dismiss/Actioned), and **Runs** (stuck detection, cancel, per-run **event log**) round out operations. Books include a **read-only manuscript** view for enforcement (same escaped HTML pipeline as authors, no edits).
> 
> Playwright adds three admin e2e specs (overview KPIs, users → detail actions, flags empty state). Admin pages use a shared `loading.tsx` skeleton for `cacheComponents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5501f7dedbf7705be84919ed95ea54465febe7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->