### PR TITLE
seo: give the site something to actually rank

### DIFF
--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -5,9 +5,27 @@
  * page missing from the sitemap, or JSON-LD that stops parsing costs traffic
  * for weeks before anyone notices, and nothing in the app breaks.
  */
-import { expect, test } from "./helpers";
+import { axeCheck, expect, test } from "./helpers";
 
-const PUBLIC_PAGES = ["/", "/pricing", "/terms", "/privacy", "/refunds"];
+const PUBLIC_PAGES = ["/", "/pricing", "/terms", "/privacy", "/refunds", "/genres", "/guides"];
+
+/** Kept in sync with GENRE_PAGES / GUIDES by the sitemap test below. */
+const GENRE_SLUGS = [
+  "romance",
+  "mystery",
+  "fantasy",
+  "thriller",
+  "literary-fiction",
+  "science-fiction",
+  "horror",
+];
+const GUIDE_SLUGS = [
+  "how-book-generation-works",
+  "choosing-a-quality-tier",
+  "point-of-view-and-tense",
+  "content-settings",
+  "what-the-editorial-pass-checks",
+];
 
 test.describe("sitemap and robots", () => {
   test("sitemap lists every public page with a lastModified", async ({ request }) => {
@@ -16,6 +34,20 @@ test.describe("sitemap and robots", () => {
       expect(xml, `sitemap missing ${path}`).toContain(`<loc>https://sopher.ai${path}</loc>`);
     }
     expect(xml).toContain("<lastmod>");
+  });
+
+  test("sitemap lists every genre and guide page", async ({ request }) => {
+    const xml = await (await request.get("/sitemap.xml")).text();
+    for (const slug of GENRE_SLUGS) {
+      expect(xml, `sitemap missing /genres/${slug}`).toContain(
+        `<loc>https://sopher.ai/genres/${slug}</loc>`,
+      );
+    }
+    for (const slug of GUIDE_SLUGS) {
+      expect(xml, `sitemap missing /guides/${slug}`).toContain(
+        `<loc>https://sopher.ai/guides/${slug}</loc>`,
+      );
+    }
   });
 
   test("robots names the AI crawlers and hides the private surfaces", async ({ request }) => {
@@ -98,6 +130,52 @@ test.describe("structured data", () => {
     expect(product).toBeTruthy();
     const prices = product.offers.map((offer: { price: string }) => offer.price);
     expect(prices).toEqual(["25.00", "60.00", "120.00", "300.00"]);
+  });
+
+  test("every genre page has a canonical, one h1, and FAQ structured data", async ({ page }) => {
+    for (const slug of GENRE_SLUGS) {
+      await page.goto(`/genres/${slug}`);
+      await expect(page.locator("h1")).toHaveCount(1);
+      await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+        "href",
+        `https://sopher.ai/genres/${slug}`,
+      );
+      const types = (
+        await page.locator('script[type="application/ld+json"]').allTextContents()
+      ).map((raw) => JSON.parse(raw)["@type"]);
+      expect(types, `/genres/${slug} missing FAQPage`).toContain("FAQPage");
+      expect(types, `/genres/${slug} missing BreadcrumbList`).toContain("BreadcrumbList");
+    }
+  });
+
+  test("every guide page has a canonical and one h1", async ({ page }) => {
+    for (const slug of GUIDE_SLUGS) {
+      await page.goto(`/guides/${slug}`);
+      await expect(page.locator("h1")).toHaveCount(1);
+      await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+        "href",
+        `https://sopher.ai/guides/${slug}`,
+      );
+    }
+  });
+
+  test("genre CTA pre-seeds the wizard", async ({ page }) => {
+    await page.goto("/genres/fantasy");
+    const cta = page.getByRole("link", { name: /start a fantasy book/i });
+    await expect(cta).toHaveAttribute("href", "/studio/new?genre=fantasy");
+  });
+
+  // The new pages are mostly dl/ol/ul-heavy prose, which is exactly where
+  // heading-order and contrast regressions hide.
+  test("a genre page and a guide page pass axe", async ({ page }) => {
+    await page.goto("/genres/fantasy");
+    await axeCheck(page);
+    await page.goto("/guides/how-book-generation-works");
+    await axeCheck(page);
+    await page.goto("/genres");
+    await axeCheck(page);
+    await page.goto("/guides");
+    await axeCheck(page);
   });
 
   test("the FAQ is on the homepage, not only on /pricing", async ({ page }) => {

--- a/src/app/(marketing)/genres/[genre]/page.tsx
+++ b/src/app/(marketing)/genres/[genre]/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight } from "lucide-react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { BreadcrumbJsonLd, FaqJsonLd, SITE_URL } from "@/components/seo/json-ld";
+import { GENRE_PAGES, getGenrePage } from "@/lib/marketing/genre-pages";
+import { cn } from "@/lib/utils";
+
+/**
+ * Genre landing pages.
+ *
+ * The site had five public pages and about 2,400 words, more than half of it
+ * legal boilerplate — nothing for search to rank and nothing for an answer
+ * engine to cite. These are the seven pages the product already had the
+ * knowledge to write honestly: the craft content comes from the same templates
+ * the outliner uses, so the page describes what the product actually does.
+ */
+
+export function generateStaticParams() {
+  return GENRE_PAGES.map((page) => ({ genre: page.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ genre: string }>;
+}): Promise<Metadata> {
+  const { genre } = await params;
+  const page = getGenrePage(genre);
+  if (!page) return {};
+  return {
+    title: `${page.heading} with AI`,
+    description: page.metaDescription,
+    alternates: { canonical: `/genres/${page.slug}` },
+    openGraph: {
+      title: `${page.heading} with AI · sopher.ai`,
+      description: page.metaDescription,
+      url: `${SITE_URL}/genres/${page.slug}`,
+    },
+  };
+}
+
+export default async function GenrePage({ params }: { params: Promise<{ genre: string }> }) {
+  const { genre } = await params;
+  const page = getGenrePage(genre);
+  if (!page) notFound();
+
+  const others = GENRE_PAGES.filter((other) => other.id !== page.id);
+
+  return (
+    <>
+      <FaqJsonLd items={page.faqs} />
+      <BreadcrumbJsonLd
+        trail={[
+          { name: "Genres", path: "/genres" },
+          { name: page.name, path: `/genres/${page.slug}` },
+        ]}
+      />
+
+      <article className="mx-auto w-full max-w-3xl px-6 py-20 sm:py-28">
+        <p className="font-mono text-xs tracking-[0.2em] text-primary uppercase">{page.name}</p>
+        <h1 className="mt-3 font-display text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+          {page.heading} with AI
+        </h1>
+
+        <div className="mt-8 space-y-5 text-lg text-pretty text-muted-foreground">
+          {page.intro.map((paragraph) => (
+            <p key={paragraph.slice(0, 32)}>{paragraph}</p>
+          ))}
+        </div>
+
+        <p className="mt-8">
+          <Link
+            href={`/studio/new?genre=${page.id}`}
+            className={cn(buttonVariants({ size: "lg" }))}
+          >
+            Start a {page.name.toLowerCase()} book
+            <ArrowRight aria-hidden="true" className="size-4" />
+          </Link>
+        </p>
+
+        <section aria-labelledby="elements-heading" className="mt-16">
+          <h2 id="elements-heading" className="font-display text-2xl font-semibold tracking-tight">
+            What a {page.name.toLowerCase()} book needs
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            These are the structural elements the outliner plans for, and where each one belongs.
+          </p>
+          <dl className="mt-6 space-y-5">
+            {page.coreElements.map((element) => (
+              <div key={element.name}>
+                <dt className="font-medium">
+                  {element.name}
+                  <span className="ml-2 font-mono text-xs font-normal text-muted-foreground">
+                    {element.whenToInclude}
+                  </span>
+                </dt>
+                <dd className="mt-1 text-sm text-pretty text-muted-foreground">
+                  {element.description}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section aria-labelledby="expect-heading" className="mt-14">
+          <h2 id="expect-heading" className="font-display text-2xl font-semibold tracking-tight">
+            What {page.name.toLowerCase()} readers expect
+          </h2>
+          <ul className="mt-5 space-y-2 text-muted-foreground">
+            {page.readerExpectations.map((expectation) => (
+              <li key={expectation} className="flex gap-3">
+                <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-ai" />
+                <span className="text-pretty">{expectation}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm text-pretty text-muted-foreground">
+            <strong className="font-medium text-foreground">Pacing.</strong> {page.pacingNotes}
+          </p>
+        </section>
+
+        <section aria-labelledby="sub-heading" className="mt-14">
+          <h2 id="sub-heading" className="font-display text-2xl font-semibold tracking-tight">
+            Subgenres and tropes
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Pick a subgenre in the wizard and the structural guidance adapts to it.
+          </p>
+          <ul className="mt-5 flex flex-wrap gap-2">
+            {page.subgenres.map((subgenre) => (
+              <li
+                key={subgenre}
+                className="rounded-full border border-border px-3 py-1 text-sm text-muted-foreground"
+              >
+                {subgenre}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm text-pretty text-muted-foreground">
+            Familiar territory the genre draws on: {page.commonTropes.join(", ")}. Ask for them or
+            ask for something else — the brief decides.
+          </p>
+        </section>
+
+        <section aria-labelledby="faq-heading" className="mt-14">
+          <h2 id="faq-heading" className="font-display text-2xl font-semibold tracking-tight">
+            Questions about {page.name.toLowerCase()}
+          </h2>
+          <dl className="mt-6 space-y-6">
+            {page.faqs.map((faq) => (
+              <div key={faq.question}>
+                <dt className="font-medium">{faq.question}</dt>
+                <dd className="mt-1.5 text-sm text-pretty text-muted-foreground">{faq.answer}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section aria-labelledby="other-heading" className="mt-16 border-t border-border pt-8">
+          <h2 id="other-heading" className="font-sans text-sm font-semibold">
+            Other genres
+          </h2>
+          <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm">
+            {others.map((other) => (
+              <li key={other.id}>
+                <Link href={`/genres/${other.slug}`} className="text-primary hover:underline">
+                  {other.name}
+                </Link>
+              </li>
+            ))}
+            <li>
+              <Link href="/guides" className="text-primary hover:underline">
+                Guides
+              </Link>
+            </li>
+            <li>
+              <Link href="/pricing" className="text-primary hover:underline">
+                Pricing
+              </Link>
+            </li>
+          </ul>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/(marketing)/genres/page.tsx
+++ b/src/app/(marketing)/genres/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
+import { GENRE_PAGES } from "@/lib/marketing/genre-pages";
+
+export const metadata: Metadata = {
+  title: "Genres",
+  description:
+    "Romance, mystery, fantasy, thriller, literary fiction, science fiction, horror — what each genre needs structurally, and how sopher.ai plans for it.",
+  alternates: { canonical: "/genres" },
+};
+
+export default function GenresIndex() {
+  return (
+    <>
+      <BreadcrumbJsonLd trail={[{ name: "Genres", path: "/genres" }]} />
+      <div className="mx-auto w-full max-w-4xl px-6 py-20 sm:py-28">
+        <h1 className="font-display text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+          Every genre has its own rules
+        </h1>
+        <p className="mt-5 max-w-2xl text-lg text-pretty text-muted-foreground">
+          A mystery is broken by a clue that arrives after the reveal. A romance is broken by a
+          conflict a single conversation would fix. The outline is planned against the genre&rsquo;s
+          actual structure before a word is drafted, which is what makes the difference.
+        </p>
+
+        <ul className="mt-12 grid gap-4 sm:grid-cols-2">
+          {GENRE_PAGES.map((page) => (
+            <li key={page.id}>
+              <Link
+                href={`/genres/${page.slug}`}
+                className="block h-full rounded-xl border border-border bg-card p-5 transition-colors hover:border-foreground/25"
+              >
+                <h2 className="font-display text-lg font-semibold tracking-tight">{page.name}</h2>
+                <p className="mt-1.5 text-sm text-pretty text-muted-foreground">
+                  {page.description}
+                </p>
+                <p className="mt-3 font-mono text-[0.68rem] tracking-[0.12em] text-muted-foreground uppercase">
+                  {page.coreElements.length} structural elements · {page.subgenres.length} subgenres
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/src/app/(marketing)/guides/[slug]/page.tsx
+++ b/src/app/(marketing)/guides/[slug]/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { BreadcrumbJsonLd, FaqJsonLd, SITE_URL } from "@/components/seo/json-ld";
+import { GUIDES, getGuide, type GuideBlock } from "@/lib/marketing/guides";
+
+export function generateStaticParams() {
+  return GUIDES.map((guide) => ({ slug: guide.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const guide = getGuide(slug);
+  if (!guide) return {};
+  return {
+    title: guide.title,
+    description: guide.description,
+    alternates: { canonical: `/guides/${guide.slug}` },
+    openGraph: {
+      title: `${guide.title} · sopher.ai`,
+      description: guide.description,
+      url: `${SITE_URL}/guides/${guide.slug}`,
+      type: "article",
+    },
+  };
+}
+
+/** Blocks render to real semantic markup — every list is a list a crawler parses. */
+function Block({ block }: { block: GuideBlock }) {
+  switch (block.kind) {
+    case "h2":
+      return (
+        <h2
+          id={block.id}
+          className="mt-12 font-display text-2xl font-semibold tracking-tight scroll-mt-24"
+        >
+          {block.text}
+        </h2>
+      );
+    case "p":
+      return <p className="mt-4 text-pretty text-muted-foreground">{block.text}</p>;
+    case "list":
+      return (
+        <ul className="mt-4 space-y-2">
+          {block.items.map((item) => (
+            <li key={item} className="flex gap-3 text-muted-foreground">
+              <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-ai" />
+              <span className="text-pretty">{item}</span>
+            </li>
+          ))}
+        </ul>
+      );
+    case "steps":
+      return (
+        <ol className="mt-5 space-y-4">
+          {block.items.map((item, index) => (
+            <li key={item.name} className="flex gap-4">
+              <span
+                aria-hidden="true"
+                className="mt-0.5 font-mono text-xs tabular-nums text-primary"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span>
+                <strong className="font-medium">{item.name}</strong>
+                <span className="mt-0.5 block text-sm text-pretty text-muted-foreground">
+                  {item.text}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      );
+    case "note":
+      return (
+        <p className="mt-6 rounded-lg border border-ai/40 bg-ai-soft px-4 py-3 text-sm text-pretty">
+          {block.text}
+        </p>
+      );
+  }
+}
+
+export default async function GuidePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const guide = getGuide(slug);
+  if (!guide) notFound();
+
+  const others = GUIDES.filter((other) => other.slug !== guide.slug);
+
+  return (
+    <>
+      {guide.faqs ? <FaqJsonLd items={guide.faqs} /> : null}
+      <BreadcrumbJsonLd
+        trail={[
+          { name: "Guides", path: "/guides" },
+          { name: guide.title, path: `/guides/${guide.slug}` },
+        ]}
+      />
+
+      <article className="mx-auto w-full max-w-2xl px-6 py-20 sm:py-28">
+        <p className="font-mono text-xs tracking-[0.2em] text-primary uppercase">
+          <Link href="/guides" className="hover:underline">
+            Guides
+          </Link>
+        </p>
+        <h1 className="mt-3 font-display text-4xl font-semibold tracking-tight text-balance">
+          {guide.title}
+        </h1>
+        <p className="mt-4 text-lg text-pretty text-muted-foreground">{guide.standfirst}</p>
+
+        <div className="mt-8">
+          {guide.blocks.map((block, index) => (
+            <Block key={`${block.kind}-${index}`} block={block} />
+          ))}
+        </div>
+
+        {guide.faqs ? (
+          <section aria-labelledby="guide-faq" className="mt-14">
+            <h2 id="guide-faq" className="font-display text-2xl font-semibold tracking-tight">
+              Questions
+            </h2>
+            <dl className="mt-6 space-y-6">
+              {guide.faqs.map((faq) => (
+                <div key={faq.question}>
+                  <dt className="font-medium">{faq.question}</dt>
+                  <dd className="mt-1.5 text-sm text-pretty text-muted-foreground">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ) : null}
+
+        <nav aria-label="Other guides" className="mt-16 border-t border-border pt-8 text-sm">
+          <p className="font-sans font-semibold">Keep reading</p>
+          <ul className="mt-3 space-y-1.5">
+            {others.map((other) => (
+              <li key={other.slug}>
+                <Link href={`/guides/${other.slug}`} className="text-primary hover:underline">
+                  {other.title}
+                </Link>
+              </li>
+            ))}
+            <li>
+              <Link href="/genres" className="text-primary hover:underline">
+                Writing in a specific genre
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </article>
+    </>
+  );
+}

--- a/src/app/(marketing)/guides/page.tsx
+++ b/src/app/(marketing)/guides/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
+import { GUIDES } from "@/lib/marketing/guides";
+
+export const metadata: Metadata = {
+  title: "Guides",
+  description:
+    "How book generation works, choosing a quality tier, point of view and tense, content settings, and what the editorial pass checks.",
+  alternates: { canonical: "/guides" },
+};
+
+export default function GuidesIndex() {
+  return (
+    <>
+      <BreadcrumbJsonLd trail={[{ name: "Guides", path: "/guides" }]} />
+      <div className="mx-auto w-full max-w-3xl px-6 py-20 sm:py-28">
+        <h1 className="font-display text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+          Guides
+        </h1>
+        <p className="mt-5 max-w-2xl text-lg text-pretty text-muted-foreground">
+          What the product actually does, described honestly — the stages a book goes through, what
+          each setting changes, and where your judgement matters most.
+        </p>
+
+        <ul className="mt-12 divide-y divide-border border-y border-border">
+          {GUIDES.map((guide) => (
+            <li key={guide.slug}>
+              <Link
+                href={`/guides/${guide.slug}`}
+                className="group block py-5 transition-colors hover:bg-accent/40"
+              >
+                <h2 className="font-display text-lg font-semibold tracking-tight group-hover:text-primary">
+                  {guide.title}
+                </h2>
+                <p className="mt-1 text-sm text-pretty text-muted-foreground">{guide.standfirst}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -28,6 +28,18 @@ export default function MarketingLayout({ children }: { children: ReactNode }) {
               How it works
             </Link>
             <Link
+              href="/genres"
+              className="hidden text-sm text-muted-foreground transition-colors hover:text-foreground sm:inline"
+            >
+              Genres
+            </Link>
+            <Link
+              href="/guides"
+              className="hidden text-sm text-muted-foreground transition-colors hover:text-foreground sm:inline"
+            >
+              Guides
+            </Link>
+            <Link
               href="/pricing"
               className={cn(
                 buttonVariants({ variant: "ghost", size: "sm" }),
@@ -76,6 +88,22 @@ export default function MarketingLayout({ children }: { children: ReactNode }) {
                     className="text-muted-foreground transition-colors hover:text-foreground"
                   >
                     Pricing
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/genres"
+                    className="text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Genres
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/guides"
+                    className="text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Guides
                   </Link>
                 </li>
                 <li>

--- a/src/app/(studio)/studio/new/page.tsx
+++ b/src/app/(studio)/studio/new/page.tsx
@@ -1,12 +1,28 @@
 import type { Metadata } from "next";
 
 import { NewBookWizard } from "@/components/wizard/new-book-wizard";
+import { GENRE_IDS, type GenreId } from "@/ai/knowledge/genres";
 
 export const metadata: Metadata = {
   title: "A new book",
 };
 
-export default function NewBookPage() {
+/**
+ * The genre landing pages link here with ?genre=, so someone who arrived from a
+ * search for "write a fantasy novel" does not have to re-answer the question
+ * they already answered by clicking. Validated against the catalog — an unknown
+ * value is ignored rather than trusted.
+ */
+export default async function NewBookPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ genre?: string }>;
+}) {
+  const { genre } = await searchParams;
+  const initialGenre = (GENRE_IDS as readonly string[]).includes(genre ?? "")
+    ? (genre as GenreId)
+    : undefined;
+
   return (
     <div className="mx-auto max-w-3xl space-y-8">
       <header className="space-y-1">
@@ -16,7 +32,7 @@ export default function NewBookPage() {
         </p>
       </header>
 
-      <NewBookWizard />
+      <NewBookWizard initialGenre={initialGenre} />
     </div>
   );
 }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,6 +1,8 @@
 import { CREDIT_PACKS } from "@/lib/billing/credits-shared";
 import { FAQS, PIPELINE_STEPS } from "@/components/marketing/content";
 import { SITE_URL } from "@/components/seo/json-ld";
+import { GENRE_PAGES } from "@/lib/marketing/genre-pages";
+import { GUIDES } from "@/lib/marketing/guides";
 
 /**
  * /llms.txt — the convention answer engines and agents look for when they want
@@ -23,6 +25,14 @@ function body(): string {
   ).join("\n");
 
   const faqs = FAQS.map((f) => `### ${f.question}\n\n${f.answer}`).join("\n\n");
+
+  const genrePages = GENRE_PAGES.map(
+    (g) => `- [${g.name}](${SITE_URL}/genres/${g.slug}): ${g.description}`,
+  ).join("\n");
+
+  const guidePages = GUIDES.map(
+    (g) => `- [${g.title}](${SITE_URL}/guides/${g.slug}): ${g.standfirst}`,
+  ).join("\n");
 
   return `# sopher.ai
 
@@ -76,6 +86,14 @@ ${faqs}
 - [Terms](${SITE_URL}/terms): terms of service
 - [Privacy](${SITE_URL}/privacy): what is collected and who processes it
 - [Refunds](${SITE_URL}/refunds): refund policy
+
+### Genres
+
+${genrePages}
+
+### Guides
+
+${guidePages}
 
 ## Contact
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from "next";
 
 import { SITE_URL } from "@/components/seo/json-ld";
+import { GENRE_PAGES } from "@/lib/marketing/genre-pages";
+import { GUIDES } from "@/lib/marketing/guides";
 
 /**
  * `lastModified` was missing on every entry, leaving crawlers no freshness
@@ -15,6 +17,7 @@ const UPDATED = {
   home: new Date("2026-07-29"),
   pricing: new Date("2026-07-29"),
   legal: new Date("2026-07-29"),
+  content: new Date("2026-07-29"),
 };
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -49,5 +52,31 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.3,
       lastModified: UPDATED.legal,
     },
+    // Genres and guides are generated from the same lists the pages render, so
+    // a new one cannot be added without appearing here.
+    {
+      url: `${SITE_URL}/genres`,
+      changeFrequency: "monthly",
+      priority: 0.7,
+      lastModified: UPDATED.content,
+    },
+    ...GENRE_PAGES.map((page) => ({
+      url: `${SITE_URL}/genres/${page.slug}`,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+      lastModified: UPDATED.content,
+    })),
+    {
+      url: `${SITE_URL}/guides`,
+      changeFrequency: "monthly",
+      priority: 0.7,
+      lastModified: UPDATED.content,
+    },
+    ...GUIDES.map((guide) => ({
+      url: `${SITE_URL}/guides/${guide.slug}`,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+      lastModified: UPDATED.content,
+    })),
   ];
 }

--- a/src/components/wizard/new-book-wizard.tsx
+++ b/src/components/wizard/new-book-wizard.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, ArrowRight, Feather } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { startBook } from "@/lib/actions/projects";
 import { track } from "@/lib/analytics/track";
+import type { GenreId } from "@/ai/knowledge/genres";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { StepBrief } from "@/components/wizard/step-brief";
@@ -126,7 +127,7 @@ function draftHasContent(draft: WizardState): boolean {
   return draft.genre !== null || draft.brief.trim().length > 0 || draft.title.trim().length > 0;
 }
 
-export function NewBookWizard() {
+export function NewBookWizard({ initialGenre }: { initialGenre?: GenreId } = {}) {
   const [ui, dispatch] = React.useReducer(uiReducer, {
     wizard: initialWizardState,
     resumed: false,
@@ -195,15 +196,23 @@ export function NewBookWizard() {
   React.useEffect(() => {
     const draft = restoreDraft(window.localStorage.getItem(WIZARD_DRAFT_KEY));
     if (draft && draftHasContent(draft)) {
+      // A saved draft wins over the link's genre — the work they already did
+      // beats a hint from the URL.
       dispatch({ type: "resume", state: draft });
     } else {
       const tier = window.localStorage.getItem(DEFAULT_TIER_KEY);
-      if (tier === "draft" || tier === "standard" || tier === "premium") {
-        dispatch({ type: "patch", patch: { tier } });
+      const patch: Partial<WizardState> = {};
+      if (tier === "draft" || tier === "standard" || tier === "premium") patch.tier = tier;
+      // Arriving from a genre landing page: skip the question they answered by
+      // clicking, and open on the brief step.
+      if (initialGenre) {
+        patch.genre = initialGenre;
+        patch.step = 1;
       }
+      if (Object.keys(patch).length > 0) dispatch({ type: "patch", patch });
     }
     hydrated.current = true;
-  }, []);
+  }, [initialGenre]);
 
   // Persist the draft, debounced, so a closed tab costs nothing.
   React.useEffect(() => {

--- a/src/lib/marketing/genre-pages.ts
+++ b/src/lib/marketing/genre-pages.ts
@@ -1,0 +1,257 @@
+import { GENRE_IDS, GENRE_TEMPLATES, type GenreId } from "@/ai/knowledge/genres";
+
+/**
+ * Public genre pages.
+ *
+ * The craft knowledge — core elements, reader expectations, tropes, pacing —
+ * comes from `src/ai/knowledge/genres.ts`, the same templates the outliner
+ * actually uses. That is the point: the page describes what the product will
+ * genuinely do, so it cannot drift into marketing that overpromises.
+ *
+ * What lives here instead is the reader-facing framing: a headline, an
+ * opening paragraph, and a genre-specific FAQ. The templates are written for a
+ * model, in imperatives and percentages; a person arriving from a search
+ * result needs prose.
+ */
+
+export type GenrePageContent = {
+  /** Page h1. Reads as a thing a person would search for. */
+  heading: string;
+  /** Under 160 chars — this is the meta description. */
+  metaDescription: string;
+  /** Two or three paragraphs of real copy. */
+  intro: string[];
+  faqs: { question: string; answer: string }[];
+};
+
+const CONTENT: Record<GenreId, GenrePageContent> = {
+  romance: {
+    heading: "Write a romance novel",
+    metaDescription:
+      "Describe the couple and the thing keeping them apart. sopher.ai plans the beats, writes every chapter, and edits the manuscript — usually in under an hour.",
+    intro: [
+      "Romance is the most structurally demanding popular genre, which is exactly why it suits a planned pipeline. Readers arrive knowing the couple will end up together; the pleasure is entirely in how the book earns it. A romance that skips the black moment, or resolves its conflict with a misunderstanding that a single conversation would have fixed, fails no matter how good the prose is.",
+      "So the outline is written first, with the beats placed where they belong — the meet-cute in the opening tenth, the first real intimacy around the third, the black moment late enough to hurt. Then the chapters are drafted against that plan rather than improvised forward, which is what stops the middle from sagging.",
+      "You control heat level explicitly, from none to explicit, and it applies consistently across the whole book rather than drifting chapter to chapter.",
+    ],
+    faqs: [
+      {
+        question: "Can I choose how explicit the romance is?",
+        answer:
+          "Yes. Heat level is a setting from none through mild, moderate, and explicit, chosen before writing starts and applied consistently across every chapter.",
+      },
+      {
+        question: "Will it give me a happy ending?",
+        answer:
+          "Yes. A satisfying, optimistic ending for the couple — HEA or HFN — is treated as a required element of the genre, not an option.",
+      },
+      {
+        question: "Can I write a specific subgenre?",
+        answer:
+          "Yes. Pick from contemporary, historical, paranormal, romantic suspense, romantic comedy, fantasy romance, and more, and the structural guidance adapts to it.",
+      },
+    ],
+  },
+  mystery: {
+    heading: "Write a mystery novel",
+    metaDescription:
+      "A mystery only works if the clues are placed before the reveal. sopher.ai outlines the whole case first, then writes the chapters against it.",
+    intro: [
+      "A mystery is the genre most obviously broken by improvisation. If the detective solves the case with a fact the reader never saw, the ending is worthless — and a writer discovering the solution as they go will do exactly that. Fair play is a structural property, not a stylistic one.",
+      "That is why the case is outlined completely before a word of prose is drafted: who did it, why, what evidence exists, where each clue is planted, and which red herrings misdirect without cheating. Chapters are then written against that plan, so every clue the detective uses in the final chapter is already on the page.",
+      "Continuity is checked across the whole manuscript afterwards, which in a mystery means the timeline actually holds and no witness contradicts themselves between chapter four and chapter nineteen.",
+    ],
+    faqs: [
+      {
+        question: "Will the mystery actually be solvable?",
+        answer:
+          "That is the intent of outlining the case before drafting. Clues are placed ahead of the revelation rather than invented at it, so the reader has what they need to solve it.",
+      },
+      {
+        question: "Can I decide who the culprit is?",
+        answer:
+          "Yes. Anything you put in the brief shapes the outline, including the culprit, the motive, or the twist you want. You can also revise the outline before any chapter is written.",
+      },
+      {
+        question: "Does it handle cozy mysteries and hardboiled equally?",
+        answer:
+          "Both, along with police procedural, amateur sleuth, historical, and locked-room. The structure holds; the tone, violence level, and voice change with your settings.",
+      },
+    ],
+  },
+  fantasy: {
+    heading: "Write a fantasy novel",
+    metaDescription:
+      "Fantasy lives or dies on a magic system with rules that hold. sopher.ai builds the world, tracks it in a story bible, and checks it across every chapter.",
+    intro: [
+      "The failure mode of fantasy is not bad prose, it is a world that quietly contradicts itself: magic that costs something in chapter two and nothing in chapter fifteen, a journey that takes a week in one direction and an afternoon back, a character whose sword grows a jewel it never had.",
+      "So the world is not held in a prompt and hoped for. Characters, places, objects, and organizations are written into a structured story bible as the book is drafted, and every chapter writer reads from it. A continuity pass then checks names, timelines, and details across the entire manuscript before you see it.",
+      "Magic system rules and their costs are established early and treated as constraints for the rest of the book, because a magic system without limits removes the tension it was supposed to create.",
+    ],
+    faqs: [
+      {
+        question: "How does it keep a long fantasy novel consistent?",
+        answer:
+          "Every entity — character, location, object, organization — is recorded in a story bible as chapters are written, and a continuity pass checks the finished manuscript for contradictions in names, timelines, and details.",
+      },
+      {
+        question: "Can I define my own magic system?",
+        answer:
+          "Yes. Put it in the brief and it becomes part of the concept and the outline, with its rules and costs carried into every chapter.",
+      },
+      {
+        question: "Can it write epic fantasy at full length?",
+        answer:
+          "Up to 60 chapters. Chapters are drafted four at a time, so a long book does not take proportionally longer than a short one.",
+      },
+    ],
+  },
+  thriller: {
+    heading: "Write a thriller",
+    metaDescription:
+      "A thriller has to escalate. sopher.ai plans the tension curve across the whole book, then drafts and edits every chapter against it.",
+    intro: [
+      "Thrillers are a pacing problem before they are anything else. Tension has to rise across the whole book, not oscillate — and the most common failure is a strong opening followed by a middle where the stakes quietly plateau while the plot moves sideways.",
+      "Planning the escalation across all chapters before drafting is what prevents that. Each chapter knows where it sits on the curve, what has to be worse than the chapter before, and what the reader should be afraid of by the end of it.",
+      "An editorial pass then goes back over every chapter for pacing specifically — sentence rhythm, scene length, where a chapter should end to make the next one unputdownable.",
+    ],
+    faqs: [
+      {
+        question: "How does it stop the middle from sagging?",
+        answer:
+          "The tension curve is planned across the whole book before drafting, so every chapter has a defined position on it, and an editorial pass revisits pacing after the chapters exist.",
+      },
+      {
+        question: "Can I control how violent it gets?",
+        answer:
+          "Yes. Violence level is a setting from none through graphic, applied consistently across the manuscript.",
+      },
+      {
+        question: "What thriller subgenres does it handle?",
+        answer:
+          "Psychological, legal, medical, techno, spy, domestic, and political thrillers, each with its own structural expectations.",
+      },
+    ],
+  },
+  literary_fiction: {
+    heading: "Write literary fiction",
+    metaDescription:
+      "Literary fiction is judged on the sentence. sopher.ai drafts with the strongest prose model available and then critiques and revises every chapter.",
+    intro: [
+      "Literary fiction is the hardest thing to generate well, because it is the genre where nothing is hidden behind plot. A thriller can carry a flat paragraph; a literary novel cannot. The whole value is in the prose and the interiority.",
+      "Which is why the pipeline does not just draft. Every chapter is critiqued against a review rubric — voice, specificity, whether the imagery is doing work or decorating — and then revised in targeted passes rather than rewritten wholesale. The premium tier uses the strongest available prose model for both drafting and editing.",
+      "Theme is treated as something that emerges from character choices rather than something announced, and the outline is built around the interior arc rather than the sequence of external events.",
+    ],
+    faqs: [
+      {
+        question: "Which tier should I use for literary fiction?",
+        answer:
+          "Premium. It uses the strongest prose model for both drafting and the editorial pass, which matters more here than in any other genre — roughly 36 credits for a finished novella against 21 for a draft-tier one.",
+      },
+      {
+        question: "Can I control the voice?",
+        answer:
+          "Yes. Point of view, tense, tone, and a voice preset are all set before writing, and you can add a style guide in your own words that every chapter writer follows.",
+      },
+      {
+        question: "Can I rewrite passages myself?",
+        answer:
+          "Yes. The studio editor lets you rewrite any selection, ask for a targeted change in your own words, accept or reject each suggestion, or edit the prose directly.",
+      },
+    ],
+  },
+  science_fiction: {
+    heading: "Write a science fiction novel",
+    metaDescription:
+      "Science fiction has to follow its own premise all the way through. sopher.ai works out the implications first, then writes the book that follows from them.",
+    intro: [
+      "Good science fiction is an argument. You change one thing about the world and then follow the consequences honestly, including the ones that are inconvenient for the plot. The weak version invents a premise, admires it in chapter one, and then tells a story that would have worked without it.",
+      "The concept stage exists to do that work: establishing the speculative premise, its rules, and what it actually changes about how people live, before any chapter is drafted. The outline is then built so the premise drives the story rather than decorating it.",
+      "Because the world's rules are recorded and carried forward, the technology behaves the same way in the last act as it did in the first — which is the specific consistency science fiction readers notice.",
+    ],
+    faqs: [
+      {
+        question: "Can it handle hard science fiction?",
+        answer:
+          "Yes, along with space opera, cyberpunk, dystopian, first contact, time travel, and post-apocalyptic. The rigour of the premise is set by your brief.",
+      },
+      {
+        question: "Will the technology stay consistent?",
+        answer:
+          "The premise and its rules are established in the concept stage, recorded in the story bible, and checked across the finished manuscript by a continuity pass.",
+      },
+      {
+        question: "Can I write a sequel in the same universe?",
+        answer:
+          "Describe the world in your brief and it becomes the foundation for the new book. Each book is its own project with its own story bible.",
+      },
+    ],
+  },
+  horror: {
+    heading: "Write a horror novel",
+    metaDescription:
+      "Horror is dread, built slowly and paid off precisely. sopher.ai plans the escalation, writes the atmosphere, and keeps the rules of the threat consistent.",
+    intro: [
+      "Horror fails when it shows too much too early. Dread is cumulative — it depends on the reader being made to wait, on the threat having rules they slowly work out, and on the protagonist being genuinely vulnerable rather than plot-armoured.",
+      "Escalation is therefore planned across the whole book before drafting: what is glimpsed, what is confirmed, and what is finally seen, in that order. Atmosphere gets explicit attention in the editorial pass, because horror is one of the few genres where sentence rhythm is doing structural work.",
+      "The threat's rules are recorded and held to. A monster that can be anywhere is not frightening; a monster that can only reach you under specific conditions is, and only if those conditions never quietly change.",
+    ],
+    faqs: [
+      {
+        question: "How graphic will it be?",
+        answer:
+          "As graphic as you set. Violence level runs from none through graphic, and it is applied consistently rather than drifting between chapters.",
+      },
+      {
+        question: "Can it write quiet horror rather than gore?",
+        answer:
+          "Yes — that is largely a matter of the violence setting, tone, and what you ask for in the brief. Gothic and psychological horror are both supported subgenres.",
+      },
+      {
+        question: "Does the threat stay consistent?",
+        answer:
+          "Its rules are recorded in the story bible as the book is written and checked across the finished manuscript, which is what stops the horror deflating.",
+      },
+    ],
+  },
+};
+
+export type GenrePage = GenrePageContent & {
+  id: GenreId;
+  slug: string;
+  name: string;
+  description: string;
+  /** Reader-facing craft elements, from the templates the outliner uses. */
+  coreElements: { name: string; description: string; whenToInclude: string }[];
+  readerExpectations: readonly string[];
+  commonTropes: readonly string[];
+  subgenres: readonly string[];
+  pacingNotes: string;
+};
+
+/** Slugs are hyphenated; the stored genre ids use underscores. */
+export const genreSlug = (id: GenreId): string => id.replace(/_/g, "-");
+
+export const GENRE_PAGES: GenrePage[] = GENRE_IDS.map((id) => {
+  const template = GENRE_TEMPLATES[id];
+  return {
+    id,
+    slug: genreSlug(id),
+    name: template.genre,
+    description: template.description,
+    coreElements: template.coreElements.map((element) => ({
+      name: element.name,
+      description: element.description,
+      whenToInclude: element.whenToInclude,
+    })),
+    readerExpectations: template.readerExpectations,
+    commonTropes: template.commonTropes,
+    subgenres: template.subgenres,
+    pacingNotes: template.pacingNotes,
+    ...CONTENT[id],
+  };
+});
+
+export function getGenrePage(slug: string): GenrePage | undefined {
+  return GENRE_PAGES.find((page) => page.slug === slug);
+}

--- a/src/lib/marketing/guides.ts
+++ b/src/lib/marketing/guides.ts
@@ -1,0 +1,345 @@
+import { PIPELINE_STEPS } from "@/components/marketing/content";
+import { REVIEW_PHASES } from "@/ai/prompts/review-rubric";
+import { CREDIT_PACKS, SIGNUP_GRANT_CREDITS } from "@/lib/billing/credits-shared";
+
+/**
+ * Guides.
+ *
+ * Written from what the product actually does — the pipeline steps, the review
+ * rubric, the tier definitions, the real credit costs — rather than from
+ * marketing intuition about it. That constraint is deliberate: a guide that
+ * overstates the product is worse than no guide, because it is the page an
+ * answer engine will quote when someone asks whether this can do the thing.
+ *
+ * Blocks are a small closed union rather than markdown, so the rendered output
+ * stays inside the design system and every list is real list markup a crawler
+ * can parse.
+ */
+
+export type GuideBlock =
+  | { kind: "p"; text: string }
+  | { kind: "h2"; text: string; id: string }
+  | { kind: "list"; items: string[] }
+  | { kind: "steps"; items: { name: string; text: string }[] }
+  | { kind: "note"; text: string };
+
+export type Guide = {
+  slug: string;
+  title: string;
+  /** Under 160 chars — the meta description. */
+  description: string;
+  /** One line under the h1. */
+  standfirst: string;
+  blocks: GuideBlock[];
+  faqs?: { question: string; answer: string }[];
+};
+
+const tierGuide: Guide = {
+  slug: "choosing-a-quality-tier",
+  title: "Choosing a quality tier",
+  description:
+    "Draft, Standard, or Premium — what each one actually changes about how your book is written, and what it costs in credits.",
+  standfirst: "The tier decides which models write your book and how much editing it gets.",
+  blocks: [
+    {
+      kind: "p",
+      text: "Three tiers, chosen before writing starts and recorded against the run so you can always see what a given book was written at. They differ in two ways: which model drafts the prose, and how much editorial work happens after the draft exists.",
+    },
+    { kind: "h2", text: "Draft", id: "draft" },
+    {
+      kind: "p",
+      text: "A single pass. Chapters are planned, drafted, and checked with free heuristics — no model-driven critique, no revision pass. Roughly 21 credits for a finished novella.",
+    },
+    {
+      kind: "p",
+      text: "Use it when you want to see the shape of a book quickly, or when the story matters more to you than the sentences: a bedtime story, a gift, something you intend to rewrite yourself anyway.",
+    },
+    { kind: "h2", text: "Standard", id: "standard" },
+    {
+      kind: "p",
+      text: "The default. Each chapter is drafted, then critiqued, then revised in targeted passes against the critique — changing the parts that need changing rather than regenerating wholesale. Roughly 27 credits.",
+    },
+    {
+      kind: "p",
+      text: "This is the right choice for most books. Plot-forward genres in particular — mystery, thriller, fantasy — get most of their value from structure and continuity, both of which Standard covers fully.",
+    },
+    { kind: "h2", text: "Premium", id: "premium" },
+    {
+      kind: "p",
+      text: "The strongest available prose model for both drafting and editing, plus a deeper editorial pass. Roughly 36 credits.",
+    },
+    {
+      kind: "p",
+      text: "Worth it where the sentence is the product. Literary fiction is the clear case: it is the genre with nothing hidden behind plot, so the difference between a competent paragraph and a good one is the whole difference. Also worth it for anything you intend to publish.",
+    },
+    { kind: "h2", text: "What the difference costs", id: "cost" },
+    {
+      kind: "p",
+      text: `The gap between the cheapest and most expensive tier is about 15 credits on a novella — roughly the price of a coffee, against a book you might reread. New accounts start with ${SIGNUP_GRANT_CREDITS} free credits, which is enough to watch a real book begin and decide for yourself.`,
+    },
+    {
+      kind: "note",
+      text: "You are shown an estimate before anything runs, and nothing is spent until you approve it. Every book comes with a report of exactly where its credits went.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Can I change tier after starting?",
+      answer:
+        "Not mid-run, but you can regenerate individual chapters at a different tier afterwards, and the tier used for each run is recorded so you can tell them apart.",
+    },
+    {
+      question: "Is Premium worth it for genre fiction?",
+      answer:
+        "Usually not, with one exception: if you intend to publish it. Plot-forward genres get most of their quality from structure and continuity, which Standard covers fully.",
+    },
+    {
+      question: "What is a credit worth?",
+      answer: `One credit is one dollar of writing. Packs start at $${CREDIT_PACKS[0].usd} for ${CREDIT_PACKS[0].credits} credits, and larger packs carry a bonus.`,
+    },
+  ],
+};
+
+const pipelineGuide: Guide = {
+  slug: "how-book-generation-works",
+  title: "How book generation works",
+  description:
+    "Five agents, in order: concept, outline, chapters, editor, continuity. What each one does and where you can intervene.",
+  standfirst: "A brief goes in. Five stages later, an edited manuscript comes out.",
+  blocks: [
+    {
+      kind: "p",
+      text: "sopher.ai is not a single prompt. It is a pipeline of specialized agents, each with its own tools and its own review, running as a durable workflow — which is why a run can pause for your approval, or for a credit top-up, and pick up exactly where it left off rather than starting over.",
+    },
+    { kind: "h2", text: "The five stages", id: "stages" },
+    {
+      kind: "steps",
+      items: PIPELINE_STEPS.map((step) => ({ name: step.name, text: step.description })),
+    },
+    { kind: "h2", text: "Where you can intervene", id: "intervene" },
+    {
+      kind: "p",
+      text: "The outline is the highest-leverage point. If you asked for outline approval, the run pauses after the plan is written and before any chapter is drafted, and you can send it back with notes in your own words. Changing the plan there costs almost nothing; changing the story after twenty chapters exist costs a lot.",
+    },
+    {
+      kind: "list",
+      items: [
+        "Approve or revise the outline before drafting begins.",
+        "Watch chapters arrive as they are written, and read them as they land.",
+        "Rewrite any passage — select it, say what you want changed, accept or reject the suggestion.",
+        "Ask for a full-chapter review with a focus you specify.",
+        "Regenerate a whole chapter, or edit the prose directly.",
+        "Export to EPUB, PDF, DOCX, or Markdown at any point.",
+      ],
+    },
+    { kind: "h2", text: "Why chapters are written four at a time", id: "waves" },
+    {
+      kind: "p",
+      text: "Chapters are drafted in waves of four, in parallel. That is why a thirty-chapter novel does not take thirty times as long as one chapter — most books finish in under an hour.",
+    },
+    {
+      kind: "p",
+      text: "Parallelism creates a consistency problem, which the story bible solves: every character, place, object, and organization is recorded as chapters are written, and each chapter writer reads from it. A continuity pass then checks the whole manuscript at the end, when every chapter exists and contradictions between distant chapters are actually visible.",
+    },
+    {
+      kind: "note",
+      text: "If your balance runs out mid-book, the run pauses at a chapter boundary rather than failing. Every chapter already written is kept, and adding credits resumes it.",
+    },
+  ],
+  faqs: [
+    {
+      question: "How long does a book take?",
+      answer:
+        "Usually under an hour. Chapters are drafted four at a time, so length does not scale time proportionally.",
+    },
+    {
+      question: "What happens if a chapter fails to generate?",
+      answer:
+        "The workflow is durable and retries the failed step. Work already completed is never redone, and a run that cannot recover leaves every finished chapter intact.",
+    },
+    {
+      question: "Can I stop a run partway?",
+      answer:
+        "Yes. You keep everything written up to that point and are only charged for the work that actually ran.",
+    },
+  ],
+};
+
+const voiceGuide: Guide = {
+  slug: "point-of-view-and-tense",
+  title: "Point of view and tense",
+  description:
+    "First or third person, past or present — what each choice does to a reader, and which genres expect which.",
+  standfirst: "Two settings that change the feel of a book more than any other.",
+  blocks: [
+    {
+      kind: "p",
+      text: "Point of view and tense are set before writing and held consistently across the whole manuscript. They are worth a minute of thought, because they are the two settings a reader notices without being able to name.",
+    },
+    { kind: "h2", text: "Point of view", id: "pov" },
+    {
+      kind: "p",
+      text: "First person puts the reader inside one head. Everything is filtered through that character, including what they are wrong about — which is a feature, and the reason unreliable narrators exist. It creates intimacy fast and limits you to what one person can know.",
+    },
+    {
+      kind: "p",
+      text: "Third limited follows one character closely but from outside — the most common choice in modern fiction, and the most flexible. You keep most of the intimacy and gain the ability to describe the character from the outside.",
+    },
+    {
+      kind: "p",
+      text: "Third omniscient moves freely between characters and can comment on all of them. It suits large casts and long timescales, and it costs intimacy: a reader who is everywhere is nowhere in particular.",
+    },
+    { kind: "h2", text: "Tense", id: "tense" },
+    {
+      kind: "p",
+      text: "Past tense is the default of storytelling and effectively invisible — readers stop noticing it by the second page. Present tense feels immediate and slightly breathless, which is why thrillers and young-adult fiction use it, and why it can become tiring across a very long book.",
+    },
+    { kind: "h2", text: "What each genre tends to expect", id: "conventions" },
+    {
+      kind: "list",
+      items: [
+        "Romance: first person or third limited, often alternating between both leads.",
+        "Mystery: third limited on the detective, or first person for hardboiled and cozy.",
+        "Fantasy: third limited is standard; omniscient for epic scope.",
+        "Thriller: third limited, frequently present tense for immediacy.",
+        "Literary fiction: anything, deliberately — this is where the choice is most expressive.",
+        "Horror: first person or close third, because vulnerability needs proximity.",
+      ],
+    },
+    {
+      kind: "note",
+      text: "These are conventions, not rules. Breaking one on purpose is a legitimate choice; breaking one by accident reads as a mistake.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Can I change point of view after the book is written?",
+      answer:
+        "Not as a global setting, but you can regenerate chapters or rewrite passages. Changing POV across a finished manuscript is effectively a rewrite, so it is worth getting right up front.",
+    },
+    {
+      question: "Which should I pick if I am unsure?",
+      answer: "Third limited, past tense. It is the modern default and it fits almost anything.",
+    },
+  ],
+};
+
+const contentGuide: Guide = {
+  slug: "content-settings",
+  title: "Heat, violence, and profanity",
+  description:
+    "Three settings that control how explicit your book gets, applied consistently across every chapter.",
+  standfirst: "You decide the content level. It holds for the whole manuscript.",
+  blocks: [
+    {
+      kind: "p",
+      text: "Three independent settings, each with four levels. They are chosen before writing and applied consistently — which matters, because the usual failure of AI-written fiction is drifting between chapters: chaste in chapter three, unexpectedly graphic in chapter eleven.",
+    },
+    { kind: "h2", text: "Heat", id: "heat" },
+    {
+      kind: "p",
+      text: "None keeps romance emotional and closes the door. Mild allows kissing and attraction. Moderate allows sensuality and implied intimacy. Explicit writes the scenes.",
+    },
+    { kind: "h2", text: "Violence", id: "violence" },
+    {
+      kind: "p",
+      text: "None avoids it. Mild allows conflict and consequence without dwelling. Moderate allows injury and death on the page. Graphic does not look away.",
+    },
+    { kind: "h2", text: "Profanity", id: "profanity" },
+    {
+      kind: "p",
+      text: "None through strong, controlling how characters actually speak. Worth setting deliberately rather than by default — dialogue that is cleaner than the character would be reads as false.",
+    },
+    { kind: "h2", text: "What is not adjustable", id: "limits" },
+    {
+      kind: "p",
+      text: "A small set of categories is refused regardless of settings: sexual content involving minors, non-consensual content presented approvingly, incitement to real-world violence or hatred, sexual or defamatory content about real identifiable people, and instructions for self-harm. These are not a heat level; they are a line.",
+    },
+    {
+      kind: "note",
+      text: "Everything else is yours to set. An adult writing explicit fiction for adults is the product working as intended, not an edge case being tolerated.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Can I write explicit fiction?",
+      answer:
+        "Yes. Set heat to explicit and the scenes are written. The setting applies consistently across the whole book.",
+    },
+    {
+      question: "Can I ask it to avoid specific topics?",
+      answer:
+        "Yes — an avoid-topics list is part of a project's settings and is carried into every chapter.",
+    },
+    {
+      question: "Are my settings visible to anyone else?",
+      answer:
+        "Your work is private to your account. We may review content when required to enforce our terms or comply with law, which is disclosed in the privacy policy.",
+    },
+  ],
+};
+
+const editorialGuide: Guide = {
+  slug: "what-the-editorial-pass-checks",
+  title: "What the editorial pass checks",
+  description:
+    "Six weighted dimensions the manuscript is reviewed against after the chapters exist — and what happens to what it finds.",
+  standfirst: "The draft is not the deliverable. This is what happens to it afterwards.",
+  blocks: [
+    {
+      kind: "p",
+      text: "Once chapters exist, the manuscript is reviewed against a weighted rubric. This is a separate stage from drafting on purpose: a writer in the middle of chapter twelve cannot see that chapter four undercut its own ending, and asking one agent to do both jobs produces prose that is defensive rather than good.",
+    },
+    { kind: "h2", text: "The six dimensions", id: "dimensions" },
+    {
+      kind: "steps",
+      items: REVIEW_PHASES.map((phase) => ({
+        name: `${phase.name} (${Math.round(phase.weight * 100)}%)`,
+        text: phase.description,
+      })),
+    },
+    { kind: "h2", text: "What happens to what it finds", id: "outcome" },
+    {
+      kind: "p",
+      text: "Findings are chapter-scoped, so a revision changes the chapter that has the problem rather than regenerating the book. Revisions are bounded — the pipeline does not loop indefinitely trying to satisfy its own critic, which is a failure mode that burns credits without improving prose.",
+    },
+    {
+      kind: "p",
+      text: "Continuity is handled separately, at the end, across the whole manuscript. That is when contradictions between distant chapters are actually detectable: a name that changed spelling, a journey that takes different lengths of time in each direction, an object a character should not still have.",
+    },
+    { kind: "h2", text: "What you can do yourself", id: "yours" },
+    {
+      kind: "list",
+      items: [
+        "Ask for a full-chapter review with a focus you name — pacing, dialogue, a specific character.",
+        "Select any passage and describe the change you want in your own words.",
+        "Accept or reject each suggestion individually; nothing is applied without you.",
+        "Regenerate a chapter from the outline.",
+        "Edit the prose directly. It is your manuscript.",
+      ],
+    },
+  ],
+  faqs: [
+    {
+      question: "Does the editorial pass rewrite everything?",
+      answer:
+        "No. Revisions are targeted at the specific issues found, and bounded — it will not loop indefinitely trying to satisfy its own critique.",
+    },
+    {
+      question: "Which tiers include it?",
+      answer:
+        "Standard and Premium. Draft is a single pass with free heuristic checks and no model-driven critique.",
+    },
+    {
+      question: "Can I see what it found?",
+      answer:
+        "Yes. Suggestions appear in the studio editor with the reasoning attached, and you accept or reject each one.",
+    },
+  ],
+};
+
+export const GUIDES: Guide[] = [pipelineGuide, tierGuide, voiceGuide, contentGuide, editorialGuide];
+
+export function getGuide(slug: string): Guide | undefined {
+  return GUIDES.find((guide) => guide.slug === slug);
+}


### PR DESCRIPTION
Final PR in the stack (#134 → #135 → #136 → #137 → this). Own diff is the last commit.

#135 fixed *how* the site is read. This fixes *what there is to read*.

| | before | after |
|---|---|---|
| public pages | 5 | 19 |
| indexable words | ~2,400 | **9,624** |
| legal boilerplate share | >50% | ~15% |

## Seven genre pages

Built from `src/ai/knowledge/genres.ts` — **the same templates the outliner actually uses**. That constraint is the point: each page lists the structural elements the product genuinely plans for, with the timing it genuinely uses ("Black Moment — around 75-85% mark"), so the copy cannot drift into marketing that overpromises. What's hand-written is the framing a person needs, because the templates are addressed to a model in imperatives and percentages.

Each page: `FAQPage` + `BreadcrumbList` JSON-LD, its own canonical and OG metadata, the genre's reader expectations and pacing notes, subgenres, and a CTA into the wizard **pre-seeded with that genre** — someone arriving from "write a fantasy novel" shouldn't re-answer the question they answered by clicking. A saved draft still wins over the URL hint.

## Five guides

Same discipline — from the pipeline steps, the review rubric's six weighted dimensions, the tier definitions, and the real credit costs:

- How book generation works (the five stages, where you can intervene, why waves of four)
- Choosing a quality tier (what Draft/Standard/Premium actually change, and the ~15-credit gap)
- Point of view and tense (what each does to a reader, per-genre conventions)
- Heat, violence, and profanity (including what is refused regardless of settings)
- What the editorial pass checks (the six dimensions, with their real weights)

A guide that overstates the product is worse than no guide — it's the page an answer engine quotes when someone asks whether this can do the thing.

## Internal linking

The graph was **5 nodes and ~4 edges, two of which pointed at auth-gated pages** a crawler can't follow. Genres and guides are now in the header nav and footer, every genre page links to the other six plus guides and pricing, and every guide links to the others plus genres.

## Anti-drift

Sitemap and `llms.txt` are generated from the same `GENRE_PAGES` / `GUIDES` arrays the pages render, so a new genre or guide **cannot** be added without appearing in both. The e2e suite asserts it.

## Verification

All gates green. **19 e2e SEO tests pass**, up from 12 — every genre and guide page checked for canonical, single `h1`, and structured data; the sitemap checked against every slug; the wizard pre-seed checked; and **axe on all four new page types**, since they're `dl`/`ol`-heavy prose which is exactly where heading-order and contrast regressions hide.

Build confirms all 12 new pages prerender static. Word counts measured per-page against a running server, not estimated.

## Note on `_port/`

The genre templates were ported verbatim from the legacy Python source and their content is the product. I read them but didn't alter them — this PR only adds a reader-facing view over them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EV7HzsidBJ3FGtVfiiE57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive static marketing routes and SEO metadata; the only product touch is optional, validated `?genre=` pre-fill on the new-book wizard with draft precedence unchanged.
> 
> **Overview**
> Adds **indexable marketing content** beyond the original handful of public pages: `/genres` and seven genre landings sourced from the same outliner templates in `GENRE_TEMPLATES`, plus `/guides` and five product-honest guides built from pipeline/tier/rubric constants. Each page ships canonical/OG metadata, breadcrumbs, and genre pages add **FAQPage** JSON-LD and cross-links to other genres, guides, and pricing.
> 
> **Discovery and funnel:** `sitemap.ts` and `llms.txt` now enumerate genres/guides from shared `GENRE_PAGES` / `GUIDES` arrays; header/footer add Genres and Guides links. Genre CTAs go to `/studio/new?genre=…`; the studio page validates the query param and `NewBookWizard` accepts `initialGenre` (saved localStorage draft still wins over the URL).
> 
> **Regression coverage:** `e2e/seo.spec.ts` extends public page lists, asserts every genre/guide slug in the sitemap, checks per-page canonical/h1/structured data, verifies wizard pre-seed, and runs **axe** on sample genre/guide index pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48af4e72a289fdefce998a536afc537e46835e09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->