### PR TITLE
perf: quote all three tiers in one request

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f \"/Users/aaron/.agents/skills/impeccable/scripts/hook.mjs\" ] || node \"/Users/aaron/.agents/skills/impeccable/scripts/hook.mjs\"",
+            "timeout": 5,
+            "statusMessage": "Checking UI changes"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ ! -f \"/Users/aaron/.agents/skills/impeccable/scripts/hook.mjs\" ] || node \"/Users/aaron/.agents/skills/impeccable/scripts/hook.mjs\"",
+            "timeout": 30,
+            "statusMessage": "Design deep pass"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/hooks/impeccable.json
+++ b/.github/hooks/impeccable.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "matcher": "edit|create|apply_patch",
+        "bash": "node \"$(git rev-parse --show-toplevel)/.github/skills/impeccable/scripts/hook.mjs\"",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/src/ai/models.ts
+++ b/src/ai/models.ts
@@ -62,6 +62,9 @@ export const MODELS: Record<QualityTier, TierModels> = {
 // Gateway-side fallback chain for prose calls (provider hiccups, not quality tiers).
 export const PROSE_FALLBACK_MODELS = ["anthropic/claude-sonnet-4.6"];
 
+/** Canonical tier order, cheapest first. Both the API and the wizard read this. */
+export const QUALITY_TIERS: readonly QualityTier[] = ["draft", "standard", "premium"];
+
 export const TIER_LABELS: Record<QualityTier, { name: string; blurb: string }> = {
   draft: { name: "Draft", blurb: "Fast single-pass draft with heuristic quality checks" },
   standard: { name: "Standard", blurb: "Drafted, critiqued, and selectively edited" },

--- a/src/app/api/estimates/route.ts
+++ b/src/app/api/estimates/route.ts
@@ -1,4 +1,5 @@
 import { estimateBookCost } from "@/ai/estimate";
+import { QUALITY_TIERS } from "@/ai/models";
 import { requireUser } from "@/lib/auth";
 import { creditsForUsd, getBalance } from "@/lib/billing/credits";
 import { LIMITS, rateLimit } from "@/lib/security/rate-limit";
@@ -7,14 +8,22 @@ import { estimateRequestSchema } from "@/lib/validation/project";
 export const maxDuration = 15;
 
 /**
- * Pre-generation estimate. Credits are what the wallet will actually be
- * debited (metered USD x markup) — quoting metered dollars alone understated
- * the real cost 2.75x, which is how the old display misled.
+ * Pre-generation estimate — every tier in one response.
  *
- * The one route open to anonymous callers (the pricing page quotes before
- * sign-in), so it is rate limited by IP rather than by user.
+ * It used to quote a single tier, so the wizard fired three parallel requests
+ * per adjustment, one per tier. Each did its own balance query, and the balance
+ * does not vary by tier, so two of the three were computing the same sum. One
+ * slider nudge cost three rate-limit checks, three database round trips, and
+ * three cold-start-eligible invocations to fill one screen.
+ *
+ * Credits are what the wallet will actually be debited (metered USD x markup);
+ * quoting metered dollars alone understated the real cost 2.75x, which is how
+ * the old display misled.
  */
 export async function POST(req: Request) {
+  // IP-keyed, not user-keyed: the balance lookup below is best-effort by
+  // design (see comment there), so an authenticated userId is not guaranteed
+  // to exist here.
   const limited = await rateLimit(LIMITS.estimates, req, undefined);
   if (limited.limited) return limited.response;
 
@@ -24,12 +33,12 @@ export async function POST(req: Request) {
   if (!parsed.success) {
     return Response.json({ error: parsed.error.flatten() }, { status: 400 });
   }
-  const { tier, chapters, wordsPerChapter } = parsed.data;
-  const estimate = estimateBookCost(tier, chapters, wordsPerChapter);
+  const { chapters, wordsPerChapter } = parsed.data;
 
-  // Best-effort: the quote itself is pure computation and must stay usable
-  // when auth or the database is unavailable (signed-out visitors, CI without
-  // a DATABASE_URL). Balance context is a nicety, never a dependency.
+  // Best-effort, and load-bearing: the quote itself is pure computation and must
+  // stay usable when auth or the database is unavailable. The DB-free e2e suite
+  // CI runs depends on this — see e2e/wizard.spec.ts. Balance context is a
+  // nicety, never a dependency.
   let balance: number | null = null;
   try {
     const { userId } = await requireUser();
@@ -38,9 +47,10 @@ export async function POST(req: Request) {
     balance = null;
   }
 
-  return Response.json({
-    ...estimate,
-    credits: creditsForUsd(estimate.totalUsd),
-    balance,
+  const tiers = QUALITY_TIERS.map((tier) => {
+    const estimate = estimateBookCost(tier, chapters, wordsPerChapter);
+    return { ...estimate, credits: creditsForUsd(estimate.totalUsd), balance };
   });
+
+  return Response.json({ balance, tiers });
 }

--- a/src/components/wizard/step-estimate.tsx
+++ b/src/components/wizard/step-estimate.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
-import { MODELS, TIER_LABELS, type QualityTier } from "@/ai/models";
+import { MODELS, QUALITY_TIERS, TIER_LABELS, type QualityTier } from "@/ai/models";
 import type { BookEstimate } from "@/ai/estimate";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -11,7 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import type { WizardActionEvent, WizardState } from "@/components/wizard/wizard-state";
 
-const TIERS: readonly QualityTier[] = ["draft", "standard", "premium"];
+const TIERS = QUALITY_TIERS;
 
 const MODEL_NAMES: Record<string, string> = {
   "anthropic/claude-haiku-4.5": "Haiku",
@@ -59,21 +59,19 @@ export function StepEstimate({
     const timer = setTimeout(async () => {
       setLoading(true);
       try {
-        const results = await Promise.all(
-          TIERS.map(async (tier) => {
-            const res = await fetch("/api/estimates", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ tier, chapters, wordsPerChapter }),
-              signal: controller.signal,
-            });
-            if (!res.ok) return null;
-            return (await res.json()) as QuotedEstimate;
-          }),
-        );
+        // One request for all three tiers. This used to fan out to three
+        // parallel requests, each repeating the same per-user balance query.
+        const res = await fetch("/api/estimates", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ chapters, wordsPerChapter }),
+          signal: controller.signal,
+        });
+        if (!res.ok) return;
+        const body = (await res.json()) as { tiers: QuotedEstimate[] };
         const next: EstimateMap = {};
-        for (const estimate of results) {
-          if (estimate) next[estimate.tier] = estimate;
+        for (const estimate of body.tiers ?? []) {
+          next[estimate.tier] = estimate;
         }
         setEstimates(next);
         setLoading(false);

--- a/src/lib/validation/project.ts
+++ b/src/lib/validation/project.ts
@@ -33,7 +33,12 @@ export const updateProjectSchema = createProjectSchema.partial().extend({
 });
 
 export const estimateRequestSchema = z.object({
-  tier: qualityTierSchema,
+  /**
+   * Ignored — the route quotes every tier in one response. Still accepted so a
+   * browser running the previous bundle across a deploy gets a valid quote
+   * rather than a 400 that would leave the wizard stuck loading.
+   */
+  tier: qualityTierSchema.optional(),
   chapters: z.number().int().min(3).max(60),
   wordsPerChapter: z.number().int().min(800).max(8_000),
 });


### PR DESCRIPTION
Came out of the question about WAF rate-limiting cost. Top of the stack (#134 → #135 → #136 → #137 → #138 → this).

## What was wrong

The estimate step fired **three parallel requests per adjustment**, one per tier — and each one did its own `getBalance` sum. The balance is per *user*, not per tier, so two of the three were computing the same number.

One slider nudge = 3 rate-limit checks + 3 database round trips + 3 function invocations, to fill one screen.

Now one request returns all three tiers with a single balance read.

## On the $0.50/1M question

For the **paid** routes the charge is genuinely noise:

| route | model cost per request | firewall cost | firewall as share |
|---|---|---|---|
| selection edit | $0.05 | $0.0000005 | 0.001% |
| chapter review | $0.10 | $0.0000005 | 0.0005% |
| cover / portrait | $0.067 | $0.0000005 | 0.0007% |
| full book start | ~$7 | $0.0000005 | 0.000007% |

To spend **$1** on rate limiting through the edit route you'd need 2M allowed requests — which would be ~$100,000 of model spend. And the "cheaper" alternative isn't: a Postgres round trip per request costs real Neon compute plus 5–30ms of latency on every paid request, to avoid half a millionth of a dollar.

But `estimates` was the one guarded route with **no** model cost behind it, so it was the one place a per-request charge was a meaningful fraction of the work — and looking at it found the 3x fan-out, which was wrong regardless of pricing.

## Also

`QUALITY_TIERS` now comes from `ai/models` instead of the tier union being restated as a local `const` in the component.

## What I deliberately did *not* change

The route keeps its tolerant auth and best-effort balance. I started to require auth — it's only ever called from `/studio/new`, which is authenticated, so the "signed-out visitors" it defends against don't exist — but `e2e/wizard.spec.ts` is **deliberately DB-free and runs in CI**, and a required-auth quote needs a DB write via `devFallbackUser`. Tightening it would be the better posture and would break CI, so the comment now records that tradeoff rather than leaving the tolerance looking accidental.

`tier` is still accepted and ignored, so a browser on the previous bundle across a deploy gets a valid quote instead of a 400 that would leave the step stuck loading.

## Verification

All gates green. **The DB-free `wizard.spec.ts` still passes.** Verified live:

```
$ curl -X POST /api/estimates -d '{"chapters":12,"wordsPerChapter":3000}'
      draft  2.89 credits  ~34min
   standard  4.76 credits  ~34min
    premium  8.50 credits  ~40min
tiers in one response: 3

$ curl ... -d '{"tier":"premium","chapters":12,...}'   # old bundle
200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EV7HzsidBJ3FGtVfiiE57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is localized to the estimate wizard and a backward-compatible API shape; no auth, billing debit, or generation paths change.
> 
> **Overview**
> **Collapses wizard cost quoting from three parallel `/api/estimates` calls to one**, so each slider change triggers a single rate-limit check, one optional balance read, and one function invocation instead of tripling that work for identical balance data.
> 
> The API now returns `{ balance, tiers }` with every quality tier computed from shared `QUALITY_TIERS` in `ai/models.ts` (replacing a duplicated tier list in the estimate step). Request validation still accepts an optional `tier` field so older clients mid-deploy do not get a 400 and hang on loading.
> 
> Also adds **Codex and GitHub agent hooks** that run the Impeccable `hook.mjs` after edits and on stop (UI check / design pass).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6f1683a58b7a5acf3344f808b15988790ac221. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->