### PR TITLE
Fix truncated preview authoring runs

### DIFF
--- a/src/ai/metering.test.ts
+++ b/src/ai/metering.test.ts
@@ -1,3 +1,4 @@
+import { NoOutputGeneratedError } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -25,6 +26,8 @@ vi.mock("@/lib/billing/credits", async (importOriginal) => {
 import { InsufficientCreditsError } from "@/lib/billing/credits";
 import { MeteredInputLimitError } from "./metering-limits";
 import {
+  gatewayOptions,
+  MeteredOutputDeliveryError,
   MeteringReconciliationRequiredError,
   metered,
   refundMeteredDeliveries,
@@ -60,6 +63,30 @@ beforeEach(() => {
 });
 
 describe("metered atomic authorization", () => {
+  it("disables implicit Anthropic thinking without dropping Gateway attribution or fallbacks", () => {
+    expect(
+      gatewayOptions(
+        {
+          userId: "user-1",
+          projectId: "project-1",
+          meteringAttemptId: "attempt-1",
+        },
+        "writer",
+        { withFallbacks: true },
+      ),
+    ).toEqual({
+      gateway: {
+        user: "user-1",
+        tags: ["role:writer", "project:project-1", "attempt:attempt-1"],
+        caching: "auto",
+        models: expect.any(Array),
+      },
+      anthropic: {
+        thinking: { type: "disabled" },
+      },
+    });
+  });
+
   it("claims an interactive maximum before provider work and settles through that exact claim", async () => {
     const provider = vi.fn(async () => ({ usage }));
 
@@ -326,6 +353,86 @@ describe("metered atomic authorization", () => {
     ).resolves.toEqual({ usage });
     expect(mocks.refundSettled).toHaveBeenCalledOnce();
     expect(provider).toHaveBeenCalledOnce();
+  });
+
+  it("settles and refunds truncated structured output before exposing a non-retryable error", async () => {
+    const truncatedUsage = {
+      ...usage,
+      outputTokens: 5_000,
+      outputTokenDetails: { textTokens: 72, reasoningTokens: 4_928 },
+    };
+    const provider = vi.fn(async () => ({
+      usage: truncatedUsage,
+      finishReason: "length",
+      rawFinishReason: "max_tokens",
+      get output(): never {
+        throw new NoOutputGeneratedError();
+      },
+    }));
+
+    const call = metered(
+      {
+        userId: "user-1",
+        projectId: "project-1",
+        runId: "run-1",
+        billingScope: "generation:run-1:chapter:1",
+        reservationRef: "generation-reservation:run-1:opening",
+      },
+      {
+        role: "concept",
+        operation: "concept.refine",
+        model: "anthropic/claude-sonnet-5",
+      },
+      provider,
+    );
+
+    await expect(call).rejects.toMatchObject({
+      name: "MeteredOutputDeliveryError",
+      operation: "concept.refine",
+      finishReason: "length",
+      outputTokens: 5_000,
+      reasoningTokens: 4_928,
+      isRetryable: false,
+      message: expect.stringContaining("finish reason: length"),
+    });
+    await expect(call).rejects.toBeInstanceOf(MeteredOutputDeliveryError);
+    expect(mocks.recordMany).toHaveBeenCalledOnce();
+    expect(mocks.recordMany).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        compensateDelivery: {
+          description: "Provider output for concept.refine was incomplete and not delivered",
+        },
+      }),
+    );
+    expect(mocks.refundSettled).not.toHaveBeenCalled();
+  });
+
+  it("returns complete structured output without requesting delivery compensation", async () => {
+    const output = { title: "Delivered" };
+    const result = {
+      usage,
+      finishReason: "stop",
+      get output() {
+        return output;
+      },
+    };
+
+    await expect(
+      metered(
+        { userId: "user-1", projectId: "project-1", authorizationUsd: 0.1 },
+        {
+          role: "concept",
+          operation: "concept.refine",
+          model: "anthropic/claude-sonnet-5",
+        },
+        async () => result,
+      ),
+    ).resolves.toBe(result);
+    expect(mocks.recordMany).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.not.objectContaining({ compensateDelivery: expect.anything() }),
+    );
   });
 
   it("uses a caller-stable interactive key to block replay but permits a new action key", async () => {

--- a/src/ai/metering.ts
+++ b/src/ai/metering.ts
@@ -86,9 +86,11 @@ export function gatewayOptions(
       caching: "auto",
       ...(opts?.withFallbacks ? { models: PROSE_FALLBACK_MODELS } : {}),
     },
-    // Sonnet 5 enables thinking by default. Our output ceilings are sized for
-    // the author-facing JSON/prose, so implicit reasoning can otherwise consume
-    // the entire allowance before any deliverable output is produced.
+    // Sonnet 5 enables thinking by default. This is deliberately a blanket
+    // metering policy: our output ceilings are sized for author-facing
+    // JSON/prose, so implicit reasoning can otherwise consume the allowance
+    // before any deliverable output is produced. A future operation that needs
+    // extended thinking must opt into it with a separately budgeted contract.
     anthropic: {
       thinking: { type: "disabled" },
     },
@@ -385,8 +387,11 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
     let outputDeliveryFailure: unknown;
     if ("output" in result) {
       try {
-        // AI SDK exposes completed output through a getter that throws when
-        // the provider stopped before a complete result could be parsed.
+        // AI SDK v7 exposes completed structured output through a getter that
+        // throws when the provider stopped before a complete result could be
+        // parsed. Treat any getter failure as an undelivered result so billing
+        // cannot settle without usable output; the regression test deliberately
+        // locks this SDK contract.
         void (result as T & { output: unknown }).output;
       } catch (error) {
         outputDeliveryFailure = error;

--- a/src/ai/metering.ts
+++ b/src/ai/metering.ts
@@ -71,7 +71,10 @@ export function gatewayOptions(
   ctx: MeterCtx,
   role: string,
   opts?: { withFallbacks?: boolean },
-): { gateway: Record<string, JSONValue> } {
+): {
+  gateway: Record<string, JSONValue>;
+  anthropic: Record<string, JSONValue>;
+} {
   return {
     gateway: {
       user: ctx.userId,
@@ -82,6 +85,12 @@ export function gatewayOptions(
       ],
       caching: "auto",
       ...(opts?.withFallbacks ? { models: PROSE_FALLBACK_MODELS } : {}),
+    },
+    // Sonnet 5 enables thinking by default. Our output ceilings are sized for
+    // the author-facing JSON/prose, so implicit reasoning can otherwise consume
+    // the entire allowance before any deliverable output is produced.
+    anthropic: {
+      thinking: { type: "disabled" },
     },
   };
 }
@@ -107,6 +116,30 @@ export class MeteringReconciliationRequiredError extends Error {
         : "A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.",
     );
     this.name = "MeteringReconciliationRequiredError";
+  }
+}
+
+export class MeteredOutputDeliveryError extends Error {
+  readonly isRetryable: boolean;
+
+  constructor(
+    readonly operation: string,
+    readonly finishReason: string,
+    readonly outputTokens: number,
+    readonly reasoningTokens: number,
+  ) {
+    const usageDetail = [
+      outputTokens > 0 ? `${outputTokens} output tokens` : null,
+      reasoningTokens > 0 ? `${reasoningTokens} reasoning tokens` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    super(
+      `${operation} ended before a complete result was available` +
+        ` (finish reason: ${finishReason}${usageDetail ? `; ${usageDetail}` : ""}).`,
+    );
+    this.name = "MeteredOutputDeliveryError";
+    this.isRetryable = finishReason !== "length" && finishReason !== "content-filter";
   }
 }
 
@@ -349,6 +382,16 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
 
   try {
     const result = await providerPromise;
+    let outputDeliveryFailure: unknown;
+    if ("output" in result) {
+      try {
+        // AI SDK exposes completed output through a getter that throws when
+        // the provider stopped before a complete result could be parsed.
+        void (result as T & { output: unknown }).output;
+      } catch (error) {
+        outputDeliveryFailure = error;
+      }
+    }
     // Image models bill per generated image, not per token — count returned image files.
     const imageCount =
       (result as { files?: Array<{ mediaType?: string }> }).files?.filter((f) =>
@@ -388,6 +431,13 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
         externalRefPrefix,
         intentRef,
         reservationRef: intent.reservationRef,
+        ...(outputDeliveryFailure
+          ? {
+              compensateDelivery: {
+                description: `Provider output for ${info.operation} was incomplete and not delivered`,
+              },
+            }
+          : {}),
       },
     );
     const settlement = {
@@ -397,6 +447,19 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
     };
     ctx.lastSettlement = settlement;
     ctx.settlements?.push(settlement);
+
+    if (outputDeliveryFailure) {
+      const finishReason =
+        "finishReason" in result && typeof result.finishReason === "string"
+          ? result.finishReason
+          : "unknown";
+      throw new MeteredOutputDeliveryError(
+        info.operation,
+        finishReason,
+        result.usage.outputTokens ?? 0,
+        result.usage.outputTokenDetails?.reasoningTokens ?? 0,
+      );
+    }
 
     return result;
   } catch (error) {

--- a/src/db/index.integration.test.ts
+++ b/src/db/index.integration.test.ts
@@ -21,7 +21,7 @@ import {
   updateProjectTransaction,
 } from "@/lib/project-transaction-operations";
 import { deleteClerkUserTransaction } from "@/lib/account-deletion-transaction";
-import { beginMeteredCallIntent } from "@/lib/billing/meter";
+import { beginMeteredCallIntent, recordLlmCallsAndDebit } from "@/lib/billing/meter";
 
 function isolatedDatabaseUrl(): string | null {
   const isolated = process.env.E2E_DATABASE_ISOLATED;
@@ -406,6 +406,135 @@ describeIsolated("withDbTransaction against isolated Neon", () => {
       expect(over.status).toBe("trial_cap");
     } finally {
       await observer`delete from users where id = ${fixture.userId}`;
+    }
+  });
+
+  it("atomically compensates incomplete interactive output and releases its project lease", async () => {
+    const userId = `e2e-metering-compensation-${suffix}`;
+    const projectId = randomUUID();
+    const intentRef = `metering-intent:interactive:${userId}:concept:attempt:one`;
+    const externalRefPrefix = `llm:interactive:${userId}:concept:attempt:one`;
+    try {
+      await observer`
+        insert into users (id, email)
+        values (${userId}, ${`${userId}@example.test`})
+      `;
+      await observer`
+        insert into projects (
+          id, user_id, title, brief, genre, experience,
+          target_chapters, target_words_per_chapter, settings
+        )
+        values (
+          ${projectId}, ${userId}, 'Compensation fixture',
+          'A disposable interactive metering fixture', 'fantasy',
+          'trial_short_story', 3, 1000, '{}'::jsonb
+        )
+      `;
+      await observer`
+        insert into credit_ledger (
+          user_id, amount, kind, description, project_id, external_ref
+        )
+        values (
+          ${userId}, 10, 'grant', 'Included story fixture',
+          ${projectId}, ${`metering-grant:compensation:${suffix}`}
+        )
+      `;
+
+      const intent = await beginMeteredCallIntent({
+        userId,
+        projectId,
+        intentRef,
+        intentPrefix: `metering-intent:interactive:${userId}:concept:attempt:`,
+        usagePrefix: `llm:interactive:${userId}:concept:`,
+        maxCredits: 1,
+        description: "Interactive compensated output",
+      });
+      expect(intent).toMatchObject({
+        status: "started",
+        optionalLeaseRef: `optional-operation-lease:${intentRef}`,
+      });
+      if (intent.status !== "started") throw new Error("Compensation fixture was not authorized");
+
+      const record = {
+        userId,
+        projectId,
+        runId: null,
+        agentRole: "concept",
+        operation: "concept.refine",
+        model: "anthropic/claude-sonnet-5",
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 500,
+          cachedInputTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      };
+      const debit = {
+        description: "concept.refine",
+        externalRefPrefix,
+        intentRef,
+        reservationRef: intent.reservationRef,
+        compensateDelivery: {
+          description: "Provider output was incomplete and not delivered",
+        },
+      };
+
+      const settled = await recordLlmCallsAndDebit([record], debit);
+      await expect(recordLlmCallsAndDebit([record], debit)).resolves.toEqual(settled);
+
+      const facts = firstRow<{
+        calls: number;
+        usages: number;
+        refunds: number;
+        claimReleases: number;
+        optionalLeaseReleases: number;
+        balance: string;
+      }>(
+        await observer`
+          select
+            (
+              select count(*)::int from llm_calls
+              where user_id = ${userId} and operation = 'concept.refine'
+            ) as calls,
+            count(*) filter (
+              where kind = 'usage'
+                and external_ref like ${`${externalRefPrefix}:%`}
+            )::int as usages,
+            count(*) filter (
+              where external_ref = ${`delivery-refund:${externalRefPrefix}`}
+            )::int as refunds,
+            count(*) filter (
+              where external_ref = ${`release:${intent.reservationRef}`}
+            )::int as "claimReleases",
+            count(*) filter (
+              where external_ref = ${`release:optional-operation-lease:${intentRef}`}
+            )::int as "optionalLeaseReleases",
+            coalesce(sum(amount), 0)::text as balance
+          from credit_ledger
+          where user_id = ${userId}
+        `,
+      );
+      expect(facts).toMatchObject({
+        calls: 1,
+        usages: 1,
+        refunds: 1,
+        claimReleases: 1,
+        optionalLeaseReleases: 1,
+      });
+      expect(Number(facts?.balance)).toBe(10);
+
+      const restoredCap = await beginMeteredCallIntent({
+        userId,
+        projectId,
+        intentRef: `metering-intent:interactive:${userId}:after-refund:attempt:one`,
+        intentPrefix: `metering-intent:interactive:${userId}:after-refund:attempt:`,
+        usagePrefix: `llm:interactive:${userId}:after-refund:`,
+        maxCredits: 10,
+        description: "Refund restored included-story capacity",
+      });
+      expect(restoredCap.status).toBe("started");
+    } finally {
+      await observer`delete from users where id = ${userId}`;
     }
   });
 

--- a/src/lib/billing/meter.test.ts
+++ b/src/lib/billing/meter.test.ts
@@ -135,6 +135,46 @@ describe("recordLlmCallsAndDebit", () => {
     expect(mocks.cacheDelete).toHaveBeenCalledWith("spend:user-1");
   });
 
+  it("atomically refunds incomplete interactive output and releases its project lease", async () => {
+    let queries: Array<{ strings: TemplateStringsArray; values: unknown[] }> = [];
+    mocks.transaction.mockImplementation(async (build) => {
+      const tx = (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values });
+      queries = build(tx);
+      return [
+        [],
+        [],
+        [{ recorded: true, authorized: "1", required: "0.0193", debited_credits: "0.0193" }],
+      ];
+    });
+    const interactiveRecord = {
+      ...firstRecord,
+      runId: null,
+    };
+    const interactiveDebit = {
+      ...debit,
+      compensateDelivery: {
+        description: "Provider output was incomplete and not delivered",
+      },
+    };
+
+    await expect(
+      recordLlmCallsAndDebit([interactiveRecord], interactiveDebit),
+    ).resolves.toMatchObject({
+      debitedCredits: 0.0193,
+    });
+
+    expect(queries).toHaveLength(3);
+    expect(queries[0].strings.join("?")).toContain("sopher:project-authoring:");
+    expect(queries[1].strings.join("?")).toContain("pg_advisory_xact_lock");
+    const settlementSql = queries[2].strings.join("?");
+    const settlementValues = queries[2].values.map(String).join("\n");
+    expect(settlementSql).toContain("delivery_refund");
+    expect(settlementSql).toContain("compensated_optional_lease_release");
+    expect(settlementValues).toContain(
+      `release:optional-operation-lease:${interactiveDebit.intentRef}`,
+    );
+  });
+
   it("fails closed without invalidating cache when the claim cannot authorize settlement", async () => {
     mocks.transaction.mockImplementation(async (build) => {
       const tx = (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values });
@@ -399,6 +439,44 @@ describe("metered intent authorization", () => {
     expect(queries[2].values.map(String).join("\n")).toContain("optional-operation-lease:");
     expect(sqlText).toContain("> ?");
     expect(queries[2].values.map(String)).toContain("10");
+  });
+
+  it("restores the trial cap only for an exact delivery refund, not unrelated adjustments", async () => {
+    let authorizationSql = "";
+    mocks.transaction.mockImplementation(async (build) => {
+      const tx = (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values });
+      const queries = build(tx);
+      authorizationSql = queries.at(-1)!.strings.join("?");
+      return [[], [{ status: "started", balance: "10", required: "0" }]];
+    });
+
+    await beginMeteredCallIntent({
+      userId: "user-1",
+      projectId: firstRecord.projectId,
+      runId: firstRecord.runId,
+      intentRef: debit.intentRef,
+      intentPrefix: "metering-intent:generation:run-1:chapter:1:writer.draft:attempt:",
+      usagePrefix: debit.externalRefPrefix,
+      parentReservationRef: "generation-reservation:run-1:wave-1",
+      maxCredits: 1,
+      description: "Metering intent for writer.draft",
+    });
+
+    const trialSpendSql = authorizationSql.slice(
+      authorizationSql.indexOf("trial_spend as materialized"),
+      authorizationSql.indexOf("trial_cap_blocked as materialized"),
+    );
+    expect(trialSpendSql).toContain("where entry.kind = 'usage'");
+    expect(trialSpendSql).toContain("from credit_ledger compensated");
+    expect(trialSpendSql).toContain("compensated.user_id = entry.user_id");
+    expect(trialSpendSql).toContain("compensated.kind = 'adjustment'");
+    expect(trialSpendSql).toContain("compensated.amount > 0");
+    expect(trialSpendSql).toContain(
+      "'delivery-refund:' ||\n                    regexp_replace(entry.external_ref, ':step:[0-9]+$', '')",
+    );
+    expect(trialSpendSql).not.toMatch(
+      /sum\(entry\.amount\)\s+filter\s*\(\s*where entry\.kind = 'adjustment'\s+and entry\.amount > 0/i,
+    );
   });
 
   it("rechecks suspension inside the wallet-locked authorization transaction", async () => {

--- a/src/lib/billing/meter.ts
+++ b/src/lib/billing/meter.ts
@@ -61,7 +61,7 @@ export type MeteredLedgerDebit = {
   intentRef: string;
   /** Per-attempt child claim created atomically with the intent. */
   reservationRef: string;
-  /** Atomically refund operator-verified work whose output was not delivered. */
+  /** Atomically refund settled provider work whose output was not delivered. */
   compensateDelivery?: { description: string };
 };
 
@@ -232,7 +232,19 @@ export async function beginMeteredCallIntent(input: {
     trial_spend as materialized (
       select
         coalesce(
-          -sum(entry.amount) filter (where entry.kind = 'usage'),
+          -sum(entry.amount) filter (
+            where entry.kind = 'usage'
+              and not exists (
+                select 1
+                from credit_ledger compensated
+                where compensated.user_id = entry.user_id
+                  and compensated.kind = 'adjustment'
+                  and compensated.amount > 0
+                  and compensated.external_ref =
+                    'delivery-refund:' ||
+                    regexp_replace(entry.external_ref, ':step:[0-9]+$', '')
+              )
+          ),
           0
         ) as credits_used,
         coalesce(
@@ -1446,6 +1458,10 @@ export async function recordLlmCallsAndDebit(
   const releaseRef = `release:${debit.reservationRef}`;
   const settledIntentRef = `intent-settled:${debit.intentRef}`;
   const deliveryRefundRef = `delivery-refund:${debit.externalRefPrefix}`;
+  const optionalLeaseReleaseRef =
+    debit.compensateDelivery && projectId && !runId
+      ? `release:optional-operation-lease:${debit.intentRef}`
+      : null;
   const callRows = JSON.stringify(
     costed.map(({ record, usd }) => ({
       user_id: record.userId,
@@ -1476,7 +1492,14 @@ export async function recordLlmCallsAndDebit(
   );
 
   const client = getSqlClient();
-  const [, result] = await client.transaction((tx) => [
+  const transactionResults = await client.transaction((tx) => [
+    ...(optionalLeaseReleaseRef
+      ? [
+          tx`select pg_advisory_xact_lock(
+            hashtextextended('sopher:project-authoring:' || ${projectId}, 0)
+          )`,
+        ]
+      : []),
     tx`select pg_advisory_xact_lock(hashtextextended(${userId}, 0))`,
     tx`
     with call_values as materialized (
@@ -1647,6 +1670,17 @@ export async function recordLlmCallsAndDebit(
         and run_id is not distinct from ${runId}
       limit 1
     ),
+    existing_optional_lease_release as materialized (
+      select id
+      from credit_ledger
+      where user_id = ${userId}
+        and external_ref = ${optionalLeaseReleaseRef}
+        and kind = 'adjustment'
+        and amount = 0
+        and project_id is not distinct from ${projectId}
+        and run_id is null
+      limit 1
+    ),
     delivery_refund as (
       insert into credit_ledger (
         user_id, amount, kind, description, project_id, run_id, external_ref
@@ -1662,6 +1696,26 @@ export async function recordLlmCallsAndDebit(
       from settled_intent
       where ${debit.compensateDelivery?.description ?? null}::text is not null
         and exists (select 1 from usage_insert)
+      on conflict (external_ref) do nothing
+      returning id
+    ),
+    compensated_optional_lease_release as (
+      insert into credit_ledger (
+        user_id, amount, kind, description, project_id, run_id, external_ref
+      )
+      select
+        ${userId},
+        0,
+        'adjustment',
+        'Release optional operation after compensated delivery',
+        ${projectId},
+        null,
+        ${optionalLeaseReleaseRef}
+      where ${optionalLeaseReleaseRef}::text is not null
+        and (
+          exists (select 1 from delivery_refund)
+          or exists (select 1 from existing_delivery_refund)
+        )
       on conflict (external_ref) do nothing
       returning id
     ),
@@ -1712,6 +1766,11 @@ export async function recordLlmCallsAndDebit(
             ${debit.compensateDelivery?.description ?? null}::text is null
             or exists (select 1 from delivery_refund)
           )
+          and (
+            ${optionalLeaseReleaseRef}::text is null
+            or exists (select 1 from compensated_optional_lease_release)
+            or exists (select 1 from existing_optional_lease_release)
+          )
         )
         or (
           exists (select 1 from existing_settlement)
@@ -1719,6 +1778,11 @@ export async function recordLlmCallsAndDebit(
           and (
             ${debit.compensateDelivery?.description ?? null}::text is null
             or exists (select 1 from existing_delivery_refund)
+          )
+          and (
+            ${optionalLeaseReleaseRef}::text is null
+            or exists (select 1 from compensated_optional_lease_release)
+            or exists (select 1 from existing_optional_lease_release)
           )
         )
       ) as recorded,
@@ -1735,6 +1799,7 @@ export async function recordLlmCallsAndDebit(
       ) as debited_credits
   `,
   ]);
+  const result = transactionResults.at(-1);
   const settled = (
     result as Array<{
       recorded: boolean;

--- a/src/lib/billing/run-spend.ts
+++ b/src/lib/billing/run-spend.ts
@@ -1,0 +1,27 @@
+import { sql } from "drizzle-orm";
+
+import { creditLedger } from "@/db/schema";
+
+/**
+ * Author-facing credits consumed by a run. Provider usage remains in the
+ * ledger for auditability, while delivery refunds cancel the corresponding
+ * charge in the number shown to the author.
+ */
+export function netRunCreditsUsedSql() {
+  return sql<string>`coalesce(
+    -sum(${creditLedger.amount}) filter (
+      where ${creditLedger.kind} = 'usage'
+        and not exists (
+          select 1
+          from credit_ledger compensated
+          where compensated.user_id = credit_ledger.user_id
+            and compensated.kind = 'adjustment'
+            and compensated.amount > 0
+            and compensated.external_ref =
+              'delivery-refund:' ||
+              regexp_replace(credit_ledger.external_ref, ':step:[0-9]+$', '')
+        )
+    ),
+    0
+  )`;
+}

--- a/src/lib/run-health.integration.test.ts
+++ b/src/lib/run-health.integration.test.ts
@@ -130,4 +130,45 @@ describeIsolated("run health against isolated Neon", () => {
       authoringBegan: true,
     });
   });
+
+  it("reports net credits after delivery refunds without subtracting unrelated adjustments", async () => {
+    if (!observer) throw new Error("Isolated database observer is unavailable");
+
+    await observer`
+      insert into credit_ledger (
+        user_id, amount, kind, description, project_id, run_id, external_ref
+      )
+      values
+        (
+          ${userId}, -0.4742, 'usage', 'Refunded provider usage',
+          ${projectId}, ${runId}, ${`llm:generation:${runId}:refine:attempt:one:step:0`}
+        ),
+        (
+          ${userId}, -0.2415, 'usage', 'Delivered provider usage',
+          ${projectId}, ${runId}, ${`llm:generation:${runId}:expand:attempt:two:step:0`}
+        ),
+        (
+          ${userId}, 0.4742, 'adjustment', 'Undelivered output compensation',
+          ${projectId}, ${runId}, ${`delivery-refund:llm:generation:${runId}:refine:attempt:one`}
+        ),
+        (
+          ${userId}, 9.0000, 'adjustment', 'Malformed unmatched compensation',
+          ${projectId}, ${runId}, ${`delivery-refund:llm:generation:${runId}:unmatched`}
+        ),
+        (
+          ${userId}, 1.0000, 'adjustment', 'Unrelated account adjustment',
+          ${projectId}, ${runId}, ${`support-adjustment:${runId}`}
+        )
+    `;
+
+    const [run] = await getDb()
+      .select()
+      .from(schema.generationRuns)
+      .where(eq(schema.generationRuns.id, runId))
+      .limit(1);
+    expect(run).toBeDefined();
+
+    const health = await getRunHealth(run!);
+    expect(health.spend.creditsUsed).toBeCloseTo(0.2415, 4);
+  });
 });

--- a/src/lib/run-health.ts
+++ b/src/lib/run-health.ts
@@ -4,6 +4,7 @@ import { getRun } from "workflow/api";
 import { estimateBookCost } from "@/ai/estimate";
 import type { QualityTier } from "@/ai/models";
 import { getDb, schema } from "@/db";
+import { netRunCreditsUsedSql } from "@/lib/billing/run-spend";
 import {
   ACTIVE_AUTHORING_RUN_STATUSES,
   deriveAuthoringRunAcceptanceState,
@@ -422,10 +423,10 @@ async function readRunFacts(run: RunForHealth): Promise<RunFacts> {
       .where(eq(schema.llmCalls.runId, run.id)),
     db
       .select({
-        credits: sql<string>`coalesce(-sum(${schema.creditLedger.amount}), 0)`,
+        credits: netRunCreditsUsedSql(),
       })
       .from(schema.creditLedger)
-      .where(and(eq(schema.creditLedger.runId, run.id), eq(schema.creditLedger.kind, "usage"))),
+      .where(eq(schema.creditLedger.runId, run.id)),
     db
       .select({ count: sql<number>`count(*)::int` })
       .from(schema.creditLedger)

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -29,6 +29,7 @@ import {
   releaseCreditReservation,
   reserveCredits,
 } from "@/lib/billing/credits";
+import { netRunCreditsUsedSql } from "@/lib/billing/run-spend";
 import { getOrCreateBook } from "@/db/queries/projects";
 import { listEntities, seedEntities } from "@/db/queries/entities";
 import { sendBookFinishedEmail, sendCreditsPausedEmail } from "@/lib/email/send";
@@ -116,12 +117,10 @@ export async function emitCost(ref: RunRef) {
       .where(eq(schema.llmCalls.runId, ref.dbRunId)),
     db
       .select({
-        total: sql<string>`coalesce(-sum(${schema.creditLedger.amount}), 0)`,
+        total: netRunCreditsUsedSql(),
       })
       .from(schema.creditLedger)
-      .where(
-        and(eq(schema.creditLedger.runId, ref.dbRunId), eq(schema.creditLedger.kind, "usage")),
-      ),
+      .where(eq(schema.creditLedger.runId, ref.dbRunId)),
   ]);
   const event = runCostEvent(Number(provider?.total ?? 0), Number(ledger?.total ?? 0));
   await writeEvent(PROGRESS_NS, event);


### PR DESCRIPTION
## Summary

- disable implicit Anthropic thinking so Sonnet 5 cannot spend the complete output allowance before returning the structured authoring result
- atomically compensate incomplete provider output, restore phase capacity, and release optional-operation leases
- make delivery refunds restore the included-story cap and report net rather than gross author credits
- add deterministic diagnostics and prevent retries for output-limit failures

## Incident evidence

The failed preview run reached AI Gateway successfully, but all four `concept.refine` attempts ended at the exact 5,000-token ceiling. Hidden reasoning consumed most of each allowance, and AI SDK therefore had no complete structured output to parse. A later author retry completed concept and outline successfully and remains intact.

The failed run delivered no author-visible artifact. Its remaining 0.2415-credit charge was reimbursed idempotently; its gross provider usage is now fully offset while the audit rows remain preserved.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 105 files / 771 tests
- isolated Neon suite — 18/18 tests
- `pnpm check:migrations`
- `pnpm db:check`
- `pnpm build`

The real-Neon coverage verifies atomic debit/refund/lease release, idempotent replay, restored trial capacity, and exact run-credit/refund correlation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes prepaid credit settlement, trial-cap math, and lease release in atomic SQL—billing and authoring concurrency paths; mitigated by unit and isolated Neon integration tests.
> 
> **Overview**
> Fixes preview authoring runs where **Sonnet 5** hit the output ceiling with no parseable structured result—implicit **Anthropic thinking** could burn the whole token budget on reasoning.
> 
> **`gatewayOptions`** now sets `anthropic.thinking: { type: "disabled" }` on metered calls so ceilings target deliverable JSON/prose.
> 
> When the AI SDK **`output`** getter throws after a provider response, **`metered()`** still settles usage, passes **`compensateDelivery`** into **`recordLlmCallsAndDebit`**, then throws **`MeteredOutputDeliveryError`** (non-retryable for `length` / `content-filter`) with finish reason and token diagnostics.
> 
> Settlement atomically posts a **`delivery-refund:`** adjustment, restores phase capacity where applicable, and for interactive (non-run) work releases the **optional-operation lease** under the project authoring lock. Trial-cap **`trial_spend`** ignores usage rows that have a matching delivery refund (not blanket positive adjustments).
> 
> Author-facing run spend uses new **`netRunCreditsUsedSql()`** in run health and workflow cost emission so refunded undelivered usage does not count toward **`creditsUsed`** while audit rows stay in the ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 186e51c359bf3b90806bb148b4178b3e6c3fbe00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->