### PR TITLE
ci: pin an existing model for the Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly. Left unset, the action falls back to its
+          # own built-in default — which is claude-sonnet-4-20250514, now
+          # retired, so every run failed with:
+          #   API Error: 404 not_found_error "model: claude-sonnet-4-20250514"
+          # An unpinned model means the next retirement breaks CI the same way.
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,12 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly. Left unset, the action falls back to its
+          # own built-in default — which is claude-sonnet-4-20250514, now
+          # retired, so every run failed with:
+          #   API Error: 404 not_found_error "model: claude-sonnet-4-20250514"
+          # An unpinned model means the next retirement breaks CI the same way.
+          model: "claude-sonnet-5"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
`claude-review` has been failing on every PR — including #130–#133, which are already merged. Not caused by the current stack.

## Cause

Neither workflow set a `model`, so the action fell back to its own built-in default:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error",
  "message":"model: claude-sonnet-4-20250514"},"request_id":"req_011CdX6TtpK1S8ATq5hBKqhB"}
```

`claude-sonnet-4-20250514` has been retired. The commented-out hint in both files (`# Optional: Specify model (defaults to Claude Sonnet 4...)`) was documenting exactly the default that broke.

## Fix

Pinned `claude-sonnet-5` in `claude.yml` and `claude-code-review.yml`, with the failure recorded in a comment. Leaving it unset means the next retirement breaks CI the same silent way — the job fails, but the only symptom is a red check and a "Claude encountered an error" comment with no model name in it.

## Note

Both workflows still use `anthropics/claude-code-action@beta`, which is a deprecated tag. Worth moving to the current major separately — the input names changed, so it isn't a one-line bump and it shouldn't ride along with a CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EV7HzsidBJ3FGtVfiiE57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application code, auth, or data impact; only affects which model the Claude action calls.
> 
> **Overview**
> Restores failing **Claude Code** GitHub Actions jobs by explicitly setting `model: "claude-sonnet-5"` in both `claude.yml` and `claude-code-review.yml`.
> 
> Previously neither workflow set `model`, so `anthropics/claude-code-action@beta` used its built-in default **`claude-sonnet-4-20250514`**, which is retired and caused **404** API errors on every run. The old commented “optional model” lines are replaced with comments documenting that failure and why pinning matters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e7381776b9baef6873d714189aee4dc52db65e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->