### PR TITLE
Fix interrupted authoring recovery

### DIFF
--- a/drizzle/0018_unresolved_metering_incidents.sql
+++ b/drizzle/0018_unresolved_metering_incidents.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "authoring_incidents" DROP CONSTRAINT "authoring_incidents_category_check";--> statement-breakpoint
+ALTER TABLE "authoring_incidents" ADD CONSTRAINT "authoring_incidents_category_check" CHECK ("authoring_incidents"."category" in (
+  'dispatch', 'workflow_missing', 'stalled_heartbeat', 'invalid_pause',
+  'completion_contradiction', 'cancellation_unconfirmed',
+  'stale_reservation', 'event_persistence', 'unresolved_metering', 'operator_action'
+));

--- a/drizzle/0019_notification_preferences.sql
+++ b/drizzle/0019_notification_preferences.sql
@@ -1,0 +1,26 @@
+ALTER TABLE "users" ADD COLUMN "email_authoring_action_required" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email_authoring_reminders" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email_authoring_completed" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+CREATE TABLE "notification_deliveries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"category" text NOT NULL,
+	"event_key" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"claim_token" uuid,
+	"lease_expires_at" timestamp with time zone,
+	"sent_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "notification_deliveries_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "notification_deliveries_category_check" CHECK ("notification_deliveries"."category" in ('authoringActionRequired', 'authoringReminders', 'authoringCompleted')),
+	CONSTRAINT "notification_deliveries_status_check" CHECK ("notification_deliveries"."status" in ('pending', 'sent', 'suppressed', 'failed')),
+	CONSTRAINT "notification_deliveries_claim_check" CHECK ((
+		("notification_deliveries"."status" = 'pending' and "notification_deliveries"."claim_token" is not null and "notification_deliveries"."lease_expires_at" is not null)
+		or
+		("notification_deliveries"."status" <> 'pending' and "notification_deliveries"."claim_token" is null and "notification_deliveries"."lease_expires_at" is null)
+	))
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_notification_deliveries_event_key" ON "notification_deliveries" USING btree ("event_key");--> statement-breakpoint
+CREATE INDEX "idx_notification_deliveries_user" ON "notification_deliveries" USING btree ("user_id", "created_at");

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,4009 @@
+{
+  "id": "c02eb4db-da6d-40e4-aa7b-b6ec16a2f304",
+  "prevId": "6cba8a94-9fa6-4c13-898c-a7ce2e29c679",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics_events": {
+      "name": "analytics_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anon_id": {
+          "name": "anon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "props": {
+          "name": "props",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_name_created": {
+          "name": "idx_events_name_created",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_anon": {
+          "name": "idx_events_anon",
+          "columns": [
+            {
+              "expression": "anon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assets_project": {
+          "name": "idx_assets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_project_id_projects_id_fk": {
+          "name": "assets_project_id_projects_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assets_chapter_id_chapters_id_fk": {
+          "name": "assets_chapter_id_chapters_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authoring_incidents": {
+      "name": "authoring_incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_authoring_incident_active": {
+          "name": "uq_authoring_incident_active",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"authoring_incidents\".\"resolved_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authoring_incidents_project": {
+          "name": "idx_authoring_incidents_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authoring_incidents_active": {
+          "name": "idx_authoring_incidents_active",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authoring_incidents_run_project_generation_runs_fk": {
+          "name": "authoring_incidents_run_project_generation_runs_fk",
+          "tableFrom": "authoring_incidents",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authoring_incidents_occurrence_count_check": {
+          "name": "authoring_incidents_occurrence_count_check",
+          "value": "\"authoring_incidents\".\"occurrence_count\" >= 1"
+        },
+        "authoring_incidents_severity_check": {
+          "name": "authoring_incidents_severity_check",
+          "value": "\"authoring_incidents\".\"severity\" in ('warning', 'critical')"
+        },
+        "authoring_incidents_category_check": {
+          "name": "authoring_incidents_category_check",
+          "value": "\"authoring_incidents\".\"category\" in (\n        'dispatch', 'workflow_missing', 'stalled_heartbeat', 'invalid_pause',\n        'completion_contradiction', 'cancellation_unconfirmed',\n        'stale_reservation', 'event_persistence', 'unresolved_metering', 'operator_action'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.authoring_questions": {
+      "name": "authoring_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_option_id": {
+          "name": "recommended_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_digest": {
+          "name": "decision_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_version": {
+          "name": "pause_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input_id": {
+          "name": "input_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_authoring_question_run_key": {
+          "name": "uq_authoring_question_run_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_authoring_question_pause": {
+          "name": "uq_authoring_question_pause",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pause_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"authoring_questions\".\"pause_version\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_authoring_question_input": {
+          "name": "uq_authoring_question_input",
+          "columns": [
+            {
+              "expression": "input_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"authoring_questions\".\"input_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authoring_questions_pending": {
+          "name": "idx_authoring_questions_pending",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authoring_questions_input_id_authoring_run_inputs_id_fk": {
+          "name": "authoring_questions_input_id_authoring_run_inputs_id_fk",
+          "tableFrom": "authoring_questions",
+          "tableTo": "authoring_run_inputs",
+          "columnsFrom": [
+            "input_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "authoring_questions_run_project_generation_runs_fk": {
+          "name": "authoring_questions_run_project_generation_runs_fk",
+          "tableFrom": "authoring_questions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authoring_questions_options_count_check": {
+          "name": "authoring_questions_options_count_check",
+          "value": "jsonb_array_length(\"authoring_questions\".\"options\") = 3"
+        },
+        "authoring_questions_pause_version_check": {
+          "name": "authoring_questions_pause_version_check",
+          "value": "\"authoring_questions\".\"pause_version\" is null or \"authoring_questions\".\"pause_version\" >= 1"
+        },
+        "authoring_questions_status_check": {
+          "name": "authoring_questions_status_check",
+          "value": "\"authoring_questions\".\"status\" in ('pending', 'answered')"
+        },
+        "authoring_questions_stage_check": {
+          "name": "authoring_questions_stage_check",
+          "value": "\"authoring_questions\".\"stage\" = 'after_concept'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.authoring_run_inputs": {
+      "name": "authoring_run_inputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pause_version": {
+          "name": "pause_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accepted'"
+        },
+        "delivery_attempts": {
+          "name": "delivery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_error": {
+          "name": "last_delivery_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_authoring_run_input_pause": {
+          "name": "uq_authoring_run_input_pause",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pause_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_authoring_run_input_request": {
+          "name": "uq_authoring_run_input_request",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authoring_run_inputs_delivery": {
+          "name": "idx_authoring_run_inputs_delivery",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authoring_run_inputs_run_id_generation_runs_id_fk": {
+          "name": "authoring_run_inputs_run_id_generation_runs_id_fk",
+          "tableFrom": "authoring_run_inputs",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authoring_run_inputs_pause_version_check": {
+          "name": "authoring_run_inputs_pause_version_check",
+          "value": "\"authoring_run_inputs\".\"pause_version\" >= 1"
+        },
+        "authoring_run_inputs_delivery_attempts_check": {
+          "name": "authoring_run_inputs_delivery_attempts_check",
+          "value": "\"authoring_run_inputs\".\"delivery_attempts\" >= 0"
+        },
+        "authoring_run_inputs_status_check": {
+          "name": "authoring_run_inputs_status_check",
+          "value": "\"authoring_run_inputs\".\"status\" in ('accepted', 'delivered', 'consumed')"
+        },
+        "authoring_run_inputs_kind_check": {
+          "name": "authoring_run_inputs_kind_check",
+          "value": "\"authoring_run_inputs\".\"kind\" in ('outline_approval', 'credits_topup', 'creative_decision')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.authoring_stream_leases": {
+      "name": "authoring_stream_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_authoring_stream_leases_active": {
+          "name": "idx_authoring_stream_leases_active",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_authoring_stream_leases_user": {
+          "name": "idx_authoring_stream_leases_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authoring_stream_leases_run_user_generation_runs_fk": {
+          "name": "authoring_stream_leases_run_user_generation_runs_fk",
+          "tableFrom": "authoring_stream_leases",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "authoring_stream_leases_namespace_check": {
+          "name": "authoring_stream_leases_namespace_check",
+          "value": "\"authoring_stream_leases\".\"namespace\" = 'progress' or \"authoring_stream_leases\".\"namespace\" ~ '^chapter:[1-9][0-9]{0,3}$'"
+        },
+        "authoring_stream_leases_expiry_check": {
+          "name": "authoring_stream_leases_expiry_check",
+          "value": "\"authoring_stream_leases\".\"expires_at\" > \"authoring_stream_leases\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synopsis": {
+          "name": "synopsis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concept": {
+          "name": "concept",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "front_matter": {
+          "name": "front_matter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_books_project": {
+          "name": "uq_books_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_project_id_projects_id_fk": {
+          "name": "books_project_id_projects_id_fk",
+          "tableFrom": "books",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_books_id_project": {
+          "name": "uq_books_id_project",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_revisions": {
+      "name": "chapter_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_revisions_chapter": {
+          "name": "idx_revisions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_revisions_chapter_id_chapters_id_fk": {
+          "name": "chapter_revisions_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_revisions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_chapter_num": {
+          "name": "uq_chapter_num",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chapters_summary_fts": {
+          "name": "idx_chapters_summary_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', coalesce(\"summary\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapters_book_id_books_id_fk": {
+          "name": "chapters_book_id_books_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_tool_runs": {
+      "name": "content_tool_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_id": {
+          "name": "tool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tool_runs_project": {
+          "name": "idx_tool_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tool_runs_user_id_users_id_fk": {
+          "name": "content_tool_runs_user_id_users_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_project_id_projects_id_fk": {
+          "name": "content_tool_runs_project_id_projects_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tool_runs_chapter_id_chapters_id_fk": {
+          "name": "content_tool_runs_chapter_id_chapters_id_fk",
+          "tableFrom": "content_tool_runs",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.continuity_issues": {
+      "name": "continuity_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_fix": {
+          "name": "suggested_fix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_continuity_book": {
+          "name": "idx_continuity_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "continuity_issues_book_id_books_id_fk": {
+          "name": "continuity_issues_book_id_books_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "continuity_issues_run_id_generation_runs_id_fk": {
+          "name": "continuity_issues_run_id_generation_runs_id_fk",
+          "tableFrom": "continuity_issues",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metered_usd": {
+          "name": "metered_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usd_paid": {
+          "name": "usd_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ledger_user": {
+          "name": "idx_ledger_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_ledger_external_ref": {
+          "name": "uq_ledger_external_ref",
+          "columns": [
+            {
+              "expression": "external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_user_id_users_id_fk": {
+          "name": "credit_ledger_user_id_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_project_id_projects_id_fk": {
+          "name": "credit_ledger_project_id_projects_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credit_ledger_run_id_generation_runs_id_fk": {
+          "name": "credit_ledger_run_id_generation_runs_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "portrait_asset_id": {
+          "name": "portrait_asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_appearance_chapter": {
+          "name": "first_appearance_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_chapter": {
+          "name": "last_updated_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_name": {
+          "name": "uq_entity_name",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_book": {
+          "name": "idx_entities_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_book_id_books_id_fk": {
+          "name": "entities_book_id_books_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_relationships": {
+      "name": "entity_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "established_chapter": {
+          "name": "established_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_entity_relationship": {
+          "name": "uq_entity_relationship",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_relationships_book": {
+          "name": "idx_relationships_book",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_relationships_book_id_books_id_fk": {
+          "name": "entity_relationships_book_id_books_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_from_entity_id_entities_id_fk": {
+          "name": "entity_relationships_from_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "from_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_relationships_to_entity_id_entities_id_fk": {
+          "name": "entity_relationships_to_entity_id_entities_id_fk",
+          "tableFrom": "entity_relationships",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "to_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_events": {
+      "name": "generation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_event_seq": {
+          "name": "uq_event_seq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_event_key": {
+          "name": "uq_event_key",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"generation_events\".\"event_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_events_run_id_generation_runs_id_fk": {
+          "name": "generation_events_run_id_generation_runs_id_fk",
+          "tableFrom": "generation_events",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "generation_events_seq_check": {
+          "name": "generation_events_seq_check",
+          "value": "\"generation_events\".\"seq\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.generation_runs": {
+      "name": "generation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "progress_pct": {
+          "name": "progress_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stage_description": {
+          "name": "stage_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_progress_at": {
+          "name": "last_progress_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_observed_status": {
+          "name": "workflow_observed_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_observed_at": {
+          "name": "workflow_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_missing_since": {
+          "name": "workflow_missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_missing_count": {
+          "name": "workflow_missing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_kind": {
+          "name": "pause_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_version": {
+          "name": "pause_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pause_key": {
+          "name": "pause_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_details": {
+          "name": "pause_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_registered_at": {
+          "name": "pause_registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_error_code": {
+          "name": "root_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_error_stage": {
+          "name": "root_error_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "support_reference": {
+          "name": "support_reference",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "approval_notes": {
+          "name": "approval_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_uncertain_at": {
+          "name": "acceptance_uncertain_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_dispatch_claimed_at": {
+          "name": "acceptance_dispatch_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_checked_at": {
+          "name": "health_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_runs_project": {
+          "name": "idx_runs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_health_check": {
+          "name": "idx_runs_health_check",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "health_checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_support_reference": {
+          "name": "uq_runs_support_reference",
+          "columns": [
+            {
+              "expression": "support_reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_id_project": {
+          "name": "uq_runs_id_project",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_id_user": {
+          "name": "uq_runs_id_user",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_active_per_project": {
+          "name": "uq_runs_active_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status in ('queued','running','awaiting_input') and kind <> 'export'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_runs_project_request_key": {
+          "name": "uq_runs_project_request_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_runs_project_id_projects_id_fk": {
+          "name": "generation_runs_project_id_projects_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "generation_runs_user_id_users_id_fk": {
+          "name": "generation_runs_user_id_users_id_fk",
+          "tableFrom": "generation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "generation_runs_current_stage_check": {
+          "name": "generation_runs_current_stage_check",
+          "value": "\"generation_runs\".\"current_stage\" in (\n        'queued', 'concept', 'awaiting_guidance', 'outline', 'awaiting_approval', 'awaiting_credits',\n        'bible', 'chapters', 'editing', 'continuity', 'revising',\n        'finalizing', 'done', 'failed', 'cancelled'\n      )"
+        },
+        "generation_runs_progress_pct_check": {
+          "name": "generation_runs_progress_pct_check",
+          "value": "\"generation_runs\".\"progress_pct\" between 0 and 100"
+        },
+        "generation_runs_workflow_observed_status_check": {
+          "name": "generation_runs_workflow_observed_status_check",
+          "value": "\"generation_runs\".\"workflow_observed_status\" is null or \"generation_runs\".\"workflow_observed_status\" in (\n        'pending', 'running', 'completed', 'failed', 'cancelled', 'missing', 'unavailable'\n      )"
+        },
+        "generation_runs_workflow_missing_count_check": {
+          "name": "generation_runs_workflow_missing_count_check",
+          "value": "\"generation_runs\".\"workflow_missing_count\" >= 0"
+        },
+        "generation_runs_dispatch_attempts_check": {
+          "name": "generation_runs_dispatch_attempts_check",
+          "value": "\"generation_runs\".\"dispatch_attempts\" between 0 and 3"
+        },
+        "generation_runs_pause_version_check": {
+          "name": "generation_runs_pause_version_check",
+          "value": "\"generation_runs\".\"pause_version\" >= 0"
+        },
+        "generation_runs_next_event_seq_check": {
+          "name": "generation_runs_next_event_seq_check",
+          "value": "\"generation_runs\".\"next_event_seq\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.llm_calls": {
+      "name": "llm_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_role": {
+          "name": "agent_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_input_tokens": {
+          "name": "cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usd": {
+          "name": "usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_user_time": {
+          "name": "idx_llm_user_time",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_run": {
+          "name": "idx_llm_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_project": {
+          "name": "idx_llm_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_calls_user_id_users_id_fk": {
+          "name": "llm_calls_user_id_users_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "llm_calls_project_id_projects_id_fk": {
+          "name": "llm_calls_project_id_projects_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_calls_run_id_generation_runs_id_fk": {
+          "name": "llm_calls_run_id_generation_runs_id_fk",
+          "tableFrom": "llm_calls",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_flags": {
+      "name": "moderation_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_number": {
+          "name": "chapter_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'review'"
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flags_status": {
+          "name": "idx_flags_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_flags_project_id_projects_id_fk": {
+          "name": "moderation_flags_project_id_projects_id_fk",
+          "tableFrom": "moderation_flags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_notification_deliveries_event_key": {
+          "name": "uq_notification_deliveries_event_key",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_user": {
+          "name": "idx_notification_deliveries_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_user_id_users_id_fk": {
+          "name": "notification_deliveries_user_id_users_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_deliveries_category_check": {
+          "name": "notification_deliveries_category_check",
+          "value": "\"notification_deliveries\".\"category\" in ('authoringActionRequired', 'authoringReminders', 'authoringCompleted')"
+        },
+        "notification_deliveries_status_check": {
+          "name": "notification_deliveries_status_check",
+          "value": "\"notification_deliveries\".\"status\" in ('pending', 'sent', 'suppressed', 'failed')"
+        },
+        "notification_deliveries_claim_check": {
+          "name": "notification_deliveries_claim_check",
+          "value": "(\n        (\"notification_deliveries\".\"status\" = 'pending' and \"notification_deliveries\".\"claim_token\" is not null and \"notification_deliveries\".\"lease_expires_at\" is not null)\n        or\n        (\"notification_deliveries\".\"status\" <> 'pending' and \"notification_deliveries\".\"claim_token\" is null and \"notification_deliveries\".\"lease_expires_at\" is null)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.outlines": {
+      "name": "outlines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outline_version": {
+          "name": "uq_outline_version",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlines_book_id_books_id_fk": {
+          "name": "outlines_book_id_books_id_fk",
+          "tableFrom": "outlines",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subgenre": {
+          "name": "subgenre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protagonist": {
+          "name": "protagonist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setting": {
+          "name": "setting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_book'"
+        },
+        "creation_key": {
+          "name": "creation_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_chapters": {
+          "name": "target_chapters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "target_words_per_chapter": {
+          "name": "target_words_per_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_user": {
+          "name": "idx_projects_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_projects_user_creation_key": {
+          "name": "uq_projects_user_creation_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_projects_one_trial_per_user": {
+          "name": "uq_projects_one_trial_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"experience\" = 'trial_short_story'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_editions": {
+      "name": "publication_editions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_digest": {
+          "name": "source_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incomplete": {
+          "name": "incomplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chapter_count": {
+          "name": "chapter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_words": {
+          "name": "total_words",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_publication_edition_source": {
+          "name": "uq_publication_edition_source",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_publication_editions_owner": {
+          "name": "idx_publication_editions_owner",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_editions_project_id_projects_id_fk": {
+          "name": "publication_editions_project_id_projects_id_fk",
+          "tableFrom": "publication_editions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_editions_book_id_books_id_fk": {
+          "name": "publication_editions_book_id_books_id_fk",
+          "tableFrom": "publication_editions",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_editions_user_id_users_id_fk": {
+          "name": "publication_editions_user_id_users_id_fk",
+          "tableFrom": "publication_editions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_editions_book_project_fk": {
+          "name": "publication_editions_book_project_fk",
+          "tableFrom": "publication_editions",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id",
+            "project_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_publication_edition_id_project_user": {
+          "name": "uq_publication_edition_id_project_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "publication_editions_digest_check": {
+          "name": "publication_editions_digest_check",
+          "value": "length(\"publication_editions\".\"source_digest\") = 64"
+        },
+        "publication_editions_chapter_count_check": {
+          "name": "publication_editions_chapter_count_check",
+          "value": "\"publication_editions\".\"chapter_count\" > 0"
+        },
+        "publication_editions_total_words_check": {
+          "name": "publication_editions_total_words_check",
+          "value": "\"publication_editions\".\"total_words\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reader_shares": {
+      "name": "reader_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "edition_id": {
+          "name": "edition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "allow_download": {
+          "name": "allow_download",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_reader_shares_token_hash": {
+          "name": "uq_reader_shares_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reader_shares_owner": {
+          "name": "idx_reader_shares_owner",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reader_shares_active": {
+          "name": "idx_reader_shares_active",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_shares_edition_project_user_fk": {
+          "name": "reader_shares_edition_project_user_fk",
+          "tableFrom": "reader_shares",
+          "tableTo": "publication_editions",
+          "columnsFrom": [
+            "edition_id",
+            "project_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "project_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reader_shares_token_hash_check": {
+          "name": "reader_shares_token_hash_check",
+          "value": "length(\"reader_shares\".\"token_hash\") = 64"
+        },
+        "reader_shares_status_check": {
+          "name": "reader_shares_status_check",
+          "value": "(\"reader_shares\".\"status\" = 'active' and \"reader_shares\".\"revoked_at\" is null)\n        or (\"reader_shares\".\"status\" = 'revoked' and \"reader_shares\".\"revoked_at\" is not null)"
+        },
+        "reader_shares_expiry_check": {
+          "name": "reader_shares_expiry_check",
+          "value": "\"reader_shares\".\"expires_at\" is null or \"reader_shares\".\"expires_at\" > \"reader_shares\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suggestions": {
+      "name": "suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_version": {
+          "name": "chapter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_type": {
+          "name": "pass_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_chapter": {
+          "name": "idx_suggestions_chapter",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestions_chapter_id_chapters_id_fk": {
+          "name": "suggestions_chapter_id_chapters_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestions_run_id_generation_runs_id_fk": {
+          "name": "suggestions_run_id_generation_runs_id_fk",
+          "tableFrom": "suggestions",
+          "tableTo": "generation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acquisition": {
+          "name": "acquisition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authoring_onboarding": {
+          "name": "authoring_onboarding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"version\":1,\"seenCoachmarks\":[]}'::jsonb"
+        },
+        "email_authoring_action_required": {
+          "name": "email_authoring_action_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_authoring_reminders": {
+          "name": "email_authoring_reminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_authoring_completed": {
+          "name": "email_authoring_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1785740988478,
       "tag": "0017_publication_editions",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1785750000000,
+      "tag": "0018_unresolved_metering_incidents",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1785750000000,
       "tag": "0018_unresolved_metering_incidents",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1785753600000,
+      "tag": "0019_notification_preferences",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -87,7 +87,7 @@ test("library exposes one truthful action for every authoring state", async ({
     {
       title: "The Orchard Below",
       label: "Resume from saved work",
-      href: `/projects/${PROJECTS.partialFailure}/write`,
+      href: `/projects/${PROJECTS.partialFailure}/write#authoring-recovery`,
       detail: "2 saved chapters",
     },
     {
@@ -361,4 +361,92 @@ test("mobile next step remains below the app bar and incomplete work stays expli
 
   expect(consoleErrors, "browser console errors").toEqual([]);
   expect(serverErrors, "500 responses").toEqual([]);
+});
+
+test("mobile interrupted recovery CTA reaches the actionable recovery panel", async ({
+  page,
+}, testInfo) => {
+  const recoveredRunId = "70707070-0000-4000-8000-000000000005";
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.route(`**/api/projects/${PROJECTS.partialFailure}/generate`, async (route) => {
+    await route.fulfill({
+      status: 202,
+      contentType: "application/json",
+      body: JSON.stringify({
+        runId: recoveredRunId,
+        kind: "full_book",
+        status: "queued",
+        config: {
+          tier: "standard",
+          targetChapters: 3,
+          targetWordsPerChapter: 1000,
+          requireOutlineApproval: false,
+        },
+      }),
+    });
+  });
+  await page.route(`**/api/runs/${recoveredRunId}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        run: { id: recoveredRunId, status: "queued", error: null },
+        health: {
+          databaseStatus: "queued",
+          effectiveStatus: "queued",
+          stage: "queued",
+          progressPct: 0,
+          stageDescription: "Preparing the writing room",
+          noWorkStarted: true,
+          health: "healthy",
+          savedChapterCount: 2,
+          savedCheckpointCount: 2,
+        },
+      }),
+    });
+  });
+  await page.route(`**/api/runs/${recoveredRunId}/stream?**`, async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/x-ndjson", body: "" });
+  });
+  await page.goto(`/projects/${PROJECTS.partialFailure}/write`);
+
+  const nextStep = page.getByRole("region", {
+    name: "Next step: Resume from saved work",
+  });
+  const resumeLink = nextStep.getByRole("link", { name: "Resume from saved work" });
+  const recoveryPanel = page.locator("#authoring-recovery");
+
+  await expect(nextStep).toBeVisible({ timeout: 20_000 });
+  await expect(resumeLink).toHaveAttribute(
+    "href",
+    `/projects/${PROJECTS.partialFailure}/write#authoring-recovery`,
+  );
+  await expect(recoveryPanel).toHaveAttribute("tabindex", "-1");
+  await expectNoPageOverflow(page, "390px interrupted recovery");
+  await axeCheck(page);
+
+  await resumeLink.click();
+
+  await expect(page).toHaveURL(
+    new RegExp(`/projects/${PROJECTS.partialFailure}/write#authoring-recovery$`, "u"),
+  );
+  await expect(recoveryPanel).toBeVisible();
+  await expect(recoveryPanel).toBeFocused();
+  await expect
+    .poll(async () => {
+      const box = await recoveryPanel.boundingBox();
+      if (!box) return false;
+      return box.y < 844 && box.y + box.height > 0;
+    })
+    .toBe(true);
+  await expect(recoveryPanel.getByRole("button", { name: "Resume from saved work" })).toBeVisible();
+  await screenshot(page, testInfo.project.name, "mobile-interrupted-recovery", false);
+
+  await recoveryPanel.getByRole("button", { name: "Resume from saved work" }).click();
+
+  await expect(page.getByRole("region", { name: "Next step: Watch production" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Resume from saved work" })).toHaveCount(0);
+  await expect(page.getByRole("region", { name: "Book generation run" })).toBeFocused();
+  await expectNoPageOverflow(page, "390px recovered production");
 });

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -409,13 +409,33 @@ test("mobile interrupted recovery CTA reaches the actionable recovery panel", as
   await page.route(`**/api/runs/${recoveredRunId}/stream?**`, async (route) => {
     await route.fulfill({ status: 200, contentType: "application/x-ndjson", body: "" });
   });
+  // The generate endpoint is stubbed and therefore cannot insert the recovered
+  // run into the disposable database. Keep the provider's quiet-page fallback
+  // aligned with the same authoritative queued fixture if this assertion takes
+  // longer than one poll interval.
+  await page.route(`**/api/projects/${PROJECTS.partialFailure}/progress`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        progress: {
+          runId: recoveredRunId,
+          stage: "queued",
+          pct: 0,
+          detail: "Preparing the writing room",
+          draftedCount: 2,
+          totalChapters: 3,
+        },
+      }),
+    });
+  });
   await page.goto(`/projects/${PROJECTS.partialFailure}/write`);
 
   const nextStep = page.getByRole("region", {
     name: "Next step: Resume from saved work",
   });
   const resumeLink = nextStep.getByRole("link", { name: "Resume from saved work" });
-  const recoveryPanel = page.locator("#authoring-recovery");
+  const recoveryPanel = page.locator("#authoring-recovery:visible");
 
   await expect(nextStep).toBeVisible({ timeout: 20_000 });
   await expect(resumeLink).toHaveAttribute(
@@ -423,6 +443,7 @@ test("mobile interrupted recovery CTA reaches the actionable recovery panel", as
     `/projects/${PROJECTS.partialFailure}/write#authoring-recovery`,
   );
   await expect(recoveryPanel).toHaveAttribute("tabindex", "-1");
+  await expect(recoveryPanel).toHaveCount(1);
   await expectNoPageOverflow(page, "390px interrupted recovery");
   await axeCheck(page);
 
@@ -445,8 +466,13 @@ test("mobile interrupted recovery CTA reaches the actionable recovery panel", as
 
   await recoveryPanel.getByRole("button", { name: "Resume from saved work" }).click();
 
-  await expect(page.getByRole("region", { name: "Next step: Watch production" })).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Next step: Watch the writing room" }),
+  ).toBeVisible();
   await expect(page.getByRole("link", { name: "Resume from saved work" })).toHaveCount(0);
   await expect(page.getByRole("region", { name: "Book generation run" })).toBeFocused();
   await expectNoPageOverflow(page, "390px recovered production");
+  await page.setViewportSize({ width: 320, height: 844 });
+  await expectNoPageOverflow(page, "320px recovered production");
+  await axeCheck(page);
 });

--- a/e2e/reader.spec.ts
+++ b/e2e/reader.spec.ts
@@ -264,10 +264,12 @@ test("reader prose reflows at 320px and 390px with no serious accessibility find
     await expect(page.getByRole("heading", { level: 1, name: SHARES.first.title })).toBeVisible();
     await expectNoPageOverflow(page, `reader at ${viewport.width}px`);
 
-    const recoveredParagraph = page.getByText(
-      "The stair ended in a circular chamber lined with brass shelves. Each shelf held a glass tile etched with a different street, bridge, or rooftop from Bellweather.",
-      { exact: true },
-    );
+    const recoveredParagraph = page
+      .getByRole("article")
+      .getByText(
+        "The stair ended in a circular chamber lined with brass shelves. Each shelf held a glass tile etched with a different street, bridge, or rooftop from Bellweather.",
+        { exact: true },
+      );
     await expect(recoveredParagraph).toBeVisible();
     const layout = await recoveredParagraph.evaluate((node) => {
       const style = getComputedStyle(node);

--- a/e2e/studio-responsive.spec.ts
+++ b/e2e/studio-responsive.spec.ts
@@ -78,6 +78,11 @@ for (const viewport of PRODUCT_VIEWPORTS) {
         ready: () => page.getByRole("heading", { level: 1, name: "Your books" }),
       },
       {
+        name: "account settings",
+        route: "/studio/settings",
+        ready: () => page.getByRole("heading", { name: "Book email notifications" }),
+      },
+      {
         name: "Admin",
         route: "/admin",
         ready: () => page.getByRole("heading", { level: 1, name: "Overview" }),

--- a/e2e/studio.spec.ts
+++ b/e2e/studio.spec.ts
@@ -80,6 +80,39 @@ test.describe("studio account", () => {
     await axeCheck(page);
     await fullPageScreenshot(page, testInfo, "account-settings");
   });
+
+  test("email preferences save, survive reload, and remain keyboard operable", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "dbDependent-light",
+      "One isolated mutation proves persistence; both themes retain read-only axe coverage.",
+    );
+    await page.goto("/studio/settings#email-notifications");
+    const card = page.locator("#email-notifications");
+    await expect(card.getByRole("heading", { name: "Book email notifications" })).toBeVisible();
+    const actionRequired = card.getByRole("switch", { name: "My book needs me" });
+    await expect(actionRequired).toBeChecked();
+    await actionRequired.focus();
+    await page.keyboard.press("Space");
+    await expect(actionRequired).not.toBeChecked();
+    await card.getByRole("button", { name: "Save email preferences" }).click();
+    await expect(card.getByRole("status")).toHaveText("Email preferences saved.");
+
+    await page.reload();
+    const reloadedCard = page.locator("#email-notifications");
+    const reloadedActionRequired = reloadedCard.getByRole("switch", {
+      name: "My book needs me",
+    });
+    await expect(reloadedActionRequired).not.toBeChecked();
+    await axeCheck(page);
+    await fullPageScreenshot(page, testInfo, "account-notification-preferences");
+
+    // Restore the shared fixture for any later acceptance job using this branch.
+    await reloadedActionRequired.click();
+    await reloadedCard.getByRole("button", { name: "Save email preferences" }).click();
+    await expect(reloadedCard.getByRole("status")).toHaveText("Email preferences saved.");
+  });
 });
 
 test.describe("project management", () => {

--- a/src/app/(studio)/studio/settings/page.tsx
+++ b/src/app/(studio)/studio/settings/page.tsx
@@ -7,10 +7,11 @@ import { getBalance } from "@/lib/billing/credits";
 import { requireUser } from "@/lib/auth";
 import Link from "next/link";
 
-import { AppearanceCard, DefaultsCard } from "./settings-cards";
+import { AppearanceCard, DefaultsCard, NotificationPreferencesCard } from "./settings-cards";
 import { CostDisplay, PageHeader } from "@/components/studio/product-primitives";
 import { getStudioAccess } from "@/lib/studio-access";
 import { FULL_BOOK_UNLOCK_HREF } from "@/lib/marketing/trial-offer";
+import { getNotificationSettings } from "@/lib/notification-preferences";
 
 export const metadata: Metadata = {
   title: "Settings",
@@ -66,17 +67,44 @@ function CreditsSkeleton() {
   );
 }
 
+async function NotificationPreferencesSection() {
+  const { userId } = await requireUser();
+  const settings = await getNotificationSettings(userId);
+  return (
+    <NotificationPreferencesCard email={settings.email} initialPreferences={settings.preferences} />
+  );
+}
+
+function NotificationPreferencesSkeleton() {
+  return (
+    <Card className="instrument-surface rounded-sm">
+      <CardHeader>
+        <Skeleton className="h-5 w-52" />
+        <Skeleton className="h-4 w-full max-w-xl" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function SettingsPage() {
   return (
     <div className="mx-auto max-w-4xl space-y-8">
       <PageHeader
         title="Settings"
-        description="Choose how the studio looks and what each new book assumes."
+        description="Choose how the studio looks, what each new book assumes, and when Sopher emails you."
       />
 
       <div className="space-y-6">
         <AppearanceCard />
         <DefaultsCard />
+        <Suspense fallback={<NotificationPreferencesSkeleton />}>
+          <NotificationPreferencesSection />
+        </Suspense>
         <Suspense fallback={<CreditsSkeleton />}>
           <CreditsSection />
         </Suspense>

--- a/src/app/(studio)/studio/settings/settings-cards.test.tsx
+++ b/src/app/(studio)/studio/settings/settings-cards.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationPreferencesCard } from "./settings-cards";
+
+const initialPreferences = {
+  version: 1 as const,
+  authoringActionRequired: true,
+  authoringReminders: true,
+  authoringCompleted: true,
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("NotificationPreferencesCard", () => {
+  it("exposes three described optional switches and keeps essential mail explicit", () => {
+    render(
+      <NotificationPreferencesCard
+        email="author@example.com"
+        initialPreferences={initialPreferences}
+      />,
+    );
+
+    for (const name of ["My book needs me", "Follow-up reminders", "My book is finished"]) {
+      expect(screen.getByRole("switch", { name })).toBeChecked();
+      expect(screen.getByRole("switch", { name })).toHaveAccessibleDescription();
+    }
+    expect(screen.getByText("author@example.com")).toBeVisible();
+    expect(
+      screen.getByText(/Purchase receipts and essential account or security messages/),
+    ).toBeVisible();
+    expect(
+      screen.getByText(/books started after notification controls became available/),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save email preferences" })).toBeDisabled();
+  });
+
+  it("sends only changed fields and announces the authoritative saved result", async () => {
+    const fetchMock = vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          preferences: {
+            ...initialPreferences,
+            authoringActionRequired: false,
+            authoringCompleted: false,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(
+      <NotificationPreferencesCard
+        email="author@example.com"
+        initialPreferences={initialPreferences}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "My book needs me" }));
+    fireEvent.click(screen.getByRole("switch", { name: "My book is finished" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save email preferences" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/notification-preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          authoringActionRequired: false,
+          authoringCompleted: false,
+        }),
+      }),
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent("Email preferences saved.");
+    expect(screen.getByRole("button", { name: "Save email preferences" })).toBeDisabled();
+  });
+
+  it("keeps the intended controls and reports an unconfirmed server response truthfully", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 503 }));
+    render(
+      <NotificationPreferencesCard
+        email="author@example.com"
+        initialPreferences={initialPreferences}
+      />,
+    );
+
+    const reminder = screen.getByRole("switch", { name: "Follow-up reminders" });
+    fireEvent.click(reminder);
+    expect(reminder).not.toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Save email preferences" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "couldn't confirm whether those preferences were saved",
+    );
+    expect(reminder).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "Save email preferences" })).toBeEnabled();
+  });
+
+  it("treats response loss as unconfirmed and lets the author retry", async () => {
+    const fetchMock = vi.mocked(fetch).mockRejectedValue(new TypeError("Network connection lost"));
+    render(
+      <NotificationPreferencesCard
+        email="author@example.com"
+        initialPreferences={initialPreferences}
+      />,
+    );
+
+    const completed = screen.getByRole("switch", { name: "My book is finished" });
+    fireEvent.click(completed);
+    fireEvent.click(screen.getByRole("button", { name: "Save email preferences" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("reload to check");
+    expect(completed).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "Save email preferences" })).toBeEnabled();
+
+    // The server may have committed `false` before the response was lost. If
+    // the author changes their mind, the original baseline is no longer safe:
+    // keep Save enabled and send every current value to make the result certain.
+    fireEvent.click(completed);
+    expect(completed).toBeChecked();
+    expect(screen.getByRole("button", { name: "Save email preferences" })).toBeEnabled();
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ preferences: initialPreferences }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save email preferences" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      authoringActionRequired: true,
+      authoringReminders: true,
+      authoringCompleted: true,
+    });
+    expect(await screen.findByRole("status")).toHaveTextContent("Email preferences saved.");
+    expect(screen.getByRole("button", { name: "Save email preferences" })).toBeDisabled();
+  });
+});

--- a/src/app/(studio)/studio/settings/settings-cards.tsx
+++ b/src/app/(studio)/studio/settings/settings-cards.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "next-themes";
 
 import { DEFAULT_TIER_KEY } from "@/components/wizard/wizard-state";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -14,7 +15,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 import type { QualityTier } from "@/ai/models";
+import type { NotificationPreferences } from "@/lib/notification-preferences-shared";
 
 const themeItems: Record<string, string> = {
   light: "Light",
@@ -188,6 +191,172 @@ export function DefaultsCard() {
             <Skeleton className="h-8 w-64" />
           )}
         </SettingRow>
+      </CardContent>
+    </Card>
+  );
+}
+
+type EditableNotificationPreference = Exclude<keyof NotificationPreferences, "version">;
+
+const notificationRows: Array<{
+  key: EditableNotificationPreference;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "authoringActionRequired",
+    label: "My book needs me",
+    description:
+      "Email me when a story direction or outline needs a decision, paid writing needs credits, or production needs recovery.",
+  },
+  {
+    key: "authoringReminders",
+    label: "Follow-up reminders",
+    description: "Send one reminder after an outline has waited 24 hours for my review.",
+  },
+  {
+    key: "authoringCompleted",
+    label: "My book is finished",
+    description: "Email me when the completed manuscript is ready to read, edit, or export.",
+  },
+];
+
+export function NotificationPreferencesCard({
+  email,
+  initialPreferences,
+}: {
+  email: string;
+  initialPreferences: NotificationPreferences;
+}) {
+  const [saved, setSaved] = React.useState(initialPreferences);
+  const [preferences, setPreferences] = React.useState(initialPreferences);
+  const [unconfirmed, setUnconfirmed] = React.useState(false);
+  const [status, setStatus] = React.useState<{
+    kind: "idle" | "saving" | "saved" | "error";
+    message: string;
+  }>({ kind: "idle", message: "" });
+
+  const dirty =
+    unconfirmed || notificationRows.some((row) => preferences[row.key] !== saved[row.key]);
+
+  async function savePreferences(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const update = Object.fromEntries(
+      notificationRows
+        .filter((row) => unconfirmed || preferences[row.key] !== saved[row.key])
+        .map((row) => [row.key, preferences[row.key]]),
+    );
+    if (Object.keys(update).length === 0) return;
+    setStatus({ kind: "saving", message: "Saving email preferences…" });
+    try {
+      const response = await fetch("/api/notification-preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      });
+      if (!response.ok) throw new Error("Preference update failed");
+      const payload = (await response.json()) as { preferences: NotificationPreferences };
+      setSaved(payload.preferences);
+      setPreferences(payload.preferences);
+      setUnconfirmed(false);
+      setStatus({ kind: "saved", message: "Email preferences saved." });
+    } catch {
+      setUnconfirmed(true);
+      setStatus({
+        kind: "error",
+        message:
+          "We couldn't confirm whether those preferences were saved. Try again, or reload to check your current account settings.",
+      });
+    }
+  }
+
+  return (
+    <Card id="email-notifications" className="instrument-surface scroll-mt-24 rounded-sm">
+      <CardHeader>
+        <CardTitle role="heading" aria-level={2}>
+          Book email notifications
+        </CardTitle>
+        <CardDescription>
+          Choose which authoring updates leave the Studio. Your in-app status and next steps are
+          always available.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={savePreferences} className="space-y-5">
+          <fieldset disabled={status.kind === "saving"} className="space-y-2">
+            <legend className="sr-only">Optional book email notifications</legend>
+            {notificationRows.map((row) => {
+              const inputId = `notification-${row.key}`;
+              const descriptionId = `${inputId}-description`;
+              return (
+                <div
+                  key={row.key}
+                  className="flex min-h-16 min-w-0 items-center justify-between gap-4 border-b py-3 last:border-b-0"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <Label htmlFor={inputId}>{row.label}</Label>
+                    <p
+                      id={descriptionId}
+                      className="max-w-2xl text-xs leading-relaxed text-muted-foreground"
+                    >
+                      {row.description}
+                    </p>
+                  </div>
+                  <span className="flex min-h-11 min-w-11 shrink-0 items-center justify-end">
+                    <Switch
+                      id={inputId}
+                      checked={preferences[row.key]}
+                      aria-describedby={descriptionId}
+                      onCheckedChange={(checked) => {
+                        setPreferences((current) => ({
+                          ...current,
+                          [row.key]: checked === true,
+                        }));
+                        setStatus({ kind: "idle", message: "" });
+                      }}
+                    />
+                  </span>
+                </div>
+              );
+            })}
+          </fieldset>
+
+          <div className="rounded-sm border bg-muted/25 p-4 text-xs leading-relaxed text-muted-foreground">
+            <p>
+              Notifications go to{" "}
+              <span className="break-all font-medium text-foreground">{email}</span>. Purchase
+              receipts and essential account or security messages are always sent.
+            </p>
+            <p className="mt-2">
+              These choices apply to books started after notification controls became available. A
+              book already in production, or a message already being delivered, may still send its
+              scheduled update.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="submit"
+              className="min-h-11"
+              disabled={!dirty || status.kind === "saving"}
+            >
+              {status.kind === "saving" ? "Saving…" : "Save email preferences"}
+            </Button>
+            {status.message ? (
+              <p
+                role={status.kind === "error" ? "alert" : "status"}
+                aria-live={status.kind === "error" ? "assertive" : "polite"}
+                className={
+                  status.kind === "error"
+                    ? "text-sm text-destructive"
+                    : "text-sm text-muted-foreground"
+                }
+              >
+                {status.message}
+              </p>
+            ) : null}
+          </div>
+        </form>
       </CardContent>
     </Card>
   );

--- a/src/app/api/notification-preferences/route.test.ts
+++ b/src/app/api/notification-preferences/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireUser: vi.fn(),
+  getNotificationSettings: vi.fn(),
+  updateNotificationPreferences: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ requireUser: mocks.requireUser }));
+vi.mock("@/lib/notification-preferences", () => ({
+  getNotificationSettings: mocks.getNotificationSettings,
+  updateNotificationPreferences: mocks.updateNotificationPreferences,
+}));
+
+import { GET, PATCH } from "./route";
+
+const preferences = {
+  version: 1 as const,
+  authoringActionRequired: true,
+  authoringReminders: true,
+  authoringCompleted: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireUser.mockResolvedValue({ userId: "user-1" });
+  mocks.getNotificationSettings.mockResolvedValue({
+    email: "author@example.com",
+    preferences,
+  });
+  mocks.updateNotificationPreferences.mockResolvedValue({
+    ...preferences,
+    authoringReminders: false,
+  });
+});
+
+describe("notification preference route", () => {
+  it("returns only the signed-in account's settings without cacheable email data", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(mocks.getNotificationSettings).toHaveBeenCalledWith("user-1");
+    await expect(response.json()).resolves.toEqual({
+      email: "author@example.com",
+      preferences,
+    });
+  });
+
+  it("updates only supplied preferences under the authenticated user id", async () => {
+    const response = await PATCH(
+      new Request("https://sopher.ai/api/notification-preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ authoringReminders: false }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateNotificationPreferences).toHaveBeenCalledWith("user-1", {
+      authoringReminders: false,
+    });
+    await expect(response.json()).resolves.toEqual({
+      preferences: { ...preferences, authoringReminders: false },
+    });
+  });
+
+  it.each([
+    ["an empty update", {}],
+    ["an unknown preference", { marketing: false }],
+    ["a caller-supplied user id", { userId: "user-2", authoringCompleted: false }],
+    ["a non-boolean value", { authoringCompleted: "no" }],
+  ])("rejects %s", async (_label, body) => {
+    const response = await PATCH(
+      new Request("https://sopher.ai/api/notification-preferences", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.updateNotificationPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import {
+  getNotificationSettings,
+  updateNotificationPreferences,
+} from "@/lib/notification-preferences";
+
+const updateSchema = z
+  .object({
+    authoringActionRequired: z.boolean().optional(),
+    authoringReminders: z.boolean().optional(),
+    authoringCompleted: z.boolean().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, "At least one preference is required");
+
+const privateJson = (body: unknown, init?: ResponseInit) =>
+  Response.json(body, {
+    ...init,
+    headers: { "Cache-Control": "private, no-store", ...init?.headers },
+  });
+
+export async function GET() {
+  const { userId } = await requireUser();
+  return privateJson(await getNotificationSettings(userId));
+}
+
+export async function PATCH(request: Request) {
+  const { userId } = await requireUser();
+  const parsed = updateSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return privateJson({ error: "Invalid notification preference update" }, { status: 400 });
+  }
+  return privateJson({
+    preferences: await updateNotificationPreferences(userId, parsed.data),
+  });
+}

--- a/src/app/api/projects/[projectId]/generate/route.test.ts
+++ b/src/app/api/projects/[projectId]/generate/route.test.ts
@@ -10,10 +10,16 @@ const mocks = vi.hoisted(() => ({
   assertNotSuspended: vi.fn(),
   reconcile: vi.fn(),
   getSafetyBlock: vi.fn(),
+  insertQueued: vi.fn(),
+  getOrCreateBook: vi.fn(),
+  authorizeProjectSpend: vi.fn(),
+  rateLimit: vi.fn(),
+  prepareDispatch: vi.fn(),
+  startWorkflow: vi.fn(),
 }));
 
 vi.mock("workflow/api", () => ({
-  start: vi.fn(),
+  start: mocks.startWorkflow,
   getRun: mocks.getWorkflowRun,
 }));
 
@@ -45,7 +51,7 @@ vi.mock("@/lib/generation-runs", () => {
     required = 0;
   }
   return {
-    insertQueuedAuthoringRun: vi.fn(),
+    insertQueuedAuthoringRun: mocks.insertQueued,
     linkAuthoringRunWorkflow: vi.fn(),
     markAuthoringRunAcceptanceUncertain: vi.fn(),
     reconcileBeforeAuthoringRunConflict: mocks.reconcile,
@@ -65,6 +71,19 @@ vi.mock("@/workflows/generate-book", () => ({
 }));
 vi.mock("@/lib/authoring-start-safety", () => ({
   getAuthoringStartSafetyBlock: mocks.getSafetyBlock,
+}));
+vi.mock("@/db/queries/projects", () => ({
+  getOrCreateBook: mocks.getOrCreateBook,
+}));
+vi.mock("@/lib/project-spend-http", () => ({
+  authorizeProjectSpend: mocks.authorizeProjectSpend,
+}));
+vi.mock("@/lib/security/rate-limit", () => ({
+  LIMITS: { bookStart: {} },
+  rateLimit: mocks.rateLimit,
+}));
+vi.mock("@/lib/authoring-dispatch", () => ({
+  prepareFullBookRunDispatch: mocks.prepareDispatch,
 }));
 
 import { DELETE, POST } from "./route";
@@ -93,6 +112,9 @@ beforeEach(() => {
   mocks.assertNotSuspended.mockResolvedValue(undefined);
   mocks.reconcile.mockResolvedValue(undefined);
   mocks.getSafetyBlock.mockResolvedValue(null);
+  mocks.authorizeProjectSpend.mockResolvedValue(null);
+  mocks.rateLimit.mockResolvedValue({ limited: false });
+  mocks.getOrCreateBook.mockResolvedValue({ id: "55555555-5555-4555-8555-555555555555" });
 });
 
 describe("DELETE project generation", () => {
@@ -171,7 +193,7 @@ describe("DELETE project generation", () => {
 });
 
 describe("POST project generation safety gate", () => {
-  it("returns exact idempotent replays before evaluating replacement-run safety", async () => {
+  it("retires a terminal request-key replay before evaluating replacement-run safety", async () => {
     const select = vi
       .fn()
       .mockReturnValueOnce({
@@ -206,10 +228,178 @@ describe("POST project generation safety gate", () => {
       { params: Promise.resolve({ projectId: PROJECT_ID }) },
     );
 
-    expect(response.status).toBe(202);
-    await expect(response.json()).resolves.toMatchObject({ runId: RUN_ID, reattached: true });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      runId: RUN_ID,
+      kind: "full_book",
+      status: "failed",
+      code: "terminal_request_replay",
+      retryable: true,
+    });
     expect(mocks.reconcile).not.toHaveBeenCalled();
     expect(mocks.getSafetyBlock).not.toHaveBeenCalled();
+  });
+
+  it("reattaches an active request-key replay without creating another run", async () => {
+    const select = vi
+      .fn()
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PROJECT_ID }]) }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([
+              {
+                id: RUN_ID,
+                kind: "full_book",
+                status: "running",
+                config: { protocolVersion: 3 },
+              },
+            ]),
+          }),
+        }),
+      });
+    mocks.getDb.mockReturnValue({ select });
+
+    const response = await POST(
+      new Request("https://sopher.ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestKey: "33333333-3333-4333-8333-333333333333" }),
+      }),
+      { params: Promise.resolve({ projectId: PROJECT_ID }) },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      runId: RUN_ID,
+      kind: "full_book",
+      status: "running",
+      reattached: true,
+    });
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+    expect(mocks.getSafetyBlock).not.toHaveBeenCalled();
+  });
+
+  it("does not mark a completed request-key replay safe to retry", async () => {
+    const select = vi
+      .fn()
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: PROJECT_ID }]) }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi
+              .fn()
+              .mockResolvedValue([
+                { id: RUN_ID, kind: "full_book", status: "completed", config: {} },
+              ]),
+          }),
+        }),
+      });
+    mocks.getDb.mockReturnValue({ select });
+
+    const response = await POST(
+      new Request("https://sopher.ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestKey: "33333333-3333-4333-8333-333333333333" }),
+      }),
+      { params: Promise.resolve({ projectId: PROJECT_ID }) },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "terminal_request_replay",
+      status: "completed",
+      retryable: false,
+    });
+    expect(mocks.reconcile).not.toHaveBeenCalled();
+  });
+
+  it("returns a terminal replay when the request-key insert race loses to a failed row", async () => {
+    const project = {
+      id: PROJECT_ID,
+      userId: "author-1",
+      title: "The Clockmaker's Map",
+      brief: "A clockmaker follows a map beneath the city.",
+      genre: "mystery",
+      styleGuide: null,
+      experience: "trial_short_story",
+      targetChapters: 3,
+      targetWordsPerChapter: 1000,
+      settings: {},
+      updatedAt: new Date("2026-08-03T10:00:00.000Z"),
+    };
+    const select = vi
+      .fn()
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([project]) }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValue([]) }),
+        }),
+      });
+    mocks.getDb.mockReturnValue({ select });
+    mocks.insertQueued.mockResolvedValue({
+      id: RUN_ID,
+      inserted: false,
+      kind: "full_book",
+      status: "failed",
+      config: { protocolVersion: 3 },
+      workflowRunId: null,
+    });
+
+    const response = await POST(
+      new Request("https://sopher.ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestKey: "33333333-3333-4333-8333-333333333333" }),
+      }),
+      { params: Promise.resolve({ projectId: PROJECT_ID }) },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "terminal_request_replay",
+      status: "failed",
+      retryable: true,
+    });
+    expect(mocks.prepareDispatch).not.toHaveBeenCalled();
+    expect(mocks.startWorkflow).not.toHaveBeenCalled();
   });
 
   it("blocks a new run when fresh authoritative evidence requires support", async () => {

--- a/src/app/api/projects/[projectId]/generate/route.ts
+++ b/src/app/api/projects/[projectId]/generate/route.ts
@@ -41,6 +41,25 @@ const cancellationBodySchema = z.object({
   runId: z.uuid(),
 });
 
+const ACTIVE_AUTHORING_STATUSES = new Set(["queued", "running", "awaiting_input"]);
+
+function terminalRequestReplayResponse(run: { id: string; kind: string; status: string }) {
+  const retryable = run.status === "failed" || run.status === "cancelled";
+  return Response.json(
+    {
+      error: retryable
+        ? "This saved start request belongs to a run that is no longer active. Retrying with a new request is safe."
+        : "This saved start request already completed. The latest project state is being refreshed.",
+      code: "terminal_request_replay",
+      runId: run.id,
+      kind: run.kind,
+      status: run.status,
+      retryable,
+    },
+    { status: 409 },
+  );
+}
+
 function buildBaseGenerationConfig(input: {
   project: typeof schema.projects.$inferSelect;
   tier: GenerationConfig["tier"];
@@ -157,6 +176,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
         },
         { status: 409 },
       );
+    }
+    if (!ACTIVE_AUTHORING_STATUSES.has(requestedRun.status)) {
+      return terminalRequestReplayResponse(requestedRun);
     }
     return Response.json(
       {
@@ -318,6 +340,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
       ...(minimumBalanceCredits !== undefined ? { minimumBalanceCredits } : {}),
     });
     if (!run.inserted) {
+      if (!ACTIVE_AUTHORING_STATUSES.has(run.status)) {
+        return terminalRequestReplayResponse(run);
+      }
       return Response.json(
         {
           runId: run.id,
@@ -405,7 +430,17 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
 
     if (isE2EWorkflowStubEnabled()) {
       await settleStubbedAuthoringRunHandoff({ runId: run.id, projectId, userId });
-      return Response.json({ runId: run.id, requestKey, config, stubbed: true }, { status: 202 });
+      return Response.json(
+        {
+          runId: run.id,
+          kind: "full_book",
+          status: run.status,
+          requestKey,
+          config,
+          stubbed: true,
+        },
+        { status: 202 },
+      );
     }
   } catch (error) {
     // No Workflow invocation has happened yet, so this failure is proven
@@ -451,6 +486,8 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
     return Response.json(
       {
         runId: run.id,
+        kind: "full_book",
+        status: run.status,
         requestKey,
         config,
         confirmationPending: uncertain,
@@ -459,7 +496,10 @@ export async function POST(req: Request, ctx: { params: Promise<{ projectId: str
     );
   }
 
-  return Response.json({ runId: run.id, requestKey, config }, { status: 202 });
+  return Response.json(
+    { runId: run.id, kind: "full_book", status: run.status, requestKey, config },
+    { status: 202 },
+  );
 }
 
 export async function DELETE(req: Request, ctx: { params: Promise<{ projectId: string }> }) {

--- a/src/components/generation/run-viewer.test.ts
+++ b/src/components/generation/run-viewer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isAuthoritativeFullBookCompletion,
   isAuthoritativeRunTerminal,
+  isRecoveryActionAuthorized,
   projectProgressForRun,
   recoveryCardPrimaryAction,
 } from "./run-viewer";
@@ -183,12 +184,38 @@ describe("recoveryCardPrimaryAction", () => {
         canRecover: true,
         nextAction: {
           kind: "recover_saved_work",
-          href: `/projects/${projectId}/write`,
+          href: `/projects/${projectId}/write#authoring-recovery`,
           label: "Resume from saved work",
           description: "One checkpoint is compatible.",
           requiresMeteredAccess: true,
         },
       }),
     ).toEqual({ kind: "recover", label: "Resume from saved work" });
+  });
+});
+
+describe("isRecoveryActionAuthorized", () => {
+  const projectId = "11111111-1111-4111-8111-111111111111";
+  const recoveryAction = {
+    kind: "recover_saved_work" as const,
+    href: `/projects/${projectId}/write#authoring-recovery`,
+    label: "Resume from saved work",
+    description: "Review the recovery details before restarting.",
+    requiresMeteredAccess: true,
+  };
+
+  it("authorizes the full-book callback at the recovery fragment", () => {
+    expect(isRecoveryActionAuthorized(recoveryAction, projectId, "full_book")).toBe(true);
+  });
+
+  it("rejects a dangling page link and scoped runs", () => {
+    expect(
+      isRecoveryActionAuthorized(
+        { ...recoveryAction, href: `/projects/${projectId}/write` },
+        projectId,
+        "full_book",
+      ),
+    ).toBe(false);
+    expect(isRecoveryActionAuthorized(recoveryAction, projectId, "edit_pass")).toBe(false);
   });
 });

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -264,10 +264,7 @@ export function RunViewer({
     snapshot,
   );
   const { nextAction } = useAuthoringJourneyCommand();
-  const recoveryAuthorized =
-    runKind === "full_book" &&
-    nextAction?.kind === "recover_saved_work" &&
-    nextAction.href === `/projects/${projectId}/write`;
+  const recoveryAuthorized = isRecoveryActionAuthorized(nextAction, projectId, runKind);
   const terminal =
     state.stage === "done" || state.stage === "failed" || state.stage === "cancelled";
   const runSurfaceRef = React.useRef<HTMLDivElement | null>(null);
@@ -745,6 +742,18 @@ export function recoveryCardPrimaryAction(input: {
   };
 }
 
+export function isRecoveryActionAuthorized(
+  nextAction: AuthoringNextAction | null,
+  projectId: string,
+  runKind: "full_book" | "chapter" | "edit_pass" | "continuity" | "export",
+): boolean {
+  return (
+    runKind === "full_book" &&
+    nextAction?.kind === "recover_saved_work" &&
+    nextAction.href === `/projects/${projectId}/write#authoring-recovery`
+  );
+}
+
 function RecoveryCard({
   runId,
   projectId,
@@ -767,6 +776,22 @@ function RecoveryCard({
   error: string | null;
 }) {
   const [copied, setCopied] = React.useState(false);
+  const recoveryTargetRef = React.useRef<HTMLElement | null>(null);
+  React.useEffect(() => {
+    let frame: number | undefined;
+    const focusRecoveryTarget = () => {
+      if (window.location.hash !== "#authoring-recovery") return;
+      frame = window.requestAnimationFrame(() => {
+        recoveryTargetRef.current?.focus({ preventScroll: true });
+      });
+    };
+    focusRecoveryTarget();
+    window.addEventListener("hashchange", focusRecoveryTarget);
+    return () => {
+      window.removeEventListener("hashchange", focusRecoveryTarget);
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+    };
+  }, []);
   const saved = Math.max(savedChapterCount, state.health.savedChapterCount ?? 0);
   const checkpoints = Math.max(0, state.health.savedCheckpointCount ?? 0);
   const noWorkStarted = state.health.noWorkStarted && state.totalCredits <= 0 && saved === 0;
@@ -793,8 +818,11 @@ function RecoveryCard({
 
   return (
     <section
+      ref={recoveryTargetRef}
+      id="authoring-recovery"
+      tabIndex={-1}
       aria-labelledby="authoring-recovery-title"
-      className="instrument-surface-raised rounded-sm border-l-destructive px-5 py-6 sm:px-7"
+      className="instrument-surface-raised scroll-mt-28 rounded-sm border-l-destructive px-5 py-6 outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring sm:px-7"
     >
       <p className="folio-label text-destructive">
         {cancelled ? "Production stopped" : "Production needs attention"}

--- a/src/components/generation/stage-timeline.test.tsx
+++ b/src/components/generation/stage-timeline.test.tsx
@@ -23,6 +23,10 @@ describe("StageTimeline", () => {
     const active = screen.getByText("Chapters").closest('[aria-current="step"]');
     expect(active).toHaveAttribute("data-state", "active");
     expect(active?.querySelector(".forced-colors\\:underline")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Generation stage timeline" })).toHaveClass(
+      "contain-paint",
+      "overflow-x-auto",
+    );
     expect(screen.getByRole("progressbar", { name: "Production progress" })).toHaveAttribute(
       "aria-valuenow",
       "42",

--- a/src/components/generation/stage-timeline.tsx
+++ b/src/components/generation/stage-timeline.tsx
@@ -157,7 +157,7 @@ export function StageTimeline({
         tabIndex={0}
         role="region"
         aria-label="Generation stage timeline"
-        className="instrument-surface overflow-x-auto rounded-sm px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        className="instrument-surface contain-paint overflow-x-auto rounded-sm px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       >
         <ol className="flex min-w-max items-center gap-3">
           {steps.map((step, index) => {

--- a/src/components/generation/write-experience.test.ts
+++ b/src/components/generation/write-experience.test.ts
@@ -35,6 +35,7 @@ import {
   isCompletedRequestReplay,
   isSupportRequiredResponse,
   isTerminalRequestReplay,
+  journeyAllowsGenerationStart,
   shouldRefreshAuthoritativeJourney,
   WriteExperience,
 } from "./write-experience";
@@ -198,6 +199,19 @@ describe("canAttachToWholeBookRun", () => {
 });
 
 describe("terminal generation request replay", () => {
+  it("allows a retried POST only when the refreshed journey explicitly permits it", () => {
+    expect(
+      journeyAllowsGenerationStart({ journey: { nextAction: { kind: "recover_saved_work" } } }),
+    ).toBe(true);
+    expect(
+      journeyAllowsGenerationStart({ journey: { nextAction: { kind: "start_production" } } }),
+    ).toBe(true);
+    expect(
+      journeyAllowsGenerationStart({ journey: { nextAction: { kind: "read_or_export" } } }),
+    ).toBe(false);
+    expect(journeyAllowsGenerationStart(null)).toBe(false);
+  });
+
   it("recognizes only an explicitly retryable terminal replay", () => {
     expect(isTerminalRequestReplay(409, { code: "terminal_request_replay", retryable: true })).toBe(
       true,
@@ -210,25 +224,47 @@ describe("terminal generation request replay", () => {
     );
   });
 
-  it("refreshes durable state instead of restarting an already-completed run", async () => {
+  it("refreshes a completed replay, then honors a separately confirmed paid restart", async () => {
     window.localStorage.setItem(generationRequestStorageKey(PROJECT_ID), STALE_REQUEST_KEY);
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          error: "This saved start request already completed.",
-          code: "terminal_request_replay",
-          retryable: false,
-          runId: "44444444-4444-4444-8444-444444444444",
-          kind: "full_book",
-          status: "completed",
-        }),
-        { status: 409, headers: { "Content-Type": "application/json" } },
-      ),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: "This saved start request already completed.",
+            code: "terminal_request_replay",
+            retryable: false,
+            runId: "44444444-4444-4444-8444-444444444444",
+            kind: "full_book",
+            status: "completed",
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            runId: ACTIVE_RUN_ID,
+            kind: "full_book",
+            status: "queued",
+            config: { tier: "standard", targetChapters: 10, targetWordsPerChapter: 2500 },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      );
     vi.stubGlobal("fetch", fetchMock);
 
-    const rendered = renderPreflight();
-    fireEvent.click(screen.getByRole("button", { name: "Start my included story" }));
+    const fullBookProps = {
+      ...writeExperienceProps(),
+      experience: "full_book" as const,
+      fullBookUnlocked: true,
+      targetChapters: 10,
+      targetWordsPerChapter: 2500,
+      balanceCredits: 100,
+      requiredCredits: 20,
+    };
+    const rendered = render(React.createElement(WriteExperience, fullBookProps));
+    fireEvent.click(screen.getByRole("button", { name: "Start writing this book" }));
 
     await waitFor(() => expect(clientMocks.refresh).toHaveBeenCalledOnce());
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -236,9 +272,9 @@ describe("terminal generation request replay", () => {
     expect(clientMocks.publishProgress).not.toHaveBeenCalled();
 
     rendered.rerender(
-      React.createElement(
-        WriteExperience,
-        writeExperienceProps({
+      React.createElement(WriteExperience, {
+        ...fullBookProps,
+        initialSnapshot: {
           run: {
             id: "44444444-4444-4444-8444-444444444444",
             status: "completed",
@@ -248,26 +284,51 @@ describe("terminal generation request replay", () => {
           events: [],
           chapters: [],
           totalUsd: 0,
-        }),
-      ),
+        },
+      }),
     );
     expect(await screen.findByText("Run 44444444-4444-4444-8444-444444444444")).toBeVisible();
-    expect(screen.queryByRole("button", { name: "Start my included story" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Start writing this book" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Explicit restart" }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(`Run ${ACTIVE_RUN_ID}`)).toBeVisible();
+    expect(fetchMock.mock.calls.map((call) => call[1]?.method)).toEqual(["POST", "POST"]);
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      requestKey: string;
+    };
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
+      requestKey: string;
+    };
+    expect(firstBody.requestKey).toBe(STALE_REQUEST_KEY);
+    expect(secondBody.requestKey).not.toBe(STALE_REQUEST_KEY);
+    expect(clientMocks.refresh).toHaveBeenCalledOnce();
   });
 
   it("refreshes a support-required safety decision and blocks repeated generation posts", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          error: "This project needs a safety recheck.",
-          code: "support_required",
-          action: { kind: "contact_support" },
-        }),
-        { status: 409, headers: { "Content-Type": "application/json" } },
-      ),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: "This project needs a safety recheck.",
+            code: "support_required",
+            action: { kind: "contact_support" },
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            journey: {
+              nextAction: {
+                kind: "contact_support",
+                description: "Support is still verifying the prior provider attempt.",
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
     vi.stubGlobal("fetch", fetchMock);
 
     renderPreflight();
@@ -276,9 +337,54 @@ describe("terminal generation request replay", () => {
     await waitFor(() => expect(clientMocks.refresh).toHaveBeenCalledOnce());
     fireEvent.click(start);
 
-    expect(fetchMock).toHaveBeenCalledOnce();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls.map((call) => call[1]?.method)).toEqual(["POST", "GET"]);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Support is still verifying the prior provider attempt.",
+    );
     expect(isSupportRequiredResponse(409, { code: "support_required" })).toBe(true);
     expect(window.localStorage.getItem(generationRequestStorageKey(PROJECT_ID))).toBeNull();
+  });
+
+  it("rechecks a null-snapshot safety latch and starts only after recovery is allowed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: "This project needs a safety recheck.",
+            code: "support_required",
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ journey: { nextAction: { kind: "recover_saved_work" } } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            runId: ACTIVE_RUN_ID,
+            kind: "full_book",
+            status: "queued",
+            config: { tier: "standard", targetChapters: 3, targetWordsPerChapter: 1000 },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPreflight();
+    const start = screen.getByRole("button", { name: "Start my included story" });
+    fireEvent.click(start);
+    await waitFor(() => expect(clientMocks.refresh).toHaveBeenCalledOnce());
+    fireEvent.click(start);
+
+    expect(await screen.findByText(`Run ${ACTIVE_RUN_ID}`)).toBeVisible();
+    expect(fetchMock.mock.calls.map((call) => call[1]?.method)).toEqual(["POST", "GET", "POST"]);
   });
 
   it("distinguishes a completed replay from a retryable failed replay", () => {
@@ -343,18 +449,65 @@ describe("terminal generation request replay", () => {
     expect(secondBody.requestKey).not.toBe(STALE_REQUEST_KEY);
     expect(secondBody.requestKey).toMatch(/^[0-9a-f-]{36}$/i);
     expect(window.localStorage.getItem(generationRequestStorageKey(PROJECT_ID))).toBeNull();
-    expect(clientMocks.publishProgress).toHaveBeenCalledWith(
-      {
-        runId: ACTIVE_RUN_ID,
-        stage: "queued",
-        pct: 0,
-        detail: "Preparing the writing room",
-        draftedCount: 0,
-        totalChapters: 3,
-      },
-      { refreshAuthoritativeJourney: true },
-    );
+    expect(clientMocks.publishProgress).toHaveBeenCalledWith({
+      runId: ACTIVE_RUN_ID,
+      stage: "queued",
+      pct: 0,
+      detail: "Preparing the writing room",
+      draftedCount: 0,
+      totalChapters: 3,
+    });
   });
+
+  it.each([
+    { status: "running" as const, responseStatus: 409, reattached: false },
+    { status: "awaiting_input" as const, responseStatus: 202, reattached: true },
+    { status: "queued" as const, responseStatus: 409, reattached: false },
+  ])(
+    "waits for authoritative server state when reattaching to a $status run",
+    async ({ status, responseStatus, reattached }) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            runId: ACTIVE_RUN_ID,
+            kind: "full_book",
+            status,
+            ...(reattached ? { reattached: true } : {}),
+            config: { tier: "standard", targetChapters: 3, targetWordsPerChapter: 1000 },
+          }),
+          { status: responseStatus, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const rendered = renderPreflight();
+      fireEvent.click(screen.getByRole("button", { name: "Start my included story" }));
+
+      await waitFor(() => expect(clientMocks.refresh).toHaveBeenCalledOnce());
+      expect(screen.queryByText(`Run ${ACTIVE_RUN_ID}`)).not.toBeInTheDocument();
+      expect(clientMocks.publishProgress).not.toHaveBeenCalled();
+
+      rendered.rerender(
+        React.createElement(
+          WriteExperience,
+          writeExperienceProps({
+            run: { id: ACTIVE_RUN_ID, status, error: null, kind: "full_book" },
+            events: [],
+            chapters: [],
+            totalUsd: 0,
+            health: {
+              databaseStatus: status,
+              effectiveStatus: status,
+              stage: status === "awaiting_input" ? "awaiting_guidance" : "concept",
+              progressPct: status === "queued" ? 0 : 7,
+              health: "healthy",
+            },
+          }),
+        ),
+      );
+      expect(await screen.findByText(`Run ${ACTIVE_RUN_ID}`)).toBeVisible();
+    },
+  );
 
   it("does not loop when the fresh request also resolves to a terminal run", async () => {
     window.localStorage.setItem(generationRequestStorageKey(PROJECT_ID), STALE_REQUEST_KEY);

--- a/src/components/generation/write-experience.test.ts
+++ b/src/components/generation/write-experience.test.ts
@@ -1,12 +1,101 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientMocks = vi.hoisted(() => ({
+  publishProgress: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: clientMocks.refresh }),
+}));
+
+vi.mock("@/components/studio/project-progress", () => ({
+  useProjectProgress: () => ({ publishProgress: clientMocks.publishProgress }),
+}));
+
+vi.mock("@/components/generation/run-viewer", () => ({
+  RunViewer: ({ runId, onRestart }: { runId: string; onRestart: () => void }) =>
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement("p", null, `Run ${runId}`),
+      React.createElement("button", { type: "button", onClick: onRestart }, "Explicit restart"),
+    ),
+}));
 
 import { wizardDraftKey, wizardRequestKey } from "@/components/wizard/wizard-state";
+import type { RunSnapshot } from "@/hooks/use-run-stream";
 import {
   canAttachToWholeBookRun,
   clearRecoveredWizardStorage,
   generationRequestStorageKey,
+  isCompletedRequestReplay,
+  isSupportRequiredResponse,
+  isTerminalRequestReplay,
   shouldRefreshAuthoritativeJourney,
+  WriteExperience,
 } from "./write-experience";
+
+const PROJECT_ID = "11111111-1111-4111-8111-111111111111";
+const STALE_REQUEST_KEY = "22222222-2222-4222-8222-222222222222";
+const ACTIVE_RUN_ID = "33333333-3333-4333-8333-333333333333";
+const localValues = new Map<string, string>();
+const localStorageMock: Storage = {
+  get length() {
+    return localValues.size;
+  },
+  clear: () => localValues.clear(),
+  getItem: (key) => localValues.get(key) ?? null,
+  key: (index) => [...localValues.keys()][index] ?? null,
+  removeItem: (key) => {
+    localValues.delete(key);
+  },
+  setItem: (key, value) => {
+    localValues.set(key, String(value));
+  },
+};
+
+function writeExperienceProps(initialSnapshot: RunSnapshot | null = null) {
+  return {
+    projectId: PROJECT_ID,
+    projectTitle: "The Clockmaker's Map",
+    userId: "user_123",
+    recoveryRequestKey: null,
+    experience: "trial_short_story" as const,
+    fullBookUnlocked: false,
+    tier: "standard" as const,
+    requireOutlineApproval: true,
+    targetChapters: 3,
+    targetWordsPerChapter: 1000,
+    estimateUsd: 0.6,
+    balanceCredits: 10,
+    requiredCredits: 0,
+    initialSnapshot,
+    titles: {},
+  };
+}
+
+function renderPreflight() {
+  return render(React.createElement(WriteExperience, writeExperienceProps()));
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: localStorageMock,
+  });
+  window.localStorage.clear();
+  clientMocks.publishProgress.mockClear();
+  clientMocks.refresh.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("shouldRefreshAuthoritativeJourney", () => {
   const progress = {
@@ -26,13 +115,20 @@ describe("shouldRefreshAuthoritativeJourney", () => {
 
 describe("canAttachToWholeBookRun", () => {
   it("accepts a newly queued full-book run", () => {
-    expect(canAttachToWholeBookRun(202, "run-1", undefined)).toBe(true);
+    expect(canAttachToWholeBookRun(202, "run-1", "full_book", "queued")).toBe(true);
   });
 
   it("reattaches only to an existing full-book run", () => {
-    expect(canAttachToWholeBookRun(409, "run-1", "full_book")).toBe(true);
-    expect(canAttachToWholeBookRun(409, "run-2", "chapter")).toBe(false);
-    expect(canAttachToWholeBookRun(409, "run-3", "edit_pass")).toBe(false);
+    expect(canAttachToWholeBookRun(409, "run-1", "full_book", "running")).toBe(true);
+    expect(canAttachToWholeBookRun(409, "run-2", "chapter", "running")).toBe(false);
+    expect(canAttachToWholeBookRun(409, "run-3", "edit_pass", "queued")).toBe(false);
+  });
+
+  it("never attaches a terminal run even when the response has an attachable status code", () => {
+    expect(canAttachToWholeBookRun(202, "run-1", "full_book", "failed")).toBe(false);
+    expect(canAttachToWholeBookRun(202, "run-2", "full_book", "cancelled")).toBe(false);
+    expect(canAttachToWholeBookRun(202, "run-3", "full_book", "completed")).toBe(false);
+    expect(canAttachToWholeBookRun(409, "run-4", "full_book", "failed")).toBe(false);
   });
 
   it("never attaches without a run id", () => {
@@ -98,5 +194,193 @@ describe("canAttachToWholeBookRun", () => {
     expect(clearRecoveredWizardStorage(storage, userId, "full_book", recoveryKey)).toBe(false);
     expect(values.get(wizardRequestKey(userId, "trial_short_story"))).toBe(recoveryKey);
     expect(values.get(wizardDraftKey(userId, "trial_short_story"))).toBe("saved included setup");
+  });
+});
+
+describe("terminal generation request replay", () => {
+  it("recognizes only an explicitly retryable terminal replay", () => {
+    expect(isTerminalRequestReplay(409, { code: "terminal_request_replay", retryable: true })).toBe(
+      true,
+    );
+    expect(
+      isTerminalRequestReplay(409, { code: "terminal_request_replay", retryable: false }),
+    ).toBe(false);
+    expect(isTerminalRequestReplay(202, { code: "terminal_request_replay", retryable: true })).toBe(
+      false,
+    );
+  });
+
+  it("refreshes durable state instead of restarting an already-completed run", async () => {
+    window.localStorage.setItem(generationRequestStorageKey(PROJECT_ID), STALE_REQUEST_KEY);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "This saved start request already completed.",
+          code: "terminal_request_replay",
+          retryable: false,
+          runId: "44444444-4444-4444-8444-444444444444",
+          kind: "full_book",
+          status: "completed",
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const rendered = renderPreflight();
+    fireEvent.click(screen.getByRole("button", { name: "Start my included story" }));
+
+    await waitFor(() => expect(clientMocks.refresh).toHaveBeenCalledOnce());
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(window.localStorage.getItem(generationRequestStorageKey(PROJECT_ID))).toBeNull();
+    expect(clientMocks.publishProgress).not.toHaveBeenCalled();
+
+    rendered.rerender(
+      React.createElement(
+        WriteExperience,
+        writeExperienceProps({
+          run: {
+            id: "44444444-4444-4444-8444-444444444444",
+            status: "completed",
+            error: null,
+            kind: "full_book",
+          },
+          events: [],
+          chapters: [],
+          totalUsd: 0,
+        }),
+      ),
+    );
+    expect(await screen.findByText("Run 44444444-4444-4444-8444-444444444444")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Start my included story" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Explicit restart" }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("refreshes a support-required safety decision and blocks repeated generation posts", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "This project needs a safety recheck.",
+          code: "support_required",
+          action: { kind: "contact_support" },
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPreflight();
+    const start = screen.getByRole("button", { name: "Start my included story" });
+    fireEvent.click(start);
+    await waitFor(() => expect(clientMocks.refresh).toHaveBeenCalledOnce());
+    fireEvent.click(start);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(isSupportRequiredResponse(409, { code: "support_required" })).toBe(true);
+    expect(window.localStorage.getItem(generationRequestStorageKey(PROJECT_ID))).toBeNull();
+  });
+
+  it("distinguishes a completed replay from a retryable failed replay", () => {
+    expect(
+      isCompletedRequestReplay(409, {
+        code: "terminal_request_replay",
+        retryable: false,
+        status: "completed",
+      }),
+    ).toBe(true);
+    expect(
+      isCompletedRequestReplay(409, {
+        code: "terminal_request_replay",
+        retryable: true,
+        status: "failed",
+      }),
+    ).toBe(false);
+  });
+
+  it("retires a stale key, retries once, and publishes the replacement run immediately", async () => {
+    window.localStorage.setItem(generationRequestStorageKey(PROJECT_ID), STALE_REQUEST_KEY);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: "The old run is terminal.",
+            code: "terminal_request_replay",
+            retryable: true,
+            runId: "44444444-4444-4444-8444-444444444444",
+            kind: "full_book",
+            status: "failed",
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            runId: ACTIVE_RUN_ID,
+            kind: "full_book",
+            status: "queued",
+            config: { tier: "standard", targetChapters: 3, targetWordsPerChapter: 1000 },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPreflight();
+    fireEvent.click(screen.getByRole("button", { name: "Start my included story" }));
+
+    expect(await screen.findByText(`Run ${ACTIVE_RUN_ID}`)).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      requestKey: string;
+    };
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
+      requestKey: string;
+    };
+    expect(firstBody.requestKey).toBe(STALE_REQUEST_KEY);
+    expect(secondBody.requestKey).not.toBe(STALE_REQUEST_KEY);
+    expect(secondBody.requestKey).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(window.localStorage.getItem(generationRequestStorageKey(PROJECT_ID))).toBeNull();
+    expect(clientMocks.publishProgress).toHaveBeenCalledWith(
+      {
+        runId: ACTIVE_RUN_ID,
+        stage: "queued",
+        pct: 0,
+        detail: "Preparing the writing room",
+        draftedCount: 0,
+        totalChapters: 3,
+      },
+      { refreshAuthoritativeJourney: true },
+    );
+  });
+
+  it("does not loop when the fresh request also resolves to a terminal run", async () => {
+    window.localStorage.setItem(generationRequestStorageKey(PROJECT_ID), STALE_REQUEST_KEY);
+    const terminal = () =>
+      new Response(
+        JSON.stringify({
+          error: "The saved request is no longer active.",
+          code: "terminal_request_replay",
+          retryable: true,
+          runId: "44444444-4444-4444-8444-444444444444",
+          kind: "full_book",
+          status: "failed",
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      );
+    const fetchMock = vi.fn().mockImplementation(async () => terminal());
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPreflight();
+    fireEvent.click(screen.getByRole("button", { name: "Start my included story" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "The saved request is no longer active.",
+    );
+    expect(window.localStorage.getItem(generationRequestStorageKey(PROJECT_ID))).toBeNull();
+    expect(clientMocks.publishProgress).not.toHaveBeenCalled();
   });
 });

--- a/src/components/generation/write-experience.tsx
+++ b/src/components/generation/write-experience.tsx
@@ -26,6 +26,7 @@ function words(value: number): string {
 const GENERATION_REQUEST_KEY = "sopher.generation-request.v1";
 const ACTIVE_RUN_STATUSES = new Set(["queued", "running", "awaiting_input"] as const);
 type ActiveRunStatus = "queued" | "running" | "awaiting_input";
+type StartSafetyLatch = "support_required" | "completed_replay";
 
 export function generationRequestStorageKey(projectId: string): string {
   return `${GENERATION_REQUEST_KEY}:${projectId}`;
@@ -80,6 +81,26 @@ export function isSupportRequiredResponse(
   response: { code?: string } | null,
 ): boolean {
   return status === 409 && response?.code === "support_required";
+}
+
+export function journeyAllowsGenerationStart(response: unknown): boolean {
+  if (!response || typeof response !== "object") return false;
+  const journey = (response as { journey?: unknown }).journey;
+  if (!journey || typeof journey !== "object") return false;
+  const nextAction = (journey as { nextAction?: unknown }).nextAction;
+  if (!nextAction || typeof nextAction !== "object") return false;
+  const kind = (nextAction as { kind?: unknown }).kind;
+  return kind === "start_production" || kind === "recover_saved_work";
+}
+
+function journeyStartBlockDescription(response: unknown): string | null {
+  if (!response || typeof response !== "object") return null;
+  const journey = (response as { journey?: unknown }).journey;
+  if (!journey || typeof journey !== "object") return null;
+  const nextAction = (journey as { nextAction?: unknown }).nextAction;
+  if (!nextAction || typeof nextAction !== "object") return null;
+  const description = (nextAction as { description?: unknown }).description;
+  return typeof description === "string" ? description : null;
 }
 
 export function clearRecoveredWizardStorage(
@@ -173,7 +194,11 @@ export function WriteExperience({
     };
   });
   const { publishProgress } = useProjectProgress();
-  const safetyBlockedForSnapshotRef = React.useRef<RunSnapshot | null | undefined>(undefined);
+  // A safety response may arrive while the server snapshot is null. Do not key
+  // the latch to object identity: null would make the visible start action inert
+  // forever. A subsequent activation performs a read-only journey recheck and
+  // can proceed only when the server explicitly derives a start/recovery action.
+  const startSafetyLatchRef = React.useRef<StartSafetyLatch | null>(null);
   const activeRunId = snapshot?.run.id ?? null;
   const handleProgress = React.useCallback(
     (progress: RunProgressSnapshot) => {
@@ -207,6 +232,47 @@ export function WriteExperience({
     clearRecoveredWizardStorage(window.localStorage, userId, experience, recoveryRequestKey);
   }, [experience, recoveryRequestKey, userId]);
 
+  const recheckStartSafety = React.useCallback(
+    async (explicitCompletedRestart: boolean): Promise<boolean> => {
+      const latch = startSafetyLatchRef.current;
+      if (!latch) return true;
+
+      // A completed-request replay protects a lost response from silently
+      // starting paid work twice. Once the refreshed UI proves the full-book
+      // run completed, the separately confirmed "Start new draft" action is a
+      // new author intent and may use a fresh request key. Support blocks never
+      // receive this bypass.
+      if (
+        latch === "completed_replay" &&
+        explicitCompletedRestart &&
+        experience === "full_book" &&
+        snapshot?.run.status === "completed"
+      ) {
+        startSafetyLatchRef.current = null;
+        return true;
+      }
+
+      const response = await fetch(`/api/projects/${projectId}/journey`, {
+        method: "GET",
+        cache: "no-store",
+      });
+      const body: unknown = await response.json().catch(() => null);
+      if (response.ok && journeyAllowsGenerationStart(body)) {
+        startSafetyLatchRef.current = null;
+        return true;
+      }
+      setError(
+        journeyStartBlockDescription(body) ??
+          (response.ok
+            ? "The latest project state does not allow another production start."
+            : "The studio could not safely recheck this project. Try again in a moment."),
+      );
+      router.refresh();
+      return false;
+    },
+    [experience, projectId, router, snapshot?.run.status],
+  );
+
   React.useEffect(() => {
     if (snapshot && moveFocusToRun.current) {
       moveFocusToRun.current = false;
@@ -214,11 +280,12 @@ export function WriteExperience({
     }
   }, [snapshot]);
 
-  async function startRun() {
-    if (pending || safetyBlockedForSnapshotRef.current === initialSnapshot) return;
+  async function startRun(options?: { explicitCompletedRestart?: boolean }) {
+    if (pending) return;
     setPending(true);
     setError(null);
     try {
+      if (!(await recheckStartSafety(options?.explicitCompletedRestart === true))) return;
       const storageKey = generationRequestStorageKey(projectId);
       let requestKey =
         requestKeyRef.current ?? window.localStorage.getItem(storageKey) ?? createRequestKey();
@@ -234,6 +301,8 @@ export function WriteExperience({
         config?: Partial<GenerationConfig>;
         code?: string;
         retryable?: boolean;
+        error?: string;
+        reattached?: boolean;
       } | null;
 
       while (true) {
@@ -245,18 +314,23 @@ export function WriteExperience({
         json = await res.json().catch(() => null);
         responseBody = json as typeof responseBody;
         if (isSupportRequiredResponse(res.status, responseBody)) {
-          safetyBlockedForSnapshotRef.current = initialSnapshot;
+          startSafetyLatchRef.current = "support_required";
           window.localStorage.removeItem(storageKey);
           requestKeyRef.current = null;
+          setError(
+            responseBody?.error ??
+              "Production needs support before another safe start can be attempted.",
+          );
           router.refresh();
           return;
         }
         if (isCompletedRequestReplay(res.status, responseBody)) {
-          safetyBlockedForSnapshotRef.current = initialSnapshot;
+          startSafetyLatchRef.current = "completed_replay";
           // Never turn a lost response for already-completed paid work into a
           // second run. Retire the stale key and re-read the durable journey.
           window.localStorage.removeItem(storageKey);
           requestKeyRef.current = null;
+          setError(responseBody?.error ?? "The completed project state is being refreshed.");
           router.refresh();
           return;
         }
@@ -298,21 +372,30 @@ export function WriteExperience({
         const returnedStatus = ACTIVE_RUN_STATUSES.has(responseBody?.status as ActiveRunStatus)
           ? (responseBody?.status as ActiveRunStatus)
           : "queued";
+        const authoritativeReattach =
+          responseBody?.reattached === true || res.status === 409 || returnedStatus !== "queued";
+        if (authoritativeReattach) {
+          // The start endpoint intentionally returns no event history, pause,
+          // chapter rows, or canonical health. Mounting RunViewer from that
+          // partial response would synchronously publish guessed progress
+          // before its first health poll. Wait for the refreshed server page,
+          // which loads the complete authoritative snapshot instead.
+          moveFocusToRun.current = true;
+          router.refresh();
+          return;
+        }
         const draftedCount =
           snapshot?.chapters?.filter((chapter) =>
             ["drafted", "edited", "final"].includes(chapter.status),
           ).length ?? 0;
-        publishProgress(
-          {
-            runId,
-            stage: "queued",
-            pct: 0,
-            detail: returnedStatus === "queued" ? "Preparing the writing room" : "Reconnecting",
-            draftedCount,
-            totalChapters: chapters,
-          },
-          { refreshAuthoritativeJourney: true },
-        );
+        publishProgress({
+          runId,
+          stage: "queued",
+          pct: 0,
+          detail: "Preparing the writing room",
+          draftedCount,
+          totalChapters: chapters,
+        });
         moveFocusToRun.current = true;
         setSnapshot({
           run: { id: runId, status: returnedStatus, error: null, kind: "full_book" },
@@ -377,7 +460,7 @@ export function WriteExperience({
         estimatedMinutes={runShape.estimatedMinutes}
         plannedChapters={runShape.chapters}
         targetWordsPerChapter={runShape.wordsPerChapter}
-        onRestart={startRun}
+        onRestart={() => void startRun({ explicitCompletedRestart: true })}
         restartPending={pending}
         restartError={error}
         onProgress={handleProgress}

--- a/src/components/generation/write-experience.tsx
+++ b/src/components/generation/write-experience.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { BookOpenText, PenLine } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,8 @@ function words(value: number): string {
 }
 
 const GENERATION_REQUEST_KEY = "sopher.generation-request.v1";
+const ACTIVE_RUN_STATUSES = new Set(["queued", "running", "awaiting_input"] as const);
+type ActiveRunStatus = "queued" | "running" | "awaiting_input";
 
 export function generationRequestStorageKey(projectId: string): string {
   return `${GENERATION_REQUEST_KEY}:${projectId}`;
@@ -41,8 +44,42 @@ export function canAttachToWholeBookRun(
   status: number,
   runId: string | undefined,
   kind: string | undefined,
+  runStatus?: string,
 ): runId is string {
-  return Boolean(runId && (status === 202 || (status === 409 && kind === "full_book")));
+  if (!runId) return false;
+  const activeStatus = ACTIVE_RUN_STATUSES.has(runStatus as ActiveRunStatus);
+  // Older accepted-start responses did not include the status. Preserve that
+  // compatibility only for 202; conflict responses must prove the run active.
+  if (status === 202) return runStatus === undefined || activeStatus;
+  return status === 409 && kind === "full_book" && activeStatus;
+}
+
+export function isTerminalRequestReplay(
+  status: number,
+  response: { code?: string; retryable?: boolean } | null,
+): boolean {
+  return (
+    status === 409 && response?.code === "terminal_request_replay" && response.retryable === true
+  );
+}
+
+export function isCompletedRequestReplay(
+  status: number,
+  response: { code?: string; retryable?: boolean; status?: string } | null,
+): boolean {
+  return (
+    status === 409 &&
+    response?.code === "terminal_request_replay" &&
+    response.retryable === false &&
+    response.status === "completed"
+  );
+}
+
+export function isSupportRequiredResponse(
+  status: number,
+  response: { code?: string } | null,
+): boolean {
+  return status === 409 && response?.code === "support_required";
 }
 
 export function clearRecoveredWizardStorage(
@@ -111,7 +148,17 @@ export function WriteExperience({
   initialSnapshot: RunSnapshot | null;
   titles: Record<number, string | null>;
 }) {
-  const [snapshot, setSnapshot] = React.useState<RunSnapshot | null>(initialSnapshot);
+  const router = useRouter();
+  const [clientSnapshot, setClientSnapshot] = React.useState<{
+    serverSnapshot: RunSnapshot | null;
+    value: RunSnapshot | null;
+  }>(() => ({ serverSnapshot: initialSnapshot, value: initialSnapshot }));
+  const snapshot =
+    clientSnapshot.serverSnapshot === initialSnapshot ? clientSnapshot.value : initialSnapshot;
+  const setSnapshot = React.useCallback(
+    (value: RunSnapshot) => setClientSnapshot({ serverSnapshot: initialSnapshot, value }),
+    [initialSnapshot],
+  );
   const [pending, setPending] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [runShape, setRunShape] = React.useState(() => {
@@ -126,6 +173,7 @@ export function WriteExperience({
     };
   });
   const { publishProgress } = useProjectProgress();
+  const safetyBlockedForSnapshotRef = React.useRef<RunSnapshot | null | undefined>(undefined);
   const activeRunId = snapshot?.run.id ?? null;
   const handleProgress = React.useCallback(
     (progress: RunProgressSnapshot) => {
@@ -167,28 +215,68 @@ export function WriteExperience({
   }, [snapshot]);
 
   async function startRun() {
-    if (pending) return;
+    if (pending || safetyBlockedForSnapshotRef.current === initialSnapshot) return;
     setPending(true);
     setError(null);
     try {
       const storageKey = generationRequestStorageKey(projectId);
-      const requestKey =
+      let requestKey =
         requestKeyRef.current ?? window.localStorage.getItem(storageKey) ?? createRequestKey();
       requestKeyRef.current = requestKey;
       window.localStorage.setItem(storageKey, requestKey);
-      const res = await fetch(`/api/projects/${projectId}/generate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tier, requireOutlineApproval, requestKey }),
-      });
-      const json: unknown = await res.json().catch(() => null);
-      const responseBody = json as {
+      let terminalReplayRetried = false;
+      let res: Response;
+      let json: unknown;
+      let responseBody: {
         runId?: string;
         kind?: string;
+        status?: string;
         config?: Partial<GenerationConfig>;
+        code?: string;
+        retryable?: boolean;
       } | null;
+
+      while (true) {
+        res = await fetch(`/api/projects/${projectId}/generate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tier, requireOutlineApproval, requestKey }),
+        });
+        json = await res.json().catch(() => null);
+        responseBody = json as typeof responseBody;
+        if (isSupportRequiredResponse(res.status, responseBody)) {
+          safetyBlockedForSnapshotRef.current = initialSnapshot;
+          window.localStorage.removeItem(storageKey);
+          requestKeyRef.current = null;
+          router.refresh();
+          return;
+        }
+        if (isCompletedRequestReplay(res.status, responseBody)) {
+          safetyBlockedForSnapshotRef.current = initialSnapshot;
+          // Never turn a lost response for already-completed paid work into a
+          // second run. Retire the stale key and re-read the durable journey.
+          window.localStorage.removeItem(storageKey);
+          requestKeyRef.current = null;
+          router.refresh();
+          return;
+        }
+        if (!isTerminalRequestReplay(res.status, responseBody)) break;
+
+        // A response can be lost long enough for its durable run to become
+        // terminal while the request key remains in localStorage. It is not an
+        // active run to reattach to. Retire that key and retry once, then surface
+        // the server response rather than entering an automatic retry loop.
+        window.localStorage.removeItem(storageKey);
+        requestKeyRef.current = null;
+        if (terminalReplayRetried) break;
+        terminalReplayRetried = true;
+        requestKey = createRequestKey();
+        requestKeyRef.current = requestKey;
+        window.localStorage.setItem(storageKey, requestKey);
+      }
+
       const runId = responseBody?.runId;
-      if (canAttachToWholeBookRun(res.status, runId, responseBody?.kind)) {
+      if (canAttachToWholeBookRun(res.status, runId, responseBody?.kind, responseBody?.status)) {
         window.localStorage.removeItem(storageKey);
         requestKeyRef.current = null;
         clearRecoveredWizardState();
@@ -207,9 +295,27 @@ export function WriteExperience({
         // A duplicate full-book request attaches to its existing run. Scoped
         // chapter/edit jobs deliberately stay a busy error: their event shape
         // does not belong in this whole-manuscript viewer.
+        const returnedStatus = ACTIVE_RUN_STATUSES.has(responseBody?.status as ActiveRunStatus)
+          ? (responseBody?.status as ActiveRunStatus)
+          : "queued";
+        const draftedCount =
+          snapshot?.chapters?.filter((chapter) =>
+            ["drafted", "edited", "final"].includes(chapter.status),
+          ).length ?? 0;
+        publishProgress(
+          {
+            runId,
+            stage: "queued",
+            pct: 0,
+            detail: returnedStatus === "queued" ? "Preparing the writing room" : "Reconnecting",
+            draftedCount,
+            totalChapters: chapters,
+          },
+          { refreshAuthoritativeJourney: true },
+        );
         moveFocusToRun.current = true;
         setSnapshot({
-          run: { id: runId, status: res.status === 202 ? "queued" : "running", error: null },
+          run: { id: runId, status: returnedStatus, error: null, kind: "full_book" },
           events: [],
           chapters: [],
           totalUsd: 0,

--- a/src/components/studio/project-next-step.test.tsx
+++ b/src/components/studio/project-next-step.test.tsx
@@ -14,7 +14,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { AuthoringJourneyCommandProvider } from "@/components/studio/authoring-journey-command";
-import { ProjectNextStep } from "@/components/studio/project-next-step";
+import { JourneyActionLink, ProjectNextStep } from "@/components/studio/project-next-step";
 import { ProjectProgressProvider, useProjectProgress } from "@/components/studio/project-progress";
 import {
   deriveAuthoringJourney,
@@ -24,6 +24,7 @@ import {
 
 const NOW = "2026-07-30T12:00:00.000Z";
 const PROJECT_ID = "11111111-1111-4111-8111-111111111111";
+const RESUMED_RUN_ID = "33333333-3333-4333-8333-333333333333";
 
 function run(overrides: Partial<AuthoringJourneyRun> = {}): AuthoringJourneyRun {
   return {
@@ -108,6 +109,27 @@ function CancellationPublisher({ runId }: { runId: string }) {
   );
 }
 
+function RecoveryProgressPublisher() {
+  const { publishProgress } = useProjectProgress();
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        publishProgress({
+          runId: RESUMED_RUN_ID,
+          stage: "concept",
+          pct: 2,
+          detail: "Developing the premise",
+          draftedCount: 2,
+          totalChapters: 3,
+        })
+      }
+    >
+      Publish recovery progress
+    </button>
+  );
+}
+
 function renderNextStep(journey: ReturnType<typeof snapshot>) {
   return render(
     <AuthoringJourneyCommandProvider>
@@ -135,6 +157,30 @@ afterEach(() => {
 });
 
 describe("ProjectNextStep presentation", () => {
+  it("refocuses an already-active recovery hash instead of leaving the CTA inert", () => {
+    window.history.replaceState({}, "", `/projects/${PROJECT_ID}/write#authoring-recovery`);
+    const target = document.createElement("section");
+    target.id = "authoring-recovery";
+    target.tabIndex = -1;
+    target.scrollIntoView = vi.fn();
+    document.body.append(target);
+
+    render(
+      <JourneyActionLink
+        action={{
+          kind: "recover_saved_work",
+          href: `/projects/${PROJECT_ID}/write#authoring-recovery`,
+          label: "Resume from saved work",
+          description: "Review the saved work.",
+          requiresMeteredAccess: true,
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("link", { name: "Resume from saved work" }));
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(target).toHaveFocus();
+  });
   it("renders cancellation as passive status on its current route without changing nextAction", () => {
     const journey = snapshot(run({ cancellationRequestedAt: NOW }));
     expect(journey.nextAction.kind).toBe("finish_cancellation");
@@ -177,7 +223,51 @@ describe("ProjectNextStep presentation", () => {
     expect(region).toHaveClass("min-h-14");
     expect(region).not.toHaveClass("h-14");
     expect(region.querySelector(".truncate")).toBeNull();
-    expect(screen.getAllByRole("link", { name: "Resume from saved work" })).toHaveLength(1);
+    expect(screen.getByRole("link", { name: "Resume from saved work" })).toHaveAttribute(
+      "href",
+      `/projects/${PROJECT_ID}/write#authoring-recovery`,
+    );
+  });
+
+  it("replaces the recovery action when a distinct resumed run reports live progress", () => {
+    const interrupted = snapshot(
+      run({
+        databaseStatus: "failed",
+        workflowStatus: "failed",
+        effectiveStatus: "failed",
+        stage: "failed",
+        progressPct: 58,
+        completedAt: NOW,
+        rootErrorCode: "provider_failure",
+        rootErrorStage: "chapters",
+        health: "needs_attention",
+      }),
+    );
+
+    render(
+      <AuthoringJourneyCommandProvider>
+        <ProjectProgressProvider
+          projectId={PROJECT_ID}
+          initialProgress={{
+            runId: interrupted.run?.id ?? null,
+            stage: "failed",
+            pct: 58,
+            draftedCount: 2,
+            totalChapters: 3,
+          }}
+        >
+          <ProjectNextStep snapshot={interrupted} />
+          <RecoveryProgressPublisher />
+        </ProjectProgressProvider>
+      </AuthoringJourneyCommandProvider>,
+    );
+
+    expect(screen.getByRole("link", { name: "Resume from saved work" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Publish recovery progress" }));
+
+    expect(screen.queryByRole("link", { name: "Resume from saved work" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Watch production" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Next step: Watch production" })).toBeVisible();
   });
 
   it("switches the project-wide action to stopping safely as soon as cancellation is accepted", () => {

--- a/src/components/studio/project-next-step.test.tsx
+++ b/src/components/studio/project-next-step.test.tsx
@@ -152,18 +152,62 @@ function renderNextStep(journey: ReturnType<typeof snapshot>) {
 
 afterEach(() => {
   cleanup();
+  document.querySelectorAll("#authoring-recovery").forEach((target) => target.remove());
   navigation.pathname = `/projects/${PROJECT_ID}/write`;
+  window.history.replaceState({}, "", navigation.pathname);
   navigation.refresh.mockClear();
 });
 
 describe("ProjectNextStep presentation", () => {
-  it("refocuses an already-active recovery hash instead of leaving the CTA inert", () => {
-    window.history.replaceState({}, "", `/projects/${PROJECT_ID}/write#authoring-recovery`);
+  it("sets and retains the recovery hash while focusing the target on every activation", () => {
+    window.history.replaceState({}, "", `/projects/${PROJECT_ID}/write`);
     const target = document.createElement("section");
     target.id = "authoring-recovery";
-    target.tabIndex = -1;
     target.scrollIntoView = vi.fn();
+    target.getClientRects = vi.fn(() => [{ width: 1, height: 1 }] as unknown as DOMRectList);
     document.body.append(target);
+
+    render(
+      <JourneyActionLink
+        action={{
+          kind: "recover_saved_work",
+          href: `/projects/${PROJECT_ID}/write#authoring-recovery`,
+          label: "Resume from saved work",
+          description: "Review the saved work.",
+          requiresMeteredAccess: true,
+        }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Resume from saved work" });
+    fireEvent.click(link);
+
+    expect(window.location.hash).toBe("#authoring-recovery");
+    expect(target).toHaveAttribute("tabindex", "-1");
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(target).toHaveFocus();
+
+    target.blur();
+    vi.mocked(target.scrollIntoView).mockClear();
+    fireEvent.click(link);
+
+    expect(window.location.hash).toBe("#authoring-recovery");
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(target).toHaveFocus();
+  });
+
+  it("focuses the visible recovery target when a retained route tree has the same hash id", () => {
+    window.history.replaceState({}, "", `/projects/${PROJECT_ID}/write#authoring-recovery`);
+    const hiddenTarget = document.createElement("section");
+    hiddenTarget.id = "authoring-recovery";
+    hiddenTarget.tabIndex = -1;
+    hiddenTarget.scrollIntoView = vi.fn();
+    hiddenTarget.getClientRects = vi.fn(() => [] as unknown as DOMRectList);
+    const visibleTarget = document.createElement("section");
+    visibleTarget.id = "authoring-recovery";
+    visibleTarget.tabIndex = -1;
+    visibleTarget.scrollIntoView = vi.fn();
+    visibleTarget.getClientRects = vi.fn(() => [{ width: 1, height: 1 }] as unknown as DOMRectList);
+    document.body.append(hiddenTarget, visibleTarget);
 
     render(
       <JourneyActionLink
@@ -178,8 +222,9 @@ describe("ProjectNextStep presentation", () => {
     );
     fireEvent.click(screen.getByRole("link", { name: "Resume from saved work" }));
 
-    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
-    expect(target).toHaveFocus();
+    expect(hiddenTarget.scrollIntoView).not.toHaveBeenCalled();
+    expect(visibleTarget.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(visibleTarget).toHaveFocus();
   });
   it("renders cancellation as passive status on its current route without changing nextAction", () => {
     const journey = snapshot(run({ cancellationRequestedAt: NOW }));

--- a/src/components/studio/project-next-step.tsx
+++ b/src/components/studio/project-next-step.tsx
@@ -58,9 +58,28 @@ export function JourneyActionLink({
   variant?: "primary" | "secondary";
 }) {
   const Icon = ACTION_ICONS[action.kind];
+  const focusRepeatedHashTarget = React.useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      const destination = new URL(action.href, window.location.href);
+      if (
+        !destination.hash ||
+        destination.hash !== window.location.hash ||
+        normalizedRoute(destination.pathname) !== normalizedRoute(window.location.pathname)
+      ) {
+        return;
+      }
+      const target = document.getElementById(decodeURIComponent(destination.hash.slice(1)));
+      if (!target) return;
+      event.preventDefault();
+      target.scrollIntoView?.({ block: "start" });
+      target.focus({ preventScroll: true });
+    },
+    [action.href],
+  );
   return (
     <Link
       href={action.href as Route}
+      onClick={focusRepeatedHashTarget}
       className={cn(
         "inline-flex min-h-11 items-center justify-center gap-2 rounded-sm px-4 text-sm font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring forced-colors:border forced-colors:border-[ButtonText] forced-colors:bg-[ButtonFace] forced-colors:text-[ButtonText]",
         variant === "primary"

--- a/src/components/studio/project-next-step.tsx
+++ b/src/components/studio/project-next-step.tsx
@@ -58,19 +58,51 @@ export function JourneyActionLink({
   variant?: "primary" | "secondary";
 }) {
   const Icon = ACTION_ICONS[action.kind];
-  const focusRepeatedHashTarget = React.useCallback(
+  const navigateToVisibleHashTarget = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
       const destination = new URL(action.href, window.location.href);
       if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey ||
         !destination.hash ||
-        destination.hash !== window.location.hash ||
+        destination.origin !== window.location.origin ||
         normalizedRoute(destination.pathname) !== normalizedRoute(window.location.pathname)
       ) {
         return;
       }
-      const target = document.getElementById(decodeURIComponent(destination.hash.slice(1)));
-      if (!target) return;
+
+      // Handle same-page hashes ourselves on both the first and subsequent
+      // activations. A retained Next route tree can contain a hidden copy of
+      // the same id, while the browser's native hash navigation always chooses
+      // the first match. Keep ordinary modified-click behavior intact, update
+      // the address bar like a native anchor, then focus the rendered target.
       event.preventDefault();
+      const previousUrl = window.location.href;
+      if (destination.href !== previousUrl) {
+        window.history.pushState(window.history.state, "", destination.href);
+        window.dispatchEvent(
+          new HashChangeEvent("hashchange", {
+            oldURL: previousUrl,
+            newURL: destination.href,
+          }),
+        );
+      }
+
+      const targetId = decodeURIComponent(destination.hash.slice(1));
+      // Next's client router can retain an inert prior route tree during a
+      // refresh. Fixed hash ids may therefore exist in both the hidden tree and
+      // the active one for a moment. Focus the rendered target instead of the
+      // first document match, which could be invisible and make the CTA appear
+      // inert to keyboard and assistive-technology users.
+      const target = Array.from(document.querySelectorAll<HTMLElement>("[id]")).find(
+        (candidate) => candidate.id === targetId && candidate.getClientRects().length > 0,
+      );
+      if (!target) return;
+      if (!target.hasAttribute("tabindex")) target.tabIndex = -1;
       target.scrollIntoView?.({ block: "start" });
       target.focus({ preventScroll: true });
     },
@@ -79,7 +111,7 @@ export function JourneyActionLink({
   return (
     <Link
       href={action.href as Route}
-      onClick={focusRepeatedHashTarget}
+      onClick={navigateToVisibleHashTarget}
       className={cn(
         "inline-flex min-h-11 items-center justify-center gap-2 rounded-sm px-4 text-sm font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring forced-colors:border forced-colors:border-[ButtonText] forced-colors:bg-[ButtonFace] forced-colors:text-[ButtonText]",
         variant === "primary"

--- a/src/components/studio/project-progress.test.tsx
+++ b/src/components/studio/project-progress.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const navigation = vi.hoisted(() => ({ refresh: vi.fn() }));
@@ -23,6 +24,13 @@ const activeProgress = {
   totalChapters: 12,
 };
 
+const failedProgress = {
+  ...activeProgress,
+  stage: "failed" as const,
+  pct: 58,
+  detail: "Production stopped after four saved chapters",
+};
+
 function ProgressProbe() {
   const { progress } = useProjectProgress();
   return <div data-testid="progress-probe">{`${progress.stage}:${progress.draftedCount}`}</div>;
@@ -44,6 +52,14 @@ function CompletionPublisher() {
       </button>
     </>
   );
+}
+
+function AuthoritativeMountPublisher({ progress }: { progress: typeof failedProgress }) {
+  const { publishProgress } = useProjectProgress();
+  useEffect(() => {
+    publishProgress(progress, { refreshAuthoritativeJourney: true });
+  }, [progress, publishProgress]);
+  return null;
 }
 
 beforeEach(() => {
@@ -125,6 +141,31 @@ describe("ProjectProgressProvider polling", () => {
     expect(navigation.refresh).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Health-confirmed done" }));
+    expect(navigation.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh an initial server-authoritative terminal run again on mount", () => {
+    render(
+      <ProjectProgressProvider projectId="project-1" initialProgress={failedProgress}>
+        <AuthoritativeMountPublisher progress={failedProgress} />
+      </ProjectProgressProvider>,
+    );
+
+    expect(navigation.refresh).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes when a distinct recovery run becomes authoritative and terminal", () => {
+    const recoveredFailure = {
+      ...failedProgress,
+      runId: "66666666-6666-4666-8666-666666666662",
+    };
+
+    render(
+      <ProjectProgressProvider projectId="project-1" initialProgress={failedProgress}>
+        <AuthoritativeMountPublisher progress={recoveredFailure} />
+      </ProjectProgressProvider>,
+    );
+
     expect(navigation.refresh).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/studio/project-progress.tsx
+++ b/src/components/studio/project-progress.tsx
@@ -36,7 +36,14 @@ export function ProjectProgressProvider({
   const [progress, setProgress] = React.useState(initialProgress);
   const [pollAnnouncement, setPollAnnouncement] = React.useState("");
   const lastPublishedAtRef = React.useRef(0);
-  const refreshedRunIdRef = React.useRef<string | null>(null);
+  // A terminal initial snapshot and its journey were produced by the same
+  // server render. RunViewer republishes that health on mount, but refreshing
+  // it again can leave a stale RSC request in flight while the author starts a
+  // recovery run. Treat the initial terminal run as already synchronized;
+  // later terminal transitions and distinct recovery runs still refresh.
+  const refreshedRunIdRef = React.useRef<string | null>(
+    isActiveProductionProgress(initialProgress) ? null : initialProgress.runId,
+  );
   const active = isActiveProductionProgress(progress);
 
   const refreshAuthoritativeJourney = React.useCallback(

--- a/src/db/queries/authoring-journey.ts
+++ b/src/db/queries/authoring-journey.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/authoring-journey";
 import { creditsForUsd } from "@/lib/billing/credits-shared";
 import { getBalance } from "@/lib/billing/credits";
+import { findRunsWithUnresolvedMetering } from "@/lib/billing/unresolved-metering";
 import { deriveAuthoringRunAcceptanceState, type AuthoringRunStatus } from "@/lib/generation-runs";
 import {
   canonicalRunProgress,
@@ -163,22 +164,6 @@ function latestStageForRun(
   };
 }
 
-function blockingRecoveryEvidence(input: {
-  error: string | null;
-  incidentCategories?: string[];
-}): string[] {
-  const categories = new Set(input.incidentCategories ?? []);
-  const error = input.error?.toLowerCase() ?? "";
-  if (
-    error.includes("unresolved local metering") ||
-    error.includes("reconciliation is required") ||
-    (error.includes("already settled") && error.includes("checkpoint is missing"))
-  ) {
-    categories.add("unresolved_metering");
-  }
-  return [...categories];
-}
-
 function persistedRunToJourney(input: {
   run: PersistedRun;
   stageEvent?: StageEventRow;
@@ -316,10 +301,10 @@ function persistedRunToJourney(input: {
     dispatchAttempts: input.workflow?.dispatchAttempts ?? input.run.dispatchAttempts,
     rootErrorCode: input.run.rootErrorCode,
     rootErrorStage: input.run.rootErrorStage,
-    blockingIncidentCategories: blockingRecoveryEvidence({
-      error: input.run.error,
-      incidentCategories: input.blockingIncidentCategories,
-    }),
+    // Root errors remain immutable audit history. Recovery safety is derived
+    // from currently open incidents and pending metering intents so a verified
+    // operator reconciliation can unblock the author without erasing history.
+    blockingIncidentCategories: [...new Set(input.blockingIncidentCategories ?? [])],
     supportReference: input.workflow?.supportReference ?? input.run.supportReference,
     cancellationRequestedAt:
       input.workflow?.cancellation?.requestedAt ?? toIso(input.run.cancellationRequestedAt),
@@ -489,6 +474,7 @@ async function readBlockingIncidentCategories(
           "completion_contradiction",
           "event_persistence",
           "invalid_pause",
+          "unresolved_metering",
         ]),
       ),
     );
@@ -519,17 +505,32 @@ export async function listAuthoringJourneySnapshots(
   const balanceCredits = access.balanceCredits ?? (await getBalance(userId));
 
   const runs = await readJourneyRuns(projects.map((project) => project.id));
-  const [stageEvents, blockingIncidents] = await Promise.all([
+  const [stageEvents, blockingIncidents, unresolvedMeteringRuns] = await Promise.all([
     readLatestStageEvents(runs.map((run) => run.id)),
     readBlockingIncidentCategories(runs.map((run) => run.id)),
+    findRunsWithUnresolvedMetering(runs),
   ]);
   const runsByProject = new Map(runs.map((run) => [run.projectId, run]));
   const stagesByRun = new Map(stageEvents.map((event) => [event.runId, event]));
   const incidentCategoriesByRun = new Map<string, string[]>();
   for (const incident of blockingIncidents) {
+    // Metering incidents are derived from the live ledger. If reconciliation
+    // committed but incident cleanup was interrupted, the stale incident must
+    // not strand the author after the financial evidence is terminal.
+    if (
+      incident.category === "unresolved_metering" &&
+      !unresolvedMeteringRuns.has(incident.runId)
+    ) {
+      continue;
+    }
     const categories = incidentCategoriesByRun.get(incident.runId) ?? [];
     categories.push(incident.category);
     incidentCategoriesByRun.set(incident.runId, categories);
+  }
+  for (const runId of unresolvedMeteringRuns) {
+    const categories = incidentCategoriesByRun.get(runId) ?? [];
+    if (!categories.includes("unresolved_metering")) categories.push("unresolved_metering");
+    incidentCategoriesByRun.set(runId, categories);
   }
 
   return projects.map((project) => {
@@ -617,12 +618,14 @@ export async function getAuthoringJourneySnapshot(input: {
   ]);
   if (!data) return null;
 
-  const [chapters, outline, workflowHealth, blockingIncidents] = await Promise.all([
-    input.chapters ?? (data.book ? getChapterList(data.book.id) : Promise.resolve([])),
-    data.book ? getLatestOutline(data.book.id) : Promise.resolve(null),
-    run ? getRunHealth(run) : Promise.resolve(null),
-    run ? readBlockingIncidentCategories([run.id]) : Promise.resolve([]),
-  ]);
+  const [chapters, outline, workflowHealth, blockingIncidents, unresolvedMeteringRuns] =
+    await Promise.all([
+      input.chapters ?? (data.book ? getChapterList(data.book.id) : Promise.resolve([])),
+      data.book ? getLatestOutline(data.book.id) : Promise.resolve(null),
+      run ? getRunHealth(run) : Promise.resolve(null),
+      run ? readBlockingIncidentCategories([run.id]) : Promise.resolve([]),
+      run ? findRunsWithUnresolvedMetering([run]) : Promise.resolve(new Set<string>()),
+    ]);
   const artifacts = singleProjectArtifacts(
     data,
     chapters,
@@ -636,7 +639,15 @@ export async function getAuthoringJourneySnapshot(input: {
         artifacts,
         projectSpendUsd,
         projectCompletedAt: data.project.completedAt,
-        blockingIncidentCategories: blockingIncidents.map((incident) => incident.category),
+        blockingIncidentCategories: [
+          ...blockingIncidents
+            .filter(
+              (incident) =>
+                incident.category !== "unresolved_metering" || unresolvedMeteringRuns.has(run.id),
+            )
+            .map((incident) => incident.category),
+          ...(unresolvedMeteringRuns.has(run.id) ? ["unresolved_metering"] : []),
+        ],
         workflow: workflowHealth
           ? {
               databaseStatus: workflowHealth.databaseStatus,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -48,8 +48,60 @@ export const users = pgTable("users", {
     .$type<AuthoringOnboarding>()
     .default({ version: 1, seenCoachmarks: [] })
     .notNull(),
+  /** Optional authoring notices. Billing and account-security mail bypasses these controls. */
+  emailAuthoringActionRequired: boolean("email_authoring_action_required").default(true).notNull(),
+  emailAuthoringReminders: boolean("email_authoring_reminders").default(true).notNull(),
+  emailAuthoringCompleted: boolean("email_authoring_completed").default(true).notNull(),
   ...timestamps,
 });
+
+/**
+ * Content-free delivery ledger. Stable event keys make Workflow replays safe,
+ * and a durable suppressed decision cannot become a stale email after opt-in.
+ */
+export const notificationDeliveries = pgTable(
+  "notification_deliveries",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    category: text("category", {
+      enum: ["authoringActionRequired", "authoringReminders", "authoringCompleted"],
+    }).notNull(),
+    eventKey: text("event_key").notNull(),
+    status: text("status", {
+      enum: ["pending", "sent", "suppressed", "failed"],
+    })
+      .default("pending")
+      .notNull(),
+    attempts: integer("attempts").default(0).notNull(),
+    claimToken: uuid("claim_token"),
+    leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+    sentAt: timestamp("sent_at", { withTimezone: true }),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("uq_notification_deliveries_event_key").on(t.eventKey),
+    index("idx_notification_deliveries_user").on(t.userId, t.createdAt),
+    check(
+      "notification_deliveries_category_check",
+      sql`${t.category} in ('authoringActionRequired', 'authoringReminders', 'authoringCompleted')`,
+    ),
+    check(
+      "notification_deliveries_status_check",
+      sql`${t.status} in ('pending', 'sent', 'suppressed', 'failed')`,
+    ),
+    check(
+      "notification_deliveries_claim_check",
+      sql`(
+        (${t.status} = 'pending' and ${t.claimToken} is not null and ${t.leaseExpiresAt} is not null)
+        or
+        (${t.status} <> 'pending' and ${t.claimToken} is null and ${t.leaseExpiresAt} is null)
+      )`,
+    ),
+  ],
+);
 
 export type Acquisition = {
   source?: string;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -652,6 +652,7 @@ export const authoringIncidents = pgTable(
         "cancellation_unconfirmed",
         "stale_reservation",
         "event_persistence",
+        "unresolved_metering",
         "operator_action",
       ],
     }).notNull(),
@@ -681,7 +682,7 @@ export const authoringIncidents = pgTable(
       sql`${t.category} in (
         'dispatch', 'workflow_missing', 'stalled_heartbeat', 'invalid_pause',
         'completion_contradiction', 'cancellation_unconfirmed',
-        'stale_reservation', 'event_persistence', 'operator_action'
+        'stale_reservation', 'event_persistence', 'unresolved_metering', 'operator_action'
       )`,
     ),
   ],

--- a/src/db/unresolved-metering-migration.test.ts
+++ b/src/db/unresolved-metering-migration.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  join(process.cwd(), "drizzle", "0018_unresolved_metering_incidents.sql"),
+  "utf8",
+);
+
+describe("unresolved metering incident migration", () => {
+  it("widens the existing check without rewriting migration history", () => {
+    expect(migration).toContain('DROP CONSTRAINT "authoring_incidents_category_check"');
+    expect(migration).toContain("'unresolved_metering'");
+    expect(migration).toContain('ADD CONSTRAINT "authoring_incidents_category_check"');
+  });
+});

--- a/src/lib/actions/admin.test.ts
+++ b/src/lib/actions/admin.test.ts
@@ -13,6 +13,10 @@ const mocks = vi.hoisted(() => ({
   reconcileRun: vi.fn(),
   getWorkflowRun: vi.fn(),
   cancelWorkflow: vi.fn(),
+  reconcileCharged: vi.fn(),
+  reconcileUncharged: vi.fn(),
+  resolveReconciledIncidents: vi.fn(),
+  isMeteringIntentResolved: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -49,8 +53,13 @@ vi.mock("@/lib/billing/credits", () => ({
 }));
 
 vi.mock("@/lib/billing/meter", () => ({
-  reconcileMeteredCallAsCharged: vi.fn(),
-  reconcileMeteredCallAsUncharged: vi.fn(),
+  reconcileMeteredCallAsCharged: mocks.reconcileCharged,
+  reconcileMeteredCallAsUncharged: mocks.reconcileUncharged,
+}));
+
+vi.mock("@/lib/billing/unresolved-metering", () => ({
+  isMeteringIntentResolved: mocks.isMeteringIntentResolved,
+  resolveReconciledMeteringIncidents: mocks.resolveReconciledIncidents,
 }));
 
 vi.mock("@/lib/generation-runs", () => ({
@@ -68,6 +77,8 @@ vi.mock("workflow/api", () => ({
 
 import {
   adminCancelRun,
+  adminReconcileChargedMeteringIntent,
+  adminReconcileUnchargedMeteringIntent,
   adminRecheckRun,
   adminRedeliverRunInput,
   adminRedispatchRun,
@@ -98,6 +109,10 @@ beforeEach(() => {
   mocks.resolveIncident.mockResolvedValue(undefined);
   mocks.scheduleCleanup.mockResolvedValue(undefined);
   mocks.cancelWorkflow.mockResolvedValue(undefined);
+  mocks.reconcileCharged.mockResolvedValue(undefined);
+  mocks.reconcileUncharged.mockResolvedValue(true);
+  mocks.resolveReconciledIncidents.mockResolvedValue(1);
+  mocks.isMeteringIntentResolved.mockResolvedValue(false);
   mocks.getWorkflowRun.mockReturnValue({ cancel: mocks.cancelWorkflow });
   mocks.reconcileRun.mockResolvedValue({
     runId: RUN_ID,
@@ -329,5 +344,72 @@ describe("Admin authoring recovery actions", () => {
       }),
     );
     expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("clears only derived blocking incidents after an uncharged intent is resolved", async () => {
+    const intentRef = `metering-intent:generation:${RUN_ID}:creative.question:attempt:test`;
+
+    await expect(
+      adminReconcileUnchargedMeteringIntent({
+        intentRef,
+        confirmation: "verified_no_gateway_charge",
+        note: "Gateway showed no billable generation for this attempt.",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.reconcileUncharged).toHaveBeenCalledWith({
+      intentRef,
+      adminId: "admin-1",
+      note: "Gateway showed no billable generation for this attempt.",
+    });
+    expect(mocks.resolveReconciledIncidents).toHaveBeenCalledWith(intentRef);
+  });
+
+  it("retries stale incident cleanup after an uncharged ledger reconciliation already committed", async () => {
+    const intentRef = `metering-intent:generation:${RUN_ID}:creative.question:attempt:test`;
+    mocks.reconcileUncharged.mockResolvedValue(false);
+    mocks.isMeteringIntentResolved.mockResolvedValue(true);
+
+    await expect(
+      adminReconcileUnchargedMeteringIntent({
+        intentRef,
+        confirmation: "verified_no_gateway_charge",
+        note: "Gateway showed no billable generation for this attempt.",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.isMeteringIntentResolved).toHaveBeenCalledWith(intentRef);
+    expect(mocks.resolveReconciledIncidents).toHaveBeenCalledWith(intentRef);
+  });
+
+  it("clears only derived blocking incidents after a charged intent is settled", async () => {
+    const intentRef = `metering-intent:generation:${RUN_ID}:creative.question:attempt:test`;
+
+    await expect(
+      adminReconcileChargedMeteringIntent({
+        intentRef,
+        confirmation: "verified_gateway_charge",
+        note: "Gateway usage was verified against the provider generation.",
+        calls: [{ model: "provider/model", inputTokens: 100, outputTokens: 20 }],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.reconcileCharged).toHaveBeenCalledWith({
+      intentRef,
+      adminId: "admin-1",
+      note: "Gateway usage was verified against the provider generation.",
+      calls: [
+        {
+          model: "provider/model",
+          inputTokens: 100,
+          outputTokens: 20,
+          cachedInputTokens: 0,
+          cacheWriteTokens: 0,
+          reasoningTokens: 0,
+          imageCount: 0,
+        },
+      ],
+    });
+    expect(mocks.resolveReconciledIncidents).toHaveBeenCalledWith(intentRef);
   });
 });

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -12,6 +12,10 @@ import {
   reconcileMeteredCallAsUncharged,
 } from "@/lib/billing/meter";
 import {
+  isMeteringIntentResolved,
+  resolveReconciledMeteringIncidents,
+} from "@/lib/billing/unresolved-metering";
+import {
   requestAuthoringRunCancellation,
   scheduleRunReservationCleanup,
 } from "@/lib/generation-runs";
@@ -292,9 +296,10 @@ export async function adminReconcileUnchargedMeteringIntent(input: unknown): Pro
     adminId,
     note: data.note,
   });
-  if (!released) {
+  if (!released && !(await isMeteringIntentResolved(data.intentRef))) {
     throw new Error("The intent is already resolved or no longer eligible for release");
   }
+  await resolveReconciledMeteringIncidents(data.intentRef);
   revalidatePath("/admin/runs");
 }
 
@@ -341,5 +346,6 @@ export async function adminReconcileChargedMeteringIntent(input: unknown): Promi
     note: data.note,
     calls: data.calls,
   });
+  await resolveReconciledMeteringIncidents(data.intentRef);
   revalidatePath("/admin/runs");
 }

--- a/src/lib/authoring-failures.test.ts
+++ b/src/lib/authoring-failures.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { authoringFailureMessage, classifyAuthoringFailure } from "./authoring-failures";
+
+describe("classifyAuthoringFailure", () => {
+  it("preserves unresolved metering across a Workflow error boundary", () => {
+    const message =
+      "A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.";
+    const serializedWorkflowError = new Error(message);
+    serializedWorkflowError.name = "FatalError";
+
+    expect(classifyAuthoringFailure(serializedWorkflowError)).toEqual({
+      errorCode: "metering_reconciliation_required",
+      incidentCategory: "unresolved_metering",
+    });
+  });
+
+  it("separates settled usage with missing output from an open metering intent", () => {
+    const error = new Error(
+      "This logical provider call was already settled but its output checkpoint is missing. The call was not repeated.",
+    );
+    error.name = "MeteringReconciliationRequiredError";
+
+    expect(classifyAuthoringFailure(error)).toEqual({
+      errorCode: "metered_output_missing",
+      incidentCategory: "completion_contradiction",
+    });
+    expect(authoringFailureMessage(error)).toBe(error.message);
+  });
+
+  it("also recognizes the original metering error name", () => {
+    const originalError = new Error("provider outcome needs operator evidence");
+    originalError.name = "MeteringReconciliationRequiredError";
+
+    expect(classifyAuthoringFailure(originalError)).toEqual({
+      errorCode: "metering_reconciliation_required",
+      incidentCategory: "unresolved_metering",
+    });
+  });
+
+  it("reads the safe message fields from a plain serialized Workflow error", () => {
+    const serializedWorkflowError = {
+      name: "FatalError",
+      message:
+        "A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.",
+      prompt: "must never be stringified or persisted",
+    };
+
+    expect(authoringFailureMessage(serializedWorkflowError)).toBe(serializedWorkflowError.message);
+    expect(classifyAuthoringFailure(serializedWorkflowError)).toEqual({
+      errorCode: "metering_reconciliation_required",
+      incidentCategory: "unresolved_metering",
+    });
+  });
+
+  it("can recover the safe message from a serialized cause", () => {
+    expect(
+      authoringFailureMessage({
+        name: "FatalError",
+        cause: { message: "reconciliation is required" },
+      }),
+    ).toBe(
+      "A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.",
+    );
+  });
+
+  it("does not persist arbitrary messages from serialized Workflow objects", () => {
+    expect(
+      authoringFailureMessage({
+        name: "ProviderError",
+        message: "Sensitive prompt or generated prose",
+      }),
+    ).toBe("Generation failed");
+  });
+
+  it("does not misclassify ordinary provider failures", () => {
+    expect(classifyAuthoringFailure(new Error("Provider returned 503"))).toEqual({});
+  });
+});

--- a/src/lib/authoring-failures.ts
+++ b/src/lib/authoring-failures.ts
@@ -1,0 +1,94 @@
+export type AuthoringFailureDetails = {
+  errorCode?: string;
+  errorStage?: string;
+  incidentCategory?: "unresolved_metering" | "completion_contradiction";
+};
+
+const UNRESOLVED_METERING_MESSAGES = [
+  "unresolved local metering",
+  "reconciliation is required",
+] as const;
+
+const SETTLED_OUTPUT_MISSING_MESSAGE = "already settled but its output checkpoint is missing";
+
+const UNRESOLVED_METERING_FAILURE_MESSAGE =
+  "A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.";
+const SETTLED_OUTPUT_MISSING_FAILURE_MESSAGE =
+  "This logical provider call was already settled but its output checkpoint is missing. The call was not repeated.";
+
+function ownString(value: object, key: string): string | null {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor && "value" in descriptor && typeof descriptor.value === "string"
+    ? descriptor.value
+    : null;
+}
+
+function ownCause(value: object): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, "cause");
+  return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function failureStrings(value: unknown, depth = 0): string[] {
+  if (!value || typeof value !== "object" || depth > 2) return [];
+  const name = value instanceof Error ? value.name : ownString(value, "name");
+  const message = value instanceof Error ? value.message : ownString(value, "message");
+  return [
+    ...(name ? [name] : []),
+    ...(message ? [message] : []),
+    ...failureStrings(ownCause(value), depth + 1),
+  ];
+}
+
+function extractedFailureMessage(value: unknown, depth = 0): string | null {
+  if (!value || typeof value !== "object" || depth > 2) return null;
+  const message = value instanceof Error ? value.message : ownString(value, "message");
+  return message?.trim() || extractedFailureMessage(ownCause(value), depth + 1);
+}
+
+/**
+ * Workflow may return a structured-clone-shaped object instead of an Error.
+ * Read only own name/message/cause fields; never stringify the object, where
+ * prompts or manuscript content could be attached by an upstream provider.
+ */
+export function authoringFailureMessage(error: unknown, fallback = "Generation failed"): string {
+  const serialized = failureStrings(error).join(" ").toLowerCase();
+  if (serialized.includes(SETTLED_OUTPUT_MISSING_MESSAGE)) {
+    return SETTLED_OUTPUT_MISSING_FAILURE_MESSAGE;
+  }
+  if (
+    serialized.includes("meteringreconciliationrequirederror") ||
+    UNRESOLVED_METERING_MESSAGES.some((fragment) => serialized.includes(fragment))
+  ) {
+    return UNRESOLVED_METERING_FAILURE_MESSAGE;
+  }
+  // Serialized Workflow objects may carry provider or author content in an
+  // otherwise ordinary-looking message. Preserve legacy Error behavior, but
+  // never persist arbitrary fields from a plain structured-clone object.
+  return error instanceof Error ? (extractedFailureMessage(error) ?? fallback) : fallback;
+}
+
+/**
+ * Workflow step errors may cross a serialization boundary that changes their
+ * concrete class to FatalError. Classify from both the durable name and the
+ * stable, non-sensitive operator message so the initiating cause is not lost
+ * to a generic `authoring_failed` cleanup record.
+ */
+export function classifyAuthoringFailure(error: unknown): AuthoringFailureDetails {
+  const serialized = failureStrings(error).join(" ").toLowerCase();
+  if (serialized.includes(SETTLED_OUTPUT_MISSING_MESSAGE)) {
+    return {
+      errorCode: "metered_output_missing",
+      incidentCategory: "completion_contradiction",
+    };
+  }
+  if (
+    serialized.includes("meteringreconciliationrequirederror") ||
+    UNRESOLVED_METERING_MESSAGES.some((fragment) => serialized.includes(fragment))
+  ) {
+    return {
+      errorCode: "metering_reconciliation_required",
+      incidentCategory: "unresolved_metering",
+    };
+  }
+  return {};
+}

--- a/src/lib/authoring-fault-matrix.integration.test.ts
+++ b/src/lib/authoring-fault-matrix.integration.test.ts
@@ -907,10 +907,13 @@ describeIsolated.sequential("authoring fault matrix against isolated Neon", () =
     const completionEmailKeys = emailSendMock.mock.calls.map(
       (call) => (call[1] as { idempotencyKey?: string } | undefined)?.idempotencyKey,
     );
-    expect(completionEmailKeys).toEqual([
-      `run:${completion.runId}:book-finished`,
-      `run:${completion.runId}:book-finished`,
-    ]);
+    expect(completionEmailKeys).toEqual([`run:${completion.runId}:book-finished`]);
+    await expect(
+      getDb()
+        .select({ status: schema.notificationDeliveries.status })
+        .from(schema.notificationDeliveries)
+        .where(eq(schema.notificationDeliveries.eventKey, `run:${completion.runId}:book-finished`)),
+    ).resolves.toEqual([{ status: "sent" }]);
     const [completedRun] = await getDb()
       .select({
         status: schema.generationRuns.status,

--- a/src/lib/authoring-journey.test.ts
+++ b/src/lib/authoring-journey.test.ts
@@ -10,6 +10,7 @@ import {
 
 const PROJECT_ID = "11111111-1111-4111-8111-111111111111";
 const RUN_ID = "22222222-2222-4222-8222-222222222222";
+const RESUMED_RUN_ID = "33333333-3333-4333-8333-333333333333";
 const NOW = "2026-07-30T12:00:00.000Z";
 
 function run(overrides: Partial<AuthoringJourneyRun> = {}): AuthoringJourneyRun {
@@ -206,7 +207,7 @@ describe("deriveAuthoringJourney", () => {
         }),
       }),
       action: "recover_saved_work",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#authoring-recovery`,
     },
     {
       name: "keeps legacy saved prose editable without presenting purchase as a failure remedy",
@@ -362,8 +363,7 @@ describe("deriveAuthoringJourney", () => {
     "completion_contradiction",
     "invalid_pause",
     "event_persistence",
-    "metering_reconciliation_required",
-    "unresolved_metering",
+    "metered_output_missing",
   ])("never offers restart or recovery for evidence-unsafe error code %s", (rootErrorCode) => {
     const journey = deriveAuthoringJourney(
       seed({
@@ -381,6 +381,25 @@ describe("deriveAuthoringJourney", () => {
 
     expect(journey.nextAction.kind).toBe("contact_support");
     expect(journey.nextAction.description).toMatch(/will not restart it automatically/i);
+  });
+
+  it("keeps a reconciled metering root error as audit history without blocking recovery", () => {
+    const journey = deriveAuthoringJourney(
+      seed({
+        artifacts: { savedChapters: 2, wordCount: 1900 },
+        run: run({
+          databaseStatus: "failed",
+          workflowStatus: "failed",
+          effectiveStatus: "failed",
+          stage: "failed",
+          rootErrorCode: "metering_reconciliation_required",
+          blockingIncidentCategories: [],
+          health: "needs_attention",
+        }),
+      }),
+    );
+
+    expect(journey.nextAction.kind).toBe("recover_saved_work");
   });
 
   it.each([
@@ -904,5 +923,107 @@ describe("authoringJourneyWithProgress", () => {
       label: "View the safe stop",
       href: `/projects/${PROJECT_ID}/write`,
     });
+  });
+
+  it("replaces a failed run with a distinct active recovery run without inheriting failure state", () => {
+    const interrupted = deriveAuthoringJourney(
+      seed({
+        artifacts: { savedChapters: 2, savedCheckpoints: 4, wordCount: 1900 },
+        run: run({
+          databaseStatus: "failed",
+          workflowStatus: "failed",
+          effectiveStatus: "failed",
+          stage: "failed",
+          progressPct: 58,
+          completedAt: NOW,
+          rootErrorCode: "provider_failure",
+          rootErrorStage: "chapters",
+          health: "needs_attention",
+        }),
+      }),
+    );
+    expect(interrupted.nextAction.kind).toBe("recover_saved_work");
+
+    const resumed = authoringJourneyWithProgress(interrupted, {
+      runId: RESUMED_RUN_ID,
+      stage: "concept",
+      pct: 2,
+      detail: "Developing the premise",
+      draftedCount: 2,
+      totalChapters: 3,
+    });
+
+    expect(resumed.run).toMatchObject({
+      id: RESUMED_RUN_ID,
+      kind: "full_book",
+      databaseStatus: "running",
+      workflowStatus: null,
+      effectiveStatus: "running",
+      stage: "concept",
+      progressPct: 2,
+      completedAt: null,
+      rootErrorCode: undefined,
+      rootErrorStage: undefined,
+      cancellationRequestedAt: undefined,
+      pause: null,
+    });
+    expect(resumed.nextAction).toMatchObject({
+      kind: "watch_production",
+      label: "Watch production",
+      href: `/projects/${PROJECT_ID}/write`,
+    });
+  });
+
+  it("does not revive a terminal run from stale same-run progress", () => {
+    const interrupted = deriveAuthoringJourney(
+      seed({
+        artifacts: { savedChapters: 2, savedCheckpoints: 4, wordCount: 1900 },
+        run: run({
+          databaseStatus: "failed",
+          workflowStatus: "failed",
+          effectiveStatus: "failed",
+          stage: "failed",
+          progressPct: 58,
+          completedAt: NOW,
+          rootErrorCode: "provider_failure",
+          rootErrorStage: "chapters",
+          health: "needs_attention",
+        }),
+      }),
+    );
+
+    const stale = authoringJourneyWithProgress(interrupted, {
+      runId: RUN_ID,
+      stage: "concept",
+      pct: 2,
+      detail: "Developing the premise",
+      draftedCount: 2,
+      totalChapters: 3,
+    });
+
+    expect(stale).toBe(interrupted);
+    expect(stale.run).toMatchObject({
+      id: RUN_ID,
+      databaseStatus: "failed",
+      effectiveStatus: "failed",
+      stage: "failed",
+      rootErrorCode: "provider_failure",
+    });
+    expect(stale.nextAction.kind).toBe("recover_saved_work");
+  });
+
+  it("does not let a distinct live progress record displace an authoritative active run", () => {
+    const active = deriveAuthoringJourney(seed({ run: run() }));
+    const conflicting = authoringJourneyWithProgress(active, {
+      runId: RESUMED_RUN_ID,
+      stage: "concept",
+      pct: 2,
+      draftedCount: 0,
+      totalChapters: 3,
+    });
+
+    expect(conflicting).toBe(active);
+    expect(conflicting.run?.id).toBe(RUN_ID);
+    expect(conflicting.run?.stage).toBe("chapters");
   });
 });

--- a/src/lib/authoring-journey.ts
+++ b/src/lib/authoring-journey.ts
@@ -1,5 +1,6 @@
 import type { ProjectExperience } from "@/db/schema";
 import {
+  isActiveProductionProgress,
   lifecyclePhaseForProduction,
   type LifecyclePhase,
   type ProductionStage,
@@ -234,9 +235,7 @@ const EVIDENCE_UNSAFE_ERROR_CODES = new Set([
   "completion_contradiction",
   "event_persistence",
   "invalid_pause",
-  "metering_reconciliation_required",
-  "metering_unresolved",
-  "unresolved_metering",
+  "metered_output_missing",
 ]);
 
 const EVIDENCE_UNSAFE_INCIDENT_CATEGORIES = new Set([
@@ -248,14 +247,8 @@ const EVIDENCE_UNSAFE_INCIDENT_CATEGORIES = new Set([
 
 function hasEvidenceUnsafeRecoveryState(run: AuthoringJourneyRun): boolean {
   const errorCode = run.rootErrorCode?.trim().toLowerCase() ?? "";
-  const unresolvedMetering =
-    errorCode.includes("metering") &&
-    (errorCode.includes("reconciliation") ||
-      errorCode.includes("settlement") ||
-      errorCode.includes("unresolved"));
   return (
     EVIDENCE_UNSAFE_ERROR_CODES.has(errorCode) ||
-    unresolvedMetering ||
     (run.blockingIncidentCategories ?? []).some((category) =>
       EVIDENCE_UNSAFE_INCIDENT_CATEGORIES.has(category),
     )
@@ -470,7 +463,7 @@ function actionForSeed(
     }
     return nextAction(
       "recover_saved_work",
-      projectWriteHref,
+      `${projectWriteHref}#authoring-recovery`,
       artifacts.savedChapters > 0 ? "Resume from saved work" : "Try starting again",
       artifacts.savedChapters > 0
         ? `${artifacts.savedChapters} saved ${
@@ -623,6 +616,20 @@ export function authoringJourneyWithProgress(
 ): AuthoringJourneySnapshot {
   if (!progress.runId) return snapshot;
 
+  const existingRun = snapshot.run;
+  const sameRun = existingRun?.id === progress.runId;
+  const existingRunIsActive =
+    existingRun !== null && ACTIVE_RUN_STATUSES.has(existingRun.effectiveStatus);
+  const activeReplacement =
+    !sameRun && isActiveProductionProgress(progress) && !existingRunIsActive;
+
+  // Project progress can briefly move ahead of the server snapshot after a
+  // deliberate recovery start. Only an active, distinct run may replace a
+  // terminal (or absent) snapshot. A second run must never displace another
+  // active run, and stale progress from a terminal run must never revive it.
+  if (!sameRun && !activeReplacement) return snapshot;
+  if (sameRun && existingRun && !existingRunIsActive) return snapshot;
+
   // A streamed `done` event is an immediate presentation signal, not durable
   // proof that finalization committed every chapter and completion digest.
   // Keep the authoritative next action and artifact counts until the server
@@ -643,67 +650,70 @@ export function authoringJourneyWithProgress(
 
   const terminalStatus: AuthoringRunStatus | null =
     progress.stage === "failed" ? "failed" : progress.stage === "cancelled" ? "cancelled" : null;
-  const existingRun = snapshot.run;
+  const inheritedRun = activeReplacement ? null : existingRun;
+  const activeStatus: AuthoringRunStatus =
+    progress.stage === "queued"
+      ? "queued"
+      : progress.stage === "awaiting_guidance" ||
+          progress.stage === "awaiting_approval" ||
+          progress.stage === "awaiting_credits"
+        ? "awaiting_input"
+        : "running";
   const run: AuthoringJourneyRun = {
     id: progress.runId,
-    kind: existingRun?.kind,
-    databaseStatus:
-      terminalStatus ??
-      existingRun?.databaseStatus ??
-      (progress.stage === "queued" ? "queued" : "running"),
-    workflowStatus: existingRun?.workflowStatus ?? null,
-    effectiveStatus:
-      terminalStatus ??
-      (progress.stage === "awaiting_guidance" ||
-      progress.stage === "awaiting_approval" ||
-      progress.stage === "awaiting_credits"
-        ? "awaiting_input"
-        : (existingRun?.effectiveStatus ?? (progress.stage === "queued" ? "queued" : "running"))),
+    kind: activeReplacement ? "full_book" : inheritedRun?.kind,
+    databaseStatus: terminalStatus ?? inheritedRun?.databaseStatus ?? activeStatus,
+    workflowStatus: inheritedRun?.workflowStatus ?? null,
+    effectiveStatus: terminalStatus ?? inheritedRun?.effectiveStatus ?? activeStatus,
     stage: progress.stage,
     progressPct: progress.pct,
     stageDescription: progress.detail ?? null,
-    acceptedAt: existingRun?.acceptedAt ?? snapshot.project.updatedAt,
-    startedAt: existingRun?.startedAt ?? null,
-    completedAt: existingRun?.completedAt ?? null,
-    lastUpdateAt: existingRun?.lastUpdateAt ?? snapshot.project.updatedAt,
-    acceptanceUncertain: existingRun?.acceptanceUncertain ?? false,
-    safeToRetry: existingRun?.safeToRetry ?? false,
-    authoringBegan: existingRun?.authoringBegan ?? progress.stage !== "queued",
+    acceptedAt: inheritedRun?.acceptedAt ?? snapshot.project.updatedAt,
+    startedAt: inheritedRun?.startedAt ?? null,
+    completedAt: inheritedRun?.completedAt ?? null,
+    lastUpdateAt: inheritedRun?.lastUpdateAt ?? snapshot.project.updatedAt,
+    acceptanceUncertain: inheritedRun?.acceptanceUncertain ?? false,
+    safeToRetry: inheritedRun?.safeToRetry ?? false,
+    authoringBegan: inheritedRun?.authoringBegan ?? progress.stage !== "queued",
     noWorkStarted:
-      existingRun?.noWorkStarted ?? (progress.stage === "queued" && progress.draftedCount === 0),
-    completionArtifactsReady: existingRun?.completionArtifactsReady,
-    heartbeatAt: existingRun?.heartbeatAt,
-    lastProgressAt: existingRun?.lastProgressAt,
-    workflowObservedAt: existingRun?.workflowObservedAt,
-    dispatchAttempts: existingRun?.dispatchAttempts,
-    rootErrorCode: existingRun?.rootErrorCode,
-    rootErrorStage: existingRun?.rootErrorStage,
-    blockingIncidentCategories: existingRun?.blockingIncidentCategories,
-    supportReference: existingRun?.supportReference,
+      inheritedRun?.noWorkStarted ?? (progress.stage === "queued" && progress.draftedCount === 0),
+    completionArtifactsReady: inheritedRun?.completionArtifactsReady,
+    heartbeatAt: inheritedRun?.heartbeatAt,
+    lastProgressAt: inheritedRun?.lastProgressAt,
+    workflowObservedAt: inheritedRun?.workflowObservedAt,
+    dispatchAttempts: inheritedRun?.dispatchAttempts,
+    rootErrorCode: inheritedRun?.rootErrorCode,
+    rootErrorStage: inheritedRun?.rootErrorStage,
+    blockingIncidentCategories: inheritedRun?.blockingIncidentCategories,
+    supportReference: inheritedRun?.supportReference,
     cancellationRequestedAt:
-      progress.cancellationRequestedAt ?? existingRun?.cancellationRequestedAt,
+      progress.cancellationRequestedAt ?? inheritedRun?.cancellationRequestedAt,
     pause:
       progress.stage === "awaiting_approval"
         ? {
-            ...(existingRun?.pause?.kind === "outline_approval" ? existingRun.pause : {}),
+            ...(inheritedRun?.pause?.kind === "outline_approval" ? inheritedRun.pause : {}),
             kind: "outline_approval",
           }
         : progress.stage === "awaiting_guidance"
           ? {
-              ...(existingRun?.pause?.kind === "creative_decision" ? existingRun.pause : {}),
+              ...(inheritedRun?.pause?.kind === "creative_decision" ? inheritedRun.pause : {}),
               kind: "creative_decision",
             }
           : progress.stage === "awaiting_credits"
             ? {
-                ...(existingRun?.pause?.kind === "credits" ? existingRun.pause : {}),
+                ...(inheritedRun?.pause?.kind === "credits" ? inheritedRun.pause : {}),
                 kind: "credits",
               }
             : null,
     health:
       terminalStatus === "failed" || terminalStatus === "cancelled"
         ? "needs_attention"
-        : (existingRun?.health ?? "healthy"),
-    spend: existingRun?.spend ?? { meteredUsd: 0, creditsUsed: 0, scope: "run" },
+        : progress.stage === "awaiting_guidance" ||
+            progress.stage === "awaiting_approval" ||
+            progress.stage === "awaiting_credits"
+          ? "waiting"
+          : (inheritedRun?.health ?? "healthy"),
+    spend: inheritedRun?.spend ?? { meteredUsd: 0, creditsUsed: 0, scope: "run" },
   };
 
   return deriveAuthoringJourney({

--- a/src/lib/authoring-reliability.integration.test.ts
+++ b/src/lib/authoring-reliability.integration.test.ts
@@ -28,6 +28,12 @@ import {
   requestAuthoringRunCancellation,
   transitionAuthoringRunState,
 } from "@/lib/generation-runs";
+import { getAuthoringStartSafetyBlock } from "@/lib/authoring-start-safety";
+import { resolveReconciledMeteringIncidents } from "@/lib/billing/unresolved-metering";
+import {
+  reconcileMeteredCallAsCharged,
+  reconcileMeteredCallAsUncharged,
+} from "@/lib/billing/meter";
 import {
   hydratePreManuscriptRetryStep,
   prepareCreativeQuestionStep,
@@ -645,8 +651,147 @@ describeIsolated("authoring reliability against isolated Neon", () => {
     expect(libraryProject?.nextAction).toEqual(openProject?.nextAction);
     expect(openProject?.nextAction).toMatchObject({
       kind: "recover_saved_work",
-      href: `/projects/${projectId}/write`,
+      href: `/projects/${projectId}/write#authoring-recovery`,
     });
+  });
+
+  it("blocks a replacement run while its billing lineage has unresolved provider evidence", async () => {
+    const projectId = randomUUID();
+    const rootRunId = randomUUID();
+    const retryRunId = randomUUID();
+    const intentRef = `metering-intent:generation:${rootRunId}:creative-question:after-concept:creative.question:attempt:test`;
+    const secondIntentRef = `metering-intent:generation:${rootRunId}:outline:creative.outline:attempt:second`;
+    await observer!`
+      insert into projects (
+        id, user_id, title, brief, genre, experience,
+        target_chapters, target_words_per_chapter, settings
+      )
+      values (
+        ${projectId}, ${userId}, 'Unresolved metering fixture',
+        'A failed provider attempt must be reconciled before retry.', 'mystery',
+        'full_book', 3, 1000, '{"qualityTier":"standard"}'::jsonb
+      )
+    `;
+    await observer!`
+      insert into generation_runs (
+        id, project_id, user_id, request_key, kind, status, config,
+        current_stage, progress_pct, error, root_error_code, root_error_stage, created_at
+      )
+      values
+        (
+          ${rootRunId}, ${projectId}, ${userId}, ${randomUUID()}, 'full_book', 'failed',
+          ${JSON.stringify({ protocolVersion: 2, tier: "standard" })}::jsonb,
+          'failed', 2, 'A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.',
+          'metering_reconciliation_required', 'concept', now() - interval '2 minutes'
+        ),
+        (
+          ${retryRunId}, ${projectId}, ${userId}, ${randomUUID()}, 'full_book', 'failed',
+          ${JSON.stringify({
+            protocolVersion: 2,
+            tier: "standard",
+            resumeFromRunId: rootRunId,
+            billingLineageRunId: rootRunId,
+          })}::jsonb,
+          'failed', 2, 'A prior provider attempt has unresolved local metering. The call was not repeated; reconciliation is required.',
+          'metering_reconciliation_required', 'concept', now() - interval '1 minute'
+        )
+    `;
+    await observer!`
+      insert into credit_ledger (
+        user_id, amount, kind, description, project_id, run_id, external_ref, created_at
+      )
+      values
+        (${userId}, 100, 'purchase', 'Entitled test wallet', ${projectId}, null,
+          ${`test-purchase:${projectId}`}, now() - interval '3 hours'),
+        (${userId}, 0, 'adjustment', 'Metering intent for creative.question',
+          ${projectId}, ${rootRunId}, ${intentRef}, now() - interval '2 hours'),
+        (${userId}, -0.275, 'adjustment', 'Provider claim',
+          ${projectId}, ${rootRunId}, ${`metering-claim:${intentRef}`}, now() - interval '2 hours'),
+        (${userId}, 0, 'adjustment', 'Second metering intent',
+          ${projectId}, ${rootRunId}, ${secondIntentRef}, now() - interval '2 hours'),
+        (${userId}, -0.275, 'adjustment', 'Second provider claim',
+          ${projectId}, ${rootRunId}, ${`metering-claim:${secondIntentRef}`}, now() - interval '2 hours')
+    `;
+    await observer!`
+      insert into authoring_incidents (
+        run_id, project_id, category, severity, dedupe_key, evidence
+      )
+      values (
+        ${retryRunId}, ${projectId}, 'unresolved_metering', 'critical',
+        'unresolved-metering', '{"errorCode":"metering_reconciliation_required"}'::jsonb
+      )
+    `;
+
+    const access = { fullBookUnlocked: true, balanceCredits: 100 };
+    const library = await listAuthoringJourneySnapshots(userId, access);
+    const openProject = await getAuthoringJourneySnapshot({ userId, projectId, access });
+    const libraryProject = library.find((snapshot) => snapshot.project.id === projectId);
+
+    expect(libraryProject?.run?.id).toBe(retryRunId);
+    expect(libraryProject?.nextAction.kind).toBe("contact_support");
+    expect(libraryProject?.purchaseAction).toBeNull();
+    expect(openProject?.nextAction.kind).toBe("contact_support");
+    await expect(getAuthoringStartSafetyBlock({ userId, projectId })).resolves.toMatchObject({
+      code: "support_required",
+      action: { kind: "contact_support", requiresMeteredAccess: false },
+    });
+
+    await expect(
+      reconcileMeteredCallAsCharged({
+        intentRef,
+        adminId: "integration-test",
+        note: "Exact Gateway attempt verified; output was not delivered.",
+        calls: [
+          {
+            model: "anthropic/claude-sonnet-5",
+            inputTokens: 2,
+            outputTokens: 537,
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ debitedCredits: expect.any(Number) });
+    await expect(resolveReconciledMeteringIncidents(intentRef)).resolves.toBe(0);
+
+    const afterFirst = await getAuthoringJourneySnapshot({ userId, projectId, access });
+    expect(afterFirst?.nextAction.kind).toBe("contact_support");
+    const chargedLedger = (await observer!`
+      select external_ref as "externalRef", amount::text, kind
+      from credit_ledger
+      where external_ref in (
+        ${`metering-claim:${intentRef}`},
+        ${`release:metering-claim:${intentRef}`},
+        ${`intent-settled:${intentRef}`},
+        ${`delivery-refund:llm:generation:${rootRunId}:creative-question:after-concept:creative.question:attempt:test`},
+        ${`llm:generation:${rootRunId}:creative-question:after-concept:creative.question:attempt:test:step:0`}
+      )
+    `) as unknown as Array<{ externalRef: string; amount: string; kind: string }>;
+    expect(chargedLedger.map((row) => row.externalRef)).toEqual(
+      expect.arrayContaining([
+        `release:metering-claim:${intentRef}`,
+        `intent-settled:${intentRef}`,
+        `delivery-refund:llm:generation:${rootRunId}:creative-question:after-concept:creative.question:attempt:test`,
+      ]),
+    );
+    expect(chargedLedger.reduce((sum, row) => sum + Number(row.amount), 0)).toBeCloseTo(0, 6);
+    const [verifiedCall] = (await observer!`
+      select input_tokens::int as "inputTokens", output_tokens::int as "outputTokens"
+      from llm_calls
+      where run_id = ${rootRunId} and operation = 'creative.question'
+    `) as unknown as Array<{ inputTokens: number; outputTokens: number }>;
+    expect(verifiedCall).toEqual({ inputTokens: 2, outputTokens: 537 });
+
+    await expect(
+      reconcileMeteredCallAsUncharged({
+        intentRef: secondIntentRef,
+        adminId: "integration-test",
+        note: "Gateway verified that the second provider attempt was uncharged.",
+      }),
+    ).resolves.toBe(true);
+    await expect(resolveReconciledMeteringIncidents(secondIntentRef)).resolves.toBeGreaterThan(0);
+
+    const reconciled = await getAuthoringJourneySnapshot({ userId, projectId, access });
+    expect(reconciled?.nextAction.kind).toBe("recover_saved_work");
+    await expect(getAuthoringStartSafetyBlock({ userId, projectId })).resolves.toBeNull();
   });
 
   it("derives the same next action for a successful scoped retry in the library and open project", async () => {

--- a/src/lib/authoring-start-safety.test.ts
+++ b/src/lib/authoring-start-safety.test.ts
@@ -2,16 +2,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getSnapshot: vi.fn(),
+  hasUnresolvedMetering: vi.fn(),
 }));
 
 vi.mock("@/db/queries/authoring-journey", () => ({
   getAuthoringJourneySnapshot: mocks.getSnapshot,
 }));
 
+vi.mock("@/lib/billing/unresolved-metering", () => ({
+  projectHasUnresolvedMetering: mocks.hasUnresolvedMetering,
+}));
+
 import { getAuthoringStartSafetyBlock } from "./authoring-start-safety";
 
 describe("getAuthoringStartSafetyBlock", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasUnresolvedMetering.mockResolvedValue(false);
+  });
 
   it("returns only content-free support routing evidence", async () => {
     mocks.getSnapshot.mockResolvedValue({
@@ -49,5 +57,29 @@ describe("getAuthoringStartSafetyBlock", () => {
     await expect(
       getAuthoringStartSafetyBlock({ projectId: "project-1", userId: "author-1" }),
     ).resolves.toBeNull();
+  });
+
+  it("fails closed before run creation when the billing lineage still has an open intent", async () => {
+    mocks.getSnapshot.mockResolvedValue({
+      supportReference: "SPH-PROJECT1-RUN00001",
+      nextAction: { kind: "recover_saved_work" },
+    });
+    mocks.hasUnresolvedMetering.mockResolvedValue(true);
+
+    await expect(
+      getAuthoringStartSafetyBlock({ projectId: "project-1", userId: "author-1" }),
+    ).resolves.toMatchObject({
+      code: "support_required",
+      supportReference: "SPH-PROJECT1-RUN00001",
+      action: {
+        kind: "contact_support",
+        label: "Contact support",
+        requiresMeteredAccess: false,
+      },
+    });
+    expect(mocks.hasUnresolvedMetering).toHaveBeenCalledWith({
+      projectId: "project-1",
+      userId: "author-1",
+    });
   });
 });

--- a/src/lib/authoring-start-safety.ts
+++ b/src/lib/authoring-start-safety.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { getAuthoringJourneySnapshot } from "@/db/queries/authoring-journey";
+import { projectHasUnresolvedMetering } from "@/lib/billing/unresolved-metering";
 import type { AuthoringNextAction } from "@/lib/authoring-journey";
 
 export type AuthoringStartSafetyBlock = {
@@ -19,12 +20,31 @@ export async function getAuthoringStartSafetyBlock(input: {
   projectId: string;
   userId: string;
 }): Promise<AuthoringStartSafetyBlock | null> {
-  const snapshot = await getAuthoringJourneySnapshot(input);
-  if (!snapshot || snapshot.nextAction.kind !== "contact_support") return null;
+  const [snapshot, unresolvedMetering] = await Promise.all([
+    getAuthoringJourneySnapshot(input),
+    projectHasUnresolvedMetering(input),
+  ]);
+  if (!snapshot) return null;
+
+  if (snapshot.nextAction.kind !== "contact_support" && !unresolvedMetering) return null;
+
+  const action: AuthoringStartSafetyBlock["action"] =
+    snapshot.nextAction.kind === "contact_support"
+      ? (snapshot.nextAction as AuthoringStartSafetyBlock["action"])
+      : {
+          kind: "contact_support",
+          href: `mailto:support@sopher.ai?subject=${encodeURIComponent(
+            `Authoring help · ${snapshot.supportReference}`,
+          )}`,
+          label: "Contact support",
+          description:
+            "A prior provider attempt has unresolved billing evidence. We will not restart or repeat that work until support verifies the provider outcome.",
+          requiresMeteredAccess: false,
+        };
 
   return {
     code: "support_required",
     supportReference: snapshot.supportReference,
-    action: snapshot.nextAction as AuthoringStartSafetyBlock["action"],
+    action,
   };
 }

--- a/src/lib/billing/unresolved-metering.test.ts
+++ b/src/lib/billing/unresolved-metering.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { unresolvedMeteringCandidate } from "./unresolved-metering";
+
+const baseRun = {
+  id: "11111111-1111-4111-8111-111111111111",
+  projectId: "22222222-2222-4222-8222-222222222222",
+  userId: "author-1",
+  config: {},
+};
+
+describe("unresolvedMeteringCandidate", () => {
+  it.each(["queued", "running", "awaiting_input", "completed"])(
+    "does not treat a %s run's in-flight intent as unsafe recovery evidence",
+    (status) => {
+      expect(unresolvedMeteringCandidate({ ...baseRun, status })).toBeNull();
+    },
+  );
+
+  it("uses the current run for a terminal root attempt", () => {
+    expect(unresolvedMeteringCandidate({ ...baseRun, status: "failed" })).toMatchObject({
+      lineageRunId: baseRun.id,
+      intentPrefix: `metering-intent:generation:${baseRun.id}:`,
+    });
+  });
+
+  it("follows the preserved billing lineage across recovery attempts", () => {
+    const lineageRunId = "33333333-3333-4333-8333-333333333333";
+    expect(
+      unresolvedMeteringCandidate({
+        ...baseRun,
+        status: "cancelled",
+        config: { billingLineageRunId: lineageRunId },
+      }),
+    ).toMatchObject({
+      lineageRunId,
+      intentPrefix: `metering-intent:generation:${lineageRunId}:`,
+    });
+  });
+});

--- a/src/lib/billing/unresolved-metering.ts
+++ b/src/lib/billing/unresolved-metering.ts
@@ -1,0 +1,219 @@
+import "server-only";
+
+import { and, desc, eq, like, notExists, or, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+
+import { getDb, schema } from "@/db";
+import { resolveAuthoringIncident } from "@/lib/authoring-incidents";
+import type { GenerationConfig } from "@/lib/run-events";
+
+export type MeteringLineageRun = {
+  id: string;
+  projectId: string;
+  userId: string;
+  status: string;
+  config: unknown;
+};
+
+type MeteringLineageCandidate = MeteringLineageRun & {
+  lineageRunId: string;
+  intentPrefix: string;
+};
+
+function configuredBillingLineage(config: unknown): string | null {
+  if (!config || typeof config !== "object") return null;
+  const lineage = (config as Partial<GenerationConfig>).billingLineageRunId;
+  return typeof lineage === "string" && lineage.length > 0 ? lineage : null;
+}
+
+/**
+ * A pending provider intent is expected while a live call is in flight. It is
+ * evidence-unsafe only after the owning authoring attempt is terminal: at that
+ * point a replacement run would reuse the same logical billing key and could
+ * repeat a provider call whose charge is still ambiguous.
+ */
+export function unresolvedMeteringCandidate(
+  run: MeteringLineageRun,
+): MeteringLineageCandidate | null {
+  if (run.status !== "failed" && run.status !== "cancelled") return null;
+  const lineageRunId = configuredBillingLineage(run.config) ?? run.id;
+  return {
+    ...run,
+    lineageRunId,
+    intentPrefix: `metering-intent:generation:${lineageRunId}:`,
+  };
+}
+
+/**
+ * Return terminal attempts whose logical billing lineage still has a provider
+ * intent without a durable settled/aborted marker. This is a content-free,
+ * fail-closed read only: it never settles, aborts, refunds, or repeats work.
+ */
+export async function findRunsWithUnresolvedMetering(
+  runs: MeteringLineageRun[],
+): Promise<Set<string>> {
+  const candidates = runs.flatMap((run) => {
+    const candidate = unresolvedMeteringCandidate(run);
+    return candidate ? [candidate] : [];
+  });
+  if (candidates.length === 0) return new Set();
+
+  const db = getDb();
+  const terminalLedger = alias(schema.creditLedger, "terminal_metering_ledger");
+  const candidateFilter = or(
+    ...candidates.map((candidate) =>
+      and(
+        eq(schema.creditLedger.userId, candidate.userId),
+        eq(schema.creditLedger.projectId, candidate.projectId),
+        like(schema.creditLedger.externalRef, `${candidate.intentPrefix}%`),
+      ),
+    ),
+  );
+  if (!candidateFilter) return new Set();
+
+  const rows = await db
+    .select({
+      userId: schema.creditLedger.userId,
+      projectId: schema.creditLedger.projectId,
+      externalRef: schema.creditLedger.externalRef,
+    })
+    .from(schema.creditLedger)
+    .where(
+      and(
+        eq(schema.creditLedger.kind, "adjustment"),
+        eq(schema.creditLedger.amount, "0"),
+        candidateFilter,
+        notExists(
+          db
+            .select({ id: terminalLedger.id })
+            .from(terminalLedger)
+            .where(
+              or(
+                eq(
+                  terminalLedger.externalRef,
+                  sql<string>`'intent-settled:' || ${schema.creditLedger.externalRef}`,
+                ),
+                eq(
+                  terminalLedger.externalRef,
+                  sql<string>`'intent-aborted:' || ${schema.creditLedger.externalRef}`,
+                ),
+              ),
+            ),
+        ),
+      ),
+    );
+
+  const blocked = new Set<string>();
+  for (const row of rows) {
+    if (!row.externalRef) continue;
+    for (const candidate of candidates) {
+      if (
+        row.userId === candidate.userId &&
+        row.projectId === candidate.projectId &&
+        row.externalRef.startsWith(candidate.intentPrefix)
+      ) {
+        blocked.add(candidate.id);
+      }
+    }
+  }
+  return blocked;
+}
+
+/**
+ * Run-start preflight defense. Read the newest whole-book attempt regardless
+ * of state so an older terminal lineage cannot supersede a currently active
+ * or completed run. Only the terminal candidate rule above can block.
+ */
+export async function projectHasUnresolvedMetering(input: {
+  projectId: string;
+  userId: string;
+}): Promise<boolean> {
+  const [latestRun] = await getDb()
+    .select({
+      id: schema.generationRuns.id,
+      projectId: schema.generationRuns.projectId,
+      userId: schema.generationRuns.userId,
+      status: schema.generationRuns.status,
+      config: schema.generationRuns.config,
+    })
+    .from(schema.generationRuns)
+    .where(
+      and(
+        eq(schema.generationRuns.projectId, input.projectId),
+        eq(schema.generationRuns.userId, input.userId),
+        eq(schema.generationRuns.kind, "full_book"),
+      ),
+    )
+    .orderBy(desc(schema.generationRuns.createdAt))
+    .limit(1);
+  if (!latestRun) return false;
+  return (await findRunsWithUnresolvedMetering([latestRun])).has(latestRun.id);
+}
+
+const GENERATION_INTENT_LINEAGE = /^metering-intent:generation:([0-9a-f-]{36}):/i;
+
+export async function isMeteringIntentResolved(intentRef: string): Promise<boolean> {
+  if (!intentRef.startsWith("metering-intent:")) return false;
+  const [terminal] = await getDb()
+    .select({ id: schema.creditLedger.id })
+    .from(schema.creditLedger)
+    .where(
+      or(
+        eq(schema.creditLedger.externalRef, `intent-settled:${intentRef}`),
+        eq(schema.creditLedger.externalRef, `intent-aborted:${intentRef}`),
+      ),
+    )
+    .limit(1);
+  return Boolean(terminal);
+}
+
+/**
+ * A successful operator reconciliation writes the terminal ledger marker
+ * first. Only then may its derived blocking incidents be resolved, and only
+ * for runs in that exact logical billing lineage. A remaining open intent
+ * keeps every incident in place.
+ */
+export async function resolveReconciledMeteringIncidents(intentRef: string): Promise<number> {
+  const lineageRunId = GENERATION_INTENT_LINEAGE.exec(intentRef)?.[1];
+  if (!lineageRunId) return 0;
+  const db = getDb();
+  const [intent] = await db
+    .select({
+      projectId: schema.creditLedger.projectId,
+      userId: schema.creditLedger.userId,
+    })
+    .from(schema.creditLedger)
+    .where(eq(schema.creditLedger.externalRef, intentRef))
+    .limit(1);
+  if (!intent?.projectId) return 0;
+
+  const lineageRuns = await db
+    .select({
+      id: schema.generationRuns.id,
+      projectId: schema.generationRuns.projectId,
+      userId: schema.generationRuns.userId,
+      status: schema.generationRuns.status,
+      config: schema.generationRuns.config,
+    })
+    .from(schema.generationRuns)
+    .where(
+      and(
+        eq(schema.generationRuns.projectId, intent.projectId),
+        eq(schema.generationRuns.userId, intent.userId),
+        or(
+          eq(schema.generationRuns.id, lineageRunId),
+          sql`${schema.generationRuns.config}->>'billingLineageRunId' = ${lineageRunId}`,
+        ),
+      ),
+    );
+  if (lineageRuns.length === 0) return 0;
+
+  const stillBlocked = await findRunsWithUnresolvedMetering(lineageRuns);
+  const resolvedRuns = lineageRuns.filter((run) => !stillBlocked.has(run.id));
+  await Promise.all(
+    resolvedRuns.map((run) =>
+      resolveAuthoringIncident({ runId: run.id, dedupeKey: "unresolved-metering" }),
+    ),
+  );
+  return resolvedRuns.length;
+}

--- a/src/lib/email/send.test.ts
+++ b/src/lib/email/send.test.ts
@@ -1,26 +1,39 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMock = vi.hoisted(() => vi.fn().mockResolvedValue({ data: { id: "email-1" } }));
+const notificationMocks = vi.hoisted(() => ({
+  claim: vi.fn().mockResolvedValue("claim-token"),
+  settle: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("resend", () => ({
   Resend: class {
     emails = { send: sendMock };
   },
 }));
+vi.mock("@/lib/notification-preferences", () => ({
+  claimAuthoringNotificationDelivery: notificationMocks.claim,
+  settleAuthoringNotificationDelivery: notificationMocks.settle,
+}));
 
 import {
   escapeEmailHtml,
   sanitizeEmailSubject,
+  sendBookFinishedEmail,
+  sendCreativeDecisionEmail,
   sendCreditsPausedEmail,
   sendIncludedStoryPausedEmail,
   sendAuthoringNeedsAttentionEmail,
   sendOutlineApprovalEmail,
+  sendReceiptEmail,
 } from "./send";
 
 describe("transactional email safety", () => {
   beforeEach(() => {
     process.env.RESEND_API_KEY = "test-key";
     sendMock.mockClear();
+    notificationMocks.claim.mockReset().mockResolvedValue("claim-token");
+    notificationMocks.settle.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -45,6 +58,7 @@ describe("transactional email safety", () => {
 
   it("uses a stable pause-version idempotency key and escapes the title body", async () => {
     await sendOutlineApprovalEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: `<The "Road">`,
       projectId: "project-1",
@@ -61,10 +75,16 @@ describe("transactional email safety", () => {
     expect(message.html).toContain("&lt;The &quot;Road&quot;&gt;");
     expect(message.html).not.toContain(`<em><The`);
     expect(options).toEqual({ idempotencyKey: "run:run-1:outline-ready:3" });
+    expect(notificationMocks.claim).toHaveBeenCalledWith({
+      userId: "user-1",
+      category: "authoringActionRequired",
+      eventKey: "run:run-1:outline-ready:3",
+    });
   });
 
   it("routes an included-story pause to recovery without a purchase prompt", async () => {
     await sendIncludedStoryPausedEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: "The First Crossing",
       projectId: "project-1",
@@ -81,10 +101,16 @@ describe("transactional email safety", () => {
     expect(message.html).toContain("SPH-TEST-PAUSE");
     expect(message.html).not.toMatch(/add credits|checkout/i);
     expect(options).toEqual({ idempotencyKey: "run:run-1:included-story-paused:2" });
+    expect(notificationMocks.claim).toHaveBeenCalledWith({
+      userId: "user-1",
+      category: "authoringActionRequired",
+      eventKey: "run:run-1:included-story-paused:2",
+    });
   });
 
   it("deep-links a paid credit pause to its exact durable run", async () => {
     await sendCreditsPausedEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: "The Long Crossing",
       projectId: "11111111-1111-4111-8111-111111111111",
@@ -102,10 +128,16 @@ describe("transactional email safety", () => {
     expect(options).toEqual({
       idempotencyKey: "run:22222222-2222-4222-8222-222222222222:credits-paused:4",
     });
+    expect(notificationMocks.claim).toHaveBeenCalledWith({
+      userId: "user-1",
+      category: "authoringActionRequired",
+      eventKey: "run:22222222-2222-4222-8222-222222222222:credits-paused:4",
+    });
   });
 
   it("uses the authoritative full-book partial recovery action", async () => {
     await sendAuthoringNeedsAttentionEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: "The Crossing",
       runId: "run-partial",
@@ -121,10 +153,16 @@ describe("transactional email safety", () => {
     expect(message.html).toContain("https://sopher.ai/projects/project-1/write");
     expect(message.html).toContain("Resume from saved work");
     expect(message.html).not.toContain("https://sopher.ai/projects/project-1/editor");
+    expect(notificationMocks.claim).toHaveBeenCalledWith({
+      userId: "user-1",
+      category: "authoringActionRequired",
+      eventKey: "run:run-partial:needs-attention",
+    });
   });
 
   it("uses the authoritative scoped partial recovery action", async () => {
     await sendAuthoringNeedsAttentionEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: "The Crossing",
       runId: "run-scoped-partial",
@@ -143,6 +181,7 @@ describe("transactional email safety", () => {
 
   it("uses the authoritative zero-work start action", async () => {
     await sendAuthoringNeedsAttentionEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: "The Crossing",
       runId: "run-zero",
@@ -161,6 +200,7 @@ describe("transactional email safety", () => {
 
   it("uses Contact support for a completion contradiction", async () => {
     await sendAuthoringNeedsAttentionEmail({
+      userId: "user-1",
       to: "author@example.com",
       bookTitle: "The Crossing",
       runId: "run-contradiction",
@@ -178,5 +218,75 @@ describe("transactional email safety", () => {
     expect(message.html).toContain("Contact support");
     expect(message.html).not.toContain("/write");
     expect(message.html).not.toContain("/editor");
+  });
+
+  it("suppresses an optional notice before Resend and durably keeps its event decision", async () => {
+    notificationMocks.claim.mockResolvedValue(null);
+
+    await sendBookFinishedEmail({
+      userId: "user-1",
+      to: "author@example.com",
+      bookTitle: "Quiet Arrival",
+      projectId: "project-1",
+      runId: "run-quiet",
+      chapterCount: 3,
+      wordCount: 3000,
+    });
+
+    expect(notificationMocks.claim).toHaveBeenCalledWith({
+      userId: "user-1",
+      category: "authoringCompleted",
+      eventKey: "run:run-quiet:book-finished",
+    });
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(notificationMocks.settle).not.toHaveBeenCalled();
+  });
+
+  it("maps creative decisions and delayed outline reminders to distinct preferences", async () => {
+    await sendCreativeDecisionEmail({
+      userId: "user-1",
+      to: "author@example.com",
+      bookTitle: "A Fork in the Story",
+      projectId: "project-1",
+      runId: "run-guided",
+      pauseVersion: 2,
+    });
+    await sendOutlineApprovalEmail({
+      userId: "user-1",
+      to: "author@example.com",
+      bookTitle: "A Fork in the Story",
+      projectId: "project-1",
+      runId: "run-guided",
+      pauseVersion: 3,
+      reminder: true,
+    });
+
+    expect(notificationMocks.claim).toHaveBeenNthCalledWith(1, {
+      userId: "user-1",
+      category: "authoringActionRequired",
+      eventKey: "run:run-guided:creative-decision:2",
+    });
+    expect(notificationMocks.claim).toHaveBeenNthCalledWith(2, {
+      userId: "user-1",
+      category: "authoringReminders",
+      eventKey: "run:run-guided:outline-reminder:3",
+    });
+    expect(sendMock.mock.calls[0]?.[0].html).toContain("Manage email preferences");
+  });
+
+  it("never subjects a purchase receipt to optional authoring preferences", async () => {
+    notificationMocks.claim.mockResolvedValue(null);
+
+    await sendReceiptEmail({
+      to: "author@example.com",
+      packName: "Story",
+      credits: 12,
+      usd: 10,
+      idempotencyKey: "receipt-1",
+    });
+
+    expect(notificationMocks.claim).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0]?.[1]).toEqual({ idempotencyKey: "receipt-1" });
   });
 });

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -2,6 +2,12 @@ import "server-only";
 
 import { Resend } from "resend";
 
+import {
+  claimAuthoringNotificationDelivery,
+  settleAuthoringNotificationDelivery,
+} from "@/lib/notification-preferences";
+import type { AuthoringNotificationCategory } from "@/lib/notification-preferences-shared";
+
 /**
  * Transactional email. Every message is triggered by an author action or a
  * state that now needs the author's attention. No marketing and no progress
@@ -49,7 +55,7 @@ export function sanitizeEmailSubject(value: string): string {
     .slice(0, 200);
 }
 
-function shell(title: string, bodyHtml: string): string {
+function shell(title: string, bodyHtml: string, managePreferences = false): string {
   return `<!doctype html>
 <html>
   <body style="margin:0;padding:24px;background:#f7f6f3;font-family:Georgia,'Times New Roman',serif;color:#14161c;">
@@ -61,6 +67,11 @@ function shell(title: string, bodyHtml: string): string {
     <p style="max-width:520px;margin:16px auto 0;font-family:ui-sans-serif,system-ui,sans-serif;font-size:12px;color:#7c8296;">
       Sent because of activity on your sopher.ai account. Questions:
       <a href="mailto:support@sopher.ai" style="color:#4a5fd0;">support@sopher.ai</a>
+      ${
+        managePreferences
+          ? ' · <a href="https://sopher.ai/studio/settings#email-notifications" style="color:#4a5fd0;">Manage email preferences</a>'
+          : ""
+      }
     </p>
   </body>
 </html>`;
@@ -76,27 +87,68 @@ async function deliver(
   subject: string,
   html: string,
   idempotencyKey?: string,
+  optional?: {
+    userId: string;
+    category: AuthoringNotificationCategory;
+    eventKey: string;
+  },
 ): Promise<void> {
+  if (!to) return;
   const resend = getResend();
-  if (!resend || !to) return;
+  if (!resend) return;
+
+  let claimToken: string | null = null;
+  if (optional) {
+    try {
+      claimToken = await claimAuthoringNotificationDelivery(optional);
+      if (!claimToken) return;
+    } catch (error) {
+      // Optional email fails closed. The authoritative next action remains in Studio.
+      console.warn("[email] optional delivery could not be claimed", {
+        category: optional.category,
+        error: error instanceof Error ? error.message : "unknown error",
+      });
+      return;
+    }
+  }
+
+  let delivered = false;
   try {
-    await resend.emails.send(
+    const result = await resend.emails.send(
       { from: FROM, to, subject, html },
       idempotencyKey ? { idempotencyKey } : undefined,
     );
+    if (result.error) throw new Error(result.error.message);
+    delivered = true;
   } catch (error) {
     // Email is best-effort by design; the product state is already correct.
     console.warn("[email] send failed:", error instanceof Error ? error.message : error);
   }
+  if (optional && claimToken) {
+    try {
+      await settleAuthoringNotificationDelivery({
+        eventKey: optional.eventKey,
+        claimToken,
+        delivered,
+      });
+    } catch (error) {
+      // Resend's idempotency key still protects a replay if settlement is unavailable.
+      console.warn("[email] optional delivery settlement failed", {
+        category: optional.category,
+        error: error instanceof Error ? error.message : "unknown error",
+      });
+    }
+  }
 }
 
 export async function sendBookFinishedEmail(input: {
+  userId: string;
   to: string;
   bookTitle: string;
   projectId: string;
   chapterCount: number;
   wordCount: number;
-  runId?: string;
+  runId: string;
 }): Promise<void> {
   const url = `https://sopher.ai/projects/${input.projectId}/manuscript`;
   const title = escapeEmailHtml(input.bookTitle);
@@ -110,23 +162,30 @@ export async function sendBookFinishedEmail(input: {
           "en-US",
         )} words — is written, edited, and waiting for you.`,
       ) + cta(url, "Open your manuscript"),
+      true,
     ),
-    input.runId ? `run:${input.runId}:book-finished` : undefined,
+    `run:${input.runId}:book-finished`,
+    {
+      userId: input.userId,
+      category: "authoringCompleted",
+      eventKey: `run:${input.runId}:book-finished`,
+    },
   );
 }
 
 export async function sendCreditsPausedEmail(input: {
+  userId: string;
   to: string;
   bookTitle: string;
   projectId: string;
   balance: number;
   required: number;
-  runId?: string;
+  runId: string;
   pauseVersion?: number;
 }): Promise<void> {
   const url = `https://sopher.ai/studio/credits?return=${encodeURIComponent(
     `/projects/${input.projectId}/write`,
-  )}${input.runId ? `&resumeRun=${encodeURIComponent(input.runId)}` : ""}`;
+  )}&resumeRun=${encodeURIComponent(input.runId)}`;
   const title = escapeEmailHtml(input.bookTitle);
   await deliver(
     input.to,
@@ -136,12 +195,19 @@ export async function sendCreditsPausedEmail(input: {
       p(
         `<em>${title}</em> needs about ${Math.ceil(input.required)} credits to continue and your balance is ${input.balance.toFixed(1)}. Every chapter drafted so far is safe; the book picks up exactly where it stopped once you top up.`,
       ) + cta(url, "Add credits and resume"),
+      true,
     ),
-    input.runId ? `run:${input.runId}:credits-paused:${input.pauseVersion ?? 0}` : undefined,
+    `run:${input.runId}:credits-paused:${input.pauseVersion ?? 0}`,
+    {
+      userId: input.userId,
+      category: "authoringActionRequired",
+      eventKey: `run:${input.runId}:credits-paused:${input.pauseVersion ?? 0}`,
+    },
   );
 }
 
 export async function sendIncludedStoryPausedEmail(input: {
+  userId: string;
   to: string;
   bookTitle: string;
   projectId: string;
@@ -161,12 +227,19 @@ export async function sendIncludedStoryPausedEmail(input: {
       ) +
         p(`Support reference: <strong>${escapeEmailHtml(input.supportReference)}</strong>`) +
         cta(url, "Review recovery options"),
+      true,
     ),
     `run:${input.runId}:included-story-paused:${input.pauseVersion ?? 0}`,
+    {
+      userId: input.userId,
+      category: "authoringActionRequired",
+      eventKey: `run:${input.runId}:included-story-paused:${input.pauseVersion ?? 0}`,
+    },
   );
 }
 
 export async function sendOutlineApprovalEmail(input: {
+  userId: string;
   to: string;
   bookTitle: string;
   projectId: string;
@@ -188,12 +261,45 @@ export async function sendOutlineApprovalEmail(input: {
       p(
         `We have paused before drafting <em>${title}</em>. Review the plan, then approve it or send it back with notes. No chapters will be written until you decide.`,
       ) + cta(url, "Review the outline"),
+      true,
     ),
     `run:${input.runId}:outline-${input.reminder ? "reminder" : "ready"}:${input.pauseVersion}`,
+    {
+      userId: input.userId,
+      category: input.reminder ? "authoringReminders" : "authoringActionRequired",
+      eventKey: `run:${input.runId}:outline-${input.reminder ? "reminder" : "ready"}:${input.pauseVersion}`,
+    },
+  );
+}
+
+export async function sendCreativeDecisionEmail(input: {
+  userId: string;
+  to: string;
+  bookTitle: string;
+  projectId: string;
+  runId: string;
+  pauseVersion: number;
+}): Promise<void> {
+  const url = `https://sopher.ai/projects/${input.projectId}/write`;
+  const title = escapeEmailHtml(input.bookTitle);
+  const eventKey = `run:${input.runId}:creative-decision:${input.pauseVersion}`;
+  await deliver(
+    input.to,
+    sanitizeEmailSubject(`Choose the direction for “${input.bookTitle}”`),
+    shell(
+      "Your story is ready for your direction.",
+      p(
+        `We have developed the central journey for <em>${title}</em> and paused before outlining. Choose a suggested direction, write your own, or ask Sopher to decide.`,
+      ) + cta(url, "Choose the story direction"),
+      true,
+    ),
+    eventKey,
+    { userId: input.userId, category: "authoringActionRequired", eventKey },
   );
 }
 
 export async function sendAuthoringNeedsAttentionEmail(input: {
+  userId: string;
   to: string;
   bookTitle: string;
   runId: string;
@@ -223,8 +329,14 @@ export async function sendAuthoringNeedsAttentionEmail(input: {
       p(`<em>${title}</em> stopped before production completed. ${savedWork}`) +
         p(`Support reference: <strong>${escapeEmailHtml(input.supportReference)}</strong>`) +
         cta(escapeEmailHtml(url), escapeEmailHtml(input.nextActionLabel)),
+      true,
     ),
     `run:${input.runId}:needs-attention`,
+    {
+      userId: input.userId,
+      category: "authoringActionRequired",
+      eventKey: `run:${input.runId}:needs-attention`,
+    },
   );
 }
 

--- a/src/lib/notification-preferences-shared.ts
+++ b/src/lib/notification-preferences-shared.ts
@@ -1,0 +1,27 @@
+export const NOTIFICATION_PREFERENCES_VERSION = 1 as const;
+
+export const AUTHORING_NOTIFICATION_CATEGORIES = [
+  "authoringActionRequired",
+  "authoringReminders",
+  "authoringCompleted",
+] as const;
+
+export type AuthoringNotificationCategory = (typeof AUTHORING_NOTIFICATION_CATEGORIES)[number];
+
+export type NotificationPreferences = {
+  version: typeof NOTIFICATION_PREFERENCES_VERSION;
+  authoringActionRequired: boolean;
+  authoringReminders: boolean;
+  authoringCompleted: boolean;
+};
+
+/**
+ * Preserve the established authoring experience for existing accounts. Authors
+ * can then opt out of any optional notice from account settings.
+ */
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = Object.freeze({
+  version: NOTIFICATION_PREFERENCES_VERSION,
+  authoringActionRequired: true,
+  authoringReminders: true,
+  authoringCompleted: true,
+});

--- a/src/lib/notification-preferences.integration.test.ts
+++ b/src/lib/notification-preferences.integration.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+
+import { neon } from "@neondatabase/serverless";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  claimAuthoringNotificationDelivery,
+  getNotificationPreferences,
+  settleAuthoringNotificationDelivery,
+  updateNotificationPreferences,
+} from "@/lib/notification-preferences";
+
+function isolatedDatabaseUrl(): string | null {
+  const isolated = process.env.E2E_DATABASE_ISOLATED;
+  const value = process.env.E2E_DATABASE_URL?.trim();
+  if (isolated !== "1" && !value) return null;
+  if (isolated !== "1" || !value || process.env.NODE_ENV === "production") {
+    throw new Error("Notification preference tests require a disposable isolated database.");
+  }
+  const parsed = new URL(value);
+  const allowedHost = process.env.E2E_DATABASE_HOST?.trim();
+  if (!allowedHost || parsed.hostname !== allowedHost) {
+    throw new Error("E2E_DATABASE_HOST must match the disposable notification test database.");
+  }
+  return value;
+}
+
+const databaseUrl = isolatedDatabaseUrl();
+const describeIsolated = databaseUrl ? describe : describe.skip;
+
+describeIsolated("notification preferences against isolated Neon", () => {
+  const userId = `e2e-notifications-${randomUUID()}`;
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  let observer: ReturnType<typeof neon>;
+
+  beforeAll(async () => {
+    if (!databaseUrl) throw new Error("Disposable database URL disappeared.");
+    process.env.DATABASE_URL = databaseUrl;
+    observer = neon(databaseUrl);
+    await observer`
+      insert into users (id, email)
+      values (${userId}, ${`${userId}@example.test`})
+    `;
+  });
+
+  afterAll(async () => {
+    if (observer) await observer`delete from users where id = ${userId}`;
+    if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previousDatabaseUrl;
+  });
+
+  it("defaults every existing authoring category on and preserves concurrent field updates", async () => {
+    await expect(getNotificationPreferences(userId)).resolves.toEqual({
+      version: 1,
+      authoringActionRequired: true,
+      authoringReminders: true,
+      authoringCompleted: true,
+    });
+
+    await Promise.all([
+      updateNotificationPreferences(userId, { authoringActionRequired: false }),
+      updateNotificationPreferences(userId, { authoringCompleted: false }),
+    ]);
+
+    await expect(getNotificationPreferences(userId)).resolves.toEqual({
+      version: 1,
+      authoringActionRequired: false,
+      authoringReminders: true,
+      authoringCompleted: false,
+    });
+  });
+
+  it("makes suppression durable across later opt-in and makes sent events replay-safe", async () => {
+    const suppressedKey = `run:${randomUUID()}:needs-attention`;
+    await updateNotificationPreferences(userId, { authoringActionRequired: false });
+    await expect(
+      claimAuthoringNotificationDelivery({
+        userId,
+        category: "authoringActionRequired",
+        eventKey: suppressedKey,
+      }),
+    ).resolves.toBeNull();
+
+    await updateNotificationPreferences(userId, { authoringActionRequired: true });
+    await expect(
+      claimAuthoringNotificationDelivery({
+        userId,
+        category: "authoringActionRequired",
+        eventKey: suppressedKey,
+      }),
+    ).resolves.toBeNull();
+
+    const sentKey = `run:${randomUUID()}:book-finished`;
+    await updateNotificationPreferences(userId, { authoringCompleted: true });
+    const sentClaim = await claimAuthoringNotificationDelivery({
+      userId,
+      category: "authoringCompleted",
+      eventKey: sentKey,
+    });
+    expect(sentClaim).toEqual(expect.any(String));
+    if (!sentClaim) throw new Error("Expected a delivery claim");
+    await settleAuthoringNotificationDelivery({
+      eventKey: sentKey,
+      claimToken: sentClaim,
+      delivered: true,
+    });
+    await expect(
+      claimAuthoringNotificationDelivery({
+        userId,
+        category: "authoringCompleted",
+        eventKey: sentKey,
+      }),
+    ).resolves.toBeNull();
+
+    const rows = (await observer`
+      select event_key, status, attempts
+      from notification_deliveries
+      where user_id = ${userId}
+      order by event_key
+    `) as unknown as Array<{ event_key: string; status: string; attempts: number }>;
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { event_key: suppressedKey, status: "suppressed", attempts: 0 },
+        { event_key: sentKey, status: "sent", attempts: 1 },
+      ]),
+    );
+  });
+
+  it("grants one concurrent lease and never lets a stale failure downgrade sent mail", async () => {
+    const eventKey = `run:${randomUUID()}:outline-ready:1`;
+    await updateNotificationPreferences(userId, { authoringActionRequired: true });
+
+    const claims = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        claimAuthoringNotificationDelivery({
+          userId,
+          category: "authoringActionRequired",
+          eventKey,
+        }),
+      ),
+    );
+    const winners = claims.filter((claim): claim is string => claim !== null);
+    expect(winners).toHaveLength(1);
+
+    await settleAuthoringNotificationDelivery({
+      eventKey,
+      claimToken: winners[0],
+      delivered: true,
+    });
+    await settleAuthoringNotificationDelivery({
+      eventKey,
+      claimToken: randomUUID(),
+      delivered: false,
+    });
+
+    const rows = (await observer`
+      select status, attempts, claim_token, lease_expires_at
+      from notification_deliveries
+      where event_key = ${eventKey}
+    `) as unknown as Array<{
+      status: string;
+      attempts: number;
+      claim_token: string | null;
+      lease_expires_at: Date | null;
+    }>;
+    expect(rows).toEqual([
+      {
+        status: "sent",
+        attempts: 1,
+        claim_token: null,
+        lease_expires_at: null,
+      },
+    ]);
+  });
+});

--- a/src/lib/notification-preferences.test.ts
+++ b/src/lib/notification-preferences.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ getDb: vi.fn() }));
+
+vi.mock("@/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/db")>();
+  return { ...actual, getDb: mocks.getDb };
+});
+
+import {
+  maySendAuthoringNotification,
+  notificationPreferencesFromRow,
+} from "@/lib/notification-preferences";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("notification preference normalization", () => {
+  it("defaults legacy or absent rows to the established enabled behavior", () => {
+    expect(notificationPreferencesFromRow()).toEqual({
+      version: 1,
+      authoringActionRequired: true,
+      authoringReminders: true,
+      authoringCompleted: true,
+    });
+  });
+
+  it("preserves explicit false values", () => {
+    expect(
+      notificationPreferencesFromRow({
+        authoringActionRequired: false,
+        authoringReminders: false,
+        authoringCompleted: false,
+      }),
+    ).toEqual({
+      version: 1,
+      authoringActionRequired: false,
+      authoringReminders: false,
+      authoringCompleted: false,
+    });
+  });
+
+  it("fails optional delivery closed when the latest account preference cannot be read", async () => {
+    mocks.getDb.mockReturnValue({
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockRejectedValue(new Error("database unavailable")),
+          })),
+        })),
+      })),
+    });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(maySendAuthoringNotification("user-1", "authoringActionRequired")).resolves.toBe(
+      false,
+    );
+    expect(warning).toHaveBeenCalledWith(
+      "[email] notification preference could not be resolved",
+      expect.objectContaining({ category: "authoringActionRequired" }),
+    );
+    warning.mockRestore();
+  });
+});

--- a/src/lib/notification-preferences.ts
+++ b/src/lib/notification-preferences.ts
@@ -1,0 +1,243 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+
+import { and, eq, isNull, lte, or, sql } from "drizzle-orm";
+
+import { getDb, schema } from "@/db";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  NOTIFICATION_PREFERENCES_VERSION,
+  type AuthoringNotificationCategory,
+  type NotificationPreferences,
+} from "@/lib/notification-preferences-shared";
+
+type NotificationPreferenceRow = {
+  authoringActionRequired: boolean;
+  authoringReminders: boolean;
+  authoringCompleted: boolean;
+};
+
+const preferenceSelection = {
+  authoringActionRequired: schema.users.emailAuthoringActionRequired,
+  authoringReminders: schema.users.emailAuthoringReminders,
+  authoringCompleted: schema.users.emailAuthoringCompleted,
+};
+
+export type NotificationPreferencesUpdate = Partial<
+  Pick<
+    NotificationPreferences,
+    "authoringActionRequired" | "authoringReminders" | "authoringCompleted"
+  >
+>;
+
+export function notificationPreferencesFromRow(
+  row?: Partial<NotificationPreferenceRow> | null,
+): NotificationPreferences {
+  return {
+    version: NOTIFICATION_PREFERENCES_VERSION,
+    authoringActionRequired:
+      row?.authoringActionRequired ?? DEFAULT_NOTIFICATION_PREFERENCES.authoringActionRequired,
+    authoringReminders:
+      row?.authoringReminders ?? DEFAULT_NOTIFICATION_PREFERENCES.authoringReminders,
+    authoringCompleted:
+      row?.authoringCompleted ?? DEFAULT_NOTIFICATION_PREFERENCES.authoringCompleted,
+  };
+}
+
+export async function getNotificationPreferences(userId: string): Promise<NotificationPreferences> {
+  const [row] = await getDb()
+    .select(preferenceSelection)
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  return notificationPreferencesFromRow(row);
+}
+
+export async function getNotificationSettings(userId: string): Promise<{
+  email: string;
+  preferences: NotificationPreferences;
+}> {
+  const [row] = await getDb()
+    .select({ email: schema.users.email, ...preferenceSelection })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  if (!row) throw new Error("User not found");
+  return { email: row.email, preferences: notificationPreferencesFromRow(row) };
+}
+
+/** Each PATCH changes only the supplied columns, so concurrent toggles cannot overwrite siblings. */
+export async function updateNotificationPreferences(
+  userId: string,
+  update: NotificationPreferencesUpdate,
+): Promise<NotificationPreferences> {
+  const values = {
+    ...(update.authoringActionRequired === undefined
+      ? {}
+      : { emailAuthoringActionRequired: update.authoringActionRequired }),
+    ...(update.authoringReminders === undefined
+      ? {}
+      : { emailAuthoringReminders: update.authoringReminders }),
+    ...(update.authoringCompleted === undefined
+      ? {}
+      : { emailAuthoringCompleted: update.authoringCompleted }),
+    updatedAt: new Date(),
+  };
+  const [row] = await getDb()
+    .update(schema.users)
+    .set(values)
+    .where(eq(schema.users.id, userId))
+    .returning(preferenceSelection);
+  if (!row) throw new Error("User not found");
+  return notificationPreferencesFromRow(row);
+}
+
+/**
+ * Optional email fails closed when its owner or latest preference cannot be
+ * resolved. Authoring itself must continue, and billing/security mail does not
+ * call this boundary.
+ */
+export async function maySendAuthoringNotification(
+  userId: string,
+  category: AuthoringNotificationCategory,
+): Promise<boolean> {
+  try {
+    const [row] = await getDb()
+      .select({ enabled: preferenceSelection[category] })
+      .from(schema.users)
+      .where(eq(schema.users.id, userId))
+      .limit(1);
+    return row?.enabled === true;
+  } catch (error) {
+    console.warn("[email] notification preference could not be resolved", {
+      category,
+      error: error instanceof Error ? error.message : "unknown error",
+    });
+    return false;
+  }
+}
+
+/**
+ * Claims one content-free delivery event. The first preference decision is
+ * durable: a suppressed event stays suppressed even if a later replay happens
+ * after the author has opted back in.
+ */
+export async function claimAuthoringNotificationDelivery(input: {
+  userId: string;
+  category: AuthoringNotificationCategory;
+  eventKey: string;
+}): Promise<string | null> {
+  const enabled = await maySendAuthoringNotification(input.userId, input.category);
+  const now = new Date();
+  const claimToken = randomUUID();
+  const leaseExpiresAt = new Date(now.getTime() + 10 * 60 * 1000);
+  const [inserted] = await getDb()
+    .insert(schema.notificationDeliveries)
+    .values({
+      userId: input.userId,
+      category: input.category,
+      eventKey: input.eventKey,
+      status: enabled ? "pending" : "suppressed",
+      attempts: enabled ? 1 : 0,
+      ...(enabled ? { claimToken, leaseExpiresAt } : {}),
+      updatedAt: now,
+    })
+    .onConflictDoNothing({ target: schema.notificationDeliveries.eventKey })
+    .returning({
+      status: schema.notificationDeliveries.status,
+      claimToken: schema.notificationDeliveries.claimToken,
+    });
+  if (inserted) return inserted.status === "pending" ? inserted.claimToken : null;
+
+  const [existing] = await getDb()
+    .select({
+      userId: schema.notificationDeliveries.userId,
+      category: schema.notificationDeliveries.category,
+      status: schema.notificationDeliveries.status,
+      leaseExpiresAt: schema.notificationDeliveries.leaseExpiresAt,
+    })
+    .from(schema.notificationDeliveries)
+    .where(eq(schema.notificationDeliveries.eventKey, input.eventKey))
+    .limit(1);
+  if (
+    !existing ||
+    existing.userId !== input.userId ||
+    existing.category !== input.category ||
+    existing.status === "sent" ||
+    existing.status === "suppressed"
+  ) {
+    return null;
+  }
+
+  if (existing.status === "failed" && !enabled) {
+    await getDb()
+      .update(schema.notificationDeliveries)
+      .set({
+        status: "suppressed",
+        claimToken: null,
+        leaseExpiresAt: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.notificationDeliveries.eventKey, input.eventKey),
+          eq(schema.notificationDeliveries.status, "failed"),
+        ),
+      );
+    return null;
+  }
+
+  const [reclaimed] = await getDb()
+    .update(schema.notificationDeliveries)
+    .set({
+      status: "pending",
+      attempts: sql`${schema.notificationDeliveries.attempts} + 1`,
+      claimToken,
+      leaseExpiresAt,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.notificationDeliveries.eventKey, input.eventKey),
+        eq(schema.notificationDeliveries.userId, input.userId),
+        eq(schema.notificationDeliveries.category, input.category),
+        or(
+          eq(schema.notificationDeliveries.status, "failed"),
+          and(
+            eq(schema.notificationDeliveries.status, "pending"),
+            or(
+              isNull(schema.notificationDeliveries.leaseExpiresAt),
+              lte(schema.notificationDeliveries.leaseExpiresAt, now),
+            ),
+          ),
+        ),
+      ),
+    )
+    .returning({ claimToken: schema.notificationDeliveries.claimToken });
+  return reclaimed?.claimToken ?? null;
+}
+
+export async function settleAuthoringNotificationDelivery(input: {
+  eventKey: string;
+  claimToken: string;
+  delivered: boolean;
+}): Promise<void> {
+  const now = new Date();
+  await getDb()
+    .update(schema.notificationDeliveries)
+    .set({
+      status: input.delivered ? "sent" : "failed",
+      ...(input.delivered ? { sentAt: now } : {}),
+      claimToken: null,
+      leaseExpiresAt: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.notificationDeliveries.eventKey, input.eventKey),
+        eq(schema.notificationDeliveries.claimToken, input.claimToken),
+        eq(schema.notificationDeliveries.status, "pending"),
+      ),
+    );
+}

--- a/src/lib/run-health.ts
+++ b/src/lib/run-health.ts
@@ -1207,6 +1207,7 @@ async function notifyRunNeedsAttention(run: RunForHealth, health: RunHealth): Pr
       supportReference: health.supportReference,
     });
     await sendAuthoringNeedsAttentionEmail({
+      userId: run.userId,
       to: row.email,
       bookTitle: row.title,
       runId: run.id,

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -4,6 +4,7 @@ import {
   AUTHORING_RUN_INACTIVE_MESSAGE,
 } from "@/lib/authoring-cancellation";
 import { withPreservedPrimaryError } from "@/lib/async-cleanup";
+import { authoringFailureMessage, classifyAuthoringFailure } from "@/lib/authoring-failures";
 import { notifyAuthoringFailureStep } from "./notify-authoring-failure";
 import { OUTLINE_REVISION_RESERVATION_KEY, type GenerationConfig } from "@/lib/run-events";
 import type { Stage } from "@/lib/run-events";
@@ -565,13 +566,19 @@ export async function generateBook(
     await finalizeStep(ref, report.recommendation);
     return { score: report.score, recommendation: report.recommendation };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Generation failed";
+    const message = authoringFailureMessage(error);
+    const failure = classifyAuthoringFailure(error);
     if (message === AUTHORING_RUN_INACTIVE_MESSAGE) {
       throw error instanceof FatalError ? error : new FatalError(message);
     }
     const cancelled = message === AUTHORING_CANCELLATION_MESSAGE;
     try {
-      await markRunStatus(ref, cancelled ? "cancelled" : "failed", message);
+      await markRunStatus(
+        ref,
+        cancelled ? "cancelled" : "failed",
+        message,
+        cancelled ? undefined : failure,
+      );
       if (!cancelled) await notifyAuthoringFailureStep(ref);
     } catch (statusError) {
       console.error("Could not persist the initiating authoring failure", {

--- a/src/workflows/generate-book.ts
+++ b/src/workflows/generate-book.ts
@@ -35,6 +35,7 @@ import {
   markCreativeQuestionPauseRegisteredStep,
   hydratePreManuscriptRetryStep,
   notifyCreditsPausedStep,
+  notifyCreativeDecisionStep,
   notifyOutlineApprovalStep,
   openingCreditCheckStep,
   initialOutlineCreditCheckStep,
@@ -246,6 +247,7 @@ export async function generateBook(
           agent: "outliner",
           message: "Waiting for your story direction before building the outline",
         });
+        await notifyCreativeDecisionStep(ref, pause.version);
         const delivery = await hook;
         const decision = await consumeCreativeDecisionStep(ref, pause.version, delivery.inputId);
         if (!decision) {

--- a/src/workflows/notify-authoring-failure.ts
+++ b/src/workflows/notify-authoring-failure.ts
@@ -59,6 +59,7 @@ export async function notifyAuthoringFailureStep(ref: {
       supportReference: facts.supportReference,
     });
     await sendAuthoringNeedsAttentionEmail({
+      userId: ref.userId,
       to: facts.email,
       bookTitle: facts.title,
       runId: ref.dbRunId,

--- a/src/workflows/outline-reminder.ts
+++ b/src/workflows/outline-reminder.ts
@@ -15,6 +15,7 @@ async function sendOutlineReminderIfStillWaiting(
       status: schema.generationRuns.status,
       pauseKind: schema.generationRuns.pauseKind,
       pauseVersion: schema.generationRuns.pauseVersion,
+      userId: schema.generationRuns.userId,
       email: schema.users.email,
       title: schema.projects.title,
     })
@@ -32,6 +33,7 @@ async function sendOutlineReminderIfStillWaiting(
     return;
   }
   await sendOutlineApprovalEmail({
+    userId: row.userId,
     to: row.email,
     bookTitle: row.title,
     projectId,

--- a/src/workflows/steps-status.test.ts
+++ b/src/workflows/steps-status.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   transition: vi.fn(),
   withDbTransaction: vi.fn(),
+  recordAuthoringIncident: vi.fn(),
 }));
 
 vi.mock("@/db", async (importOriginal) => {
@@ -15,12 +16,18 @@ vi.mock("@/lib/generation-runs", async (importOriginal) => {
   return { ...actual, transitionAuthoringRunState: mocks.transition };
 });
 
+vi.mock("@/lib/authoring-incidents", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/authoring-incidents")>();
+  return { ...actual, recordAuthoringIncident: mocks.recordAuthoringIncident };
+});
+
 import { markRunStatus, withActiveAuthoringMutation } from "./steps";
 
 const ref = { dbRunId: "run-1", projectId: "project-1", userId: "user-1" };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.recordAuthoringIncident.mockResolvedValue(undefined);
   mocks.transition.mockImplementation(async (input: { status: string }) => ({
     status: input.status,
     transitioned: true,
@@ -43,6 +50,52 @@ describe("markRunStatus transition boundary", () => {
       });
     },
   );
+
+  it("persists unresolved metering as structured root evidence and a critical incident", async () => {
+    await markRunStatus(ref, "failed", "reconciliation is required", {
+      errorCode: "metering_reconciliation_required",
+      errorStage: "concept",
+      incidentCategory: "unresolved_metering",
+    });
+
+    expect(mocks.transition).toHaveBeenCalledWith({
+      runId: "run-1",
+      projectId: "project-1",
+      userId: "user-1",
+      status: "failed",
+      error: "reconciliation is required",
+      errorCode: "metering_reconciliation_required",
+      errorStage: "concept",
+    });
+    expect(mocks.recordAuthoringIncident).toHaveBeenCalledWith({
+      runId: "run-1",
+      projectId: "project-1",
+      category: "unresolved_metering",
+      severity: "critical",
+      dedupeKey: "unresolved-metering",
+      evidence: {
+        errorCode: "metering_reconciliation_required",
+        stage: "concept",
+      },
+    });
+  });
+
+  it("keeps settled usage with a missing output checkpoint blocked as a completion contradiction", async () => {
+    await markRunStatus(ref, "failed", "The settled output checkpoint is missing", {
+      errorCode: "metered_output_missing",
+      errorStage: "concept",
+      incidentCategory: "completion_contradiction",
+    });
+
+    expect(mocks.recordAuthoringIncident).toHaveBeenCalledWith({
+      runId: "run-1",
+      projectId: "project-1",
+      category: "completion_contradiction",
+      severity: "critical",
+      dedupeKey: "settled-output-missing",
+      evidence: { errorCode: "metered_output_missing", stage: "concept" },
+    });
+  });
 
   it("classifies a cancellation that wins before work starts as cancellation", async () => {
     mocks.transition.mockResolvedValue({ status: "cancelled", transitioned: false });

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -35,6 +35,7 @@ import { getOrCreateBook } from "@/db/queries/projects";
 import { listEntities, seedEntities } from "@/db/queries/entities";
 import {
   sendBookFinishedEmail,
+  sendCreativeDecisionEmail,
   sendCreditsPausedEmail,
   sendIncludedStoryPausedEmail,
   sendOutlineApprovalEmail,
@@ -2764,6 +2765,7 @@ export async function finalizeStep(ref: RunRef, detail?: string): Promise<void> 
       .limit(1);
     if (row?.email) {
       await sendBookFinishedEmail({
+        userId: ref.userId,
         to: row.email,
         bookTitle: row.title,
         projectId: ref.projectId,
@@ -2808,6 +2810,7 @@ export async function notifyCreditsPausedStep(
     if (row?.email) {
       if (row.experience === "trial_short_story") {
         await sendIncludedStoryPausedEmail({
+          userId: ref.userId,
           to: row.email,
           bookTitle: row.title,
           projectId: ref.projectId,
@@ -2817,6 +2820,7 @@ export async function notifyCreditsPausedStep(
         });
       } else {
         await sendCreditsPausedEmail({
+          userId: ref.userId,
           to: row.email,
           bookTitle: row.title,
           projectId: ref.projectId,
@@ -2845,6 +2849,7 @@ export async function notifyOutlineApprovalStep(ref: RunRef, pauseVersion: numbe
       .limit(1);
     if (row?.email) {
       await sendOutlineApprovalEmail({
+        userId: ref.userId,
         to: row.email,
         bookTitle: row.title,
         projectId: ref.projectId,
@@ -2863,5 +2868,29 @@ export async function notifyOutlineApprovalStep(ref: RunRef, pauseVersion: numbe
     }
   } catch (error) {
     console.warn("[email] outline-approval notification failed:", error);
+  }
+}
+
+/** Emails one idempotent notice only after the creative-direction hook is actionable. */
+export async function notifyCreativeDecisionStep(ref: RunRef, pauseVersion: number): Promise<void> {
+  "use step";
+  try {
+    const [row] = await getDb()
+      .select({ email: schema.users.email, title: schema.projects.title })
+      .from(schema.projects)
+      .innerJoin(schema.users, eq(schema.users.id, schema.projects.userId))
+      .where(and(eq(schema.projects.id, ref.projectId), eq(schema.projects.userId, ref.userId)))
+      .limit(1);
+    if (!row?.email) return;
+    await sendCreativeDecisionEmail({
+      userId: ref.userId,
+      to: row.email,
+      bookTitle: row.title,
+      projectId: ref.projectId,
+      runId: ref.dbRunId,
+      pauseVersion,
+    });
+  } catch (error) {
+    console.warn("[email] creative-decision notification failed:", error);
   }
 }

--- a/src/workflows/steps.ts
+++ b/src/workflows/steps.ts
@@ -86,6 +86,7 @@ import { buildFrozenAuthoringContract } from "@/ai/authoring-guidelines";
 import { linkAuthoringRunWorkflow, transitionAuthoringRunState } from "@/lib/generation-runs";
 import { nextRunEventSequence, persistRunEvent } from "@/lib/run-event-store";
 import { recordAuthoringIncident, resolveAuthoringIncident } from "@/lib/authoring-incidents";
+import type { AuthoringFailureDetails } from "@/lib/authoring-failures";
 import {
   AUTHORING_CANCELLATION_MESSAGE,
   AUTHORING_RUN_INACTIVE_MESSAGE,
@@ -659,6 +660,7 @@ export async function markRunStatus(
   ref: RunRef,
   status: RequestedRunStatus,
   error?: string,
+  failure?: AuthoringFailureDetails,
 ): Promise<MarkRunStatusOutcome> {
   "use step";
   const result = await transitionAuthoringRunState({
@@ -667,6 +669,8 @@ export async function markRunStatus(
     userId: ref.userId,
     status,
     error,
+    ...(failure?.errorCode ? { errorCode: failure.errorCode } : {}),
+    ...(failure?.errorStage ? { errorStage: failure.errorStage } : {}),
     ...(status === "completed" ? { resolveCancellationOnComplete: true } : {}),
   });
   if (status !== "cancelled" && result.status === "cancelled") {
@@ -680,6 +684,22 @@ export async function markRunStatus(
       return { outcome: "terminal_preserved", status: result.status };
     }
     throw new FatalError("Generation run is no longer active");
+  }
+  if (status === "failed" && failure?.incidentCategory) {
+    const unresolvedMetering = failure.incidentCategory === "unresolved_metering";
+    await recordAuthoringIncident({
+      runId: ref.dbRunId,
+      projectId: ref.projectId,
+      category: failure.incidentCategory,
+      severity: "critical",
+      dedupeKey: unresolvedMetering ? "unresolved-metering" : "settled-output-missing",
+      evidence: {
+        errorCode:
+          failure.errorCode ??
+          (unresolvedMetering ? "metering_reconciliation_required" : "metered_output_missing"),
+        ...(failure.errorStage ? { stage: failure.errorStage } : {}),
+      },
+    });
   }
   return { outcome: "matched", status };
 }

--- a/src/workflows/workflow-boundaries.test.ts
+++ b/src/workflows/workflow-boundaries.test.ts
@@ -180,7 +180,8 @@ describe("workflow sandbox boundaries", () => {
       conflictChecked,
     );
     const exposed = source.indexOf('stage: "awaiting_guidance"', registered);
-    const consumed = source.indexOf("await consumeCreativeDecisionStep", exposed);
+    const notified = source.indexOf("await notifyCreativeDecisionStep", exposed);
+    const consumed = source.indexOf("await consumeCreativeDecisionStep", notified);
     const cleared = source.indexOf('clearAuthoringPauseStep(ref, "creative_decision"', consumed);
 
     expect(pauseStart).toBeGreaterThanOrEqual(0);
@@ -188,7 +189,8 @@ describe("workflow sandbox boundaries", () => {
     expect(conflictChecked).toBeGreaterThan(hookCreated);
     expect(registered).toBeGreaterThan(conflictChecked);
     expect(exposed).toBeGreaterThan(registered);
-    expect(consumed).toBeGreaterThan(exposed);
+    expect(notified).toBeGreaterThan(exposed);
+    expect(consumed).toBeGreaterThan(notified);
     expect(cleared).toBeGreaterThan(consumed);
   });
 

--- a/vitest.db-integration.config.ts
+++ b/vitest.db-integration.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "src/lib/account-deletion.integration.test.ts",
       "src/lib/clerk-deletion-finalizer.integration.test.ts",
       "src/lib/actions/books.integration.test.ts",
+      "src/lib/notification-preferences.integration.test.ts",
     ],
     testTimeout: 60_000,
     hookTimeout: 60_000,


### PR DESCRIPTION
## Summary

- make interrupted whole-book recovery land on and focus the actionable recovery panel on the first and repeated mobile activation
- replace stale failed-run UI immediately when a distinct recovery run becomes active, without allowing one active run to displace another
- wait for authoritative server state on reattachment instead of publishing a guessed stage or pause
- retire terminal request keys safely while preserving a separately confirmed paid `Start new draft` action after authoritative completion
- classify unresolved provider metering separately from settled-output contradictions and preserve structured, content-free operational evidence
- block provider retries while a billing lineage has an open intent; unblock only after verified settlement/abort and incident cleanup
- contain the seven-stage mobile timeline inside its keyboard-scrollable region so recovery has zero page-level overflow at 320px and 390px
- add account-wide email controls for “My book needs me,” follow-up reminders, and book completion in Studio Settings
- enforce those choices at the final send boundary while keeping receipts and essential account/security messages always on
- add a content-free, lease-owned delivery ledger so Workflow replay cannot duplicate a notice or downgrade a successful delivery
- notify authors when a creative-direction decision is ready, and give every optional authoring email a direct preferences link

## Root cause

The live production attempt reached Vercel AI Gateway, but the provider result was interrupted before Sopher durably committed its local metering/output checkpoint. Recovery runs inherited the same logical billing key and correctly refused to repeat a potentially charged call, while the Workflow boundary flattened that specific cause into a generic failure.

A separate client race compounded the problem: the initial failed RunViewer republished its already-authoritative terminal state and launched a redundant RSC refresh. That stale response could land after recovery started, restoring the old `Resume from saved work` callout above the new queued RunViewer. Same-route hash handling could also focus a hidden retained route copy, making the CTA appear inert.

The exact Gateway attempt reported one `anthropic/claude-sonnet-5` request with 2 input and 537 output tokens. After the one-hour evidence guard elapsed, that exact attempt was reconciled: canonical usage was recorded, the undelivered result was fully refunded, the oversized claim was released, and the author’s net charge is zero. No run was created or restarted; the project remains at five terminal attempts and 26 saved events.

Optional authoring mail previously had no account preference contract and relied only on provider idempotency. The new delivery boundary reads server-persisted preferences immediately before current-code sends and records the content-free decision by stable event key. An atomic UUID lease gives one concurrent Workflow replay ownership of each send; only that owner may settle it.

## User impact

- `Resume from saved work` now retains the recovery hash, scrolls to the visible recovery panel, and moves keyboard focus there
- starting recovery immediately changes the sole next action to `Watch the writing room`; the stale Resume action disappears
- running, paused, and queued reattachments show only Workflow-aware authoritative progress
- unresolved billing evidence becomes `Contact support` with a safe reference; purchase is never presented as the remedy
- a stale completed request cannot silently regenerate paid work, while a separately confirmed full-book `Start new draft` remains usable
- the production timeline scrolls internally without widening the mobile page
- authors can independently turn off action-required mail, the 24-hour outline reminder, and completion mail across devices
- Studio keeps every in-app next action visible even when its corresponding email is disabled
- receipts and essential account/security mail remain operational and are explained alongside the controls
- books started on deployment-pinned Workflow bundles may finish their already-scheduled notices; the Settings copy scopes that limitation explicitly

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 168 files, 1,237 tests
- `pnpm check:migrations` — all 20 migrations sequential and valid
- `pnpm db:check`; follow-up Drizzle generation reports no schema changes
- `pnpm audit --audit-level high` — no known vulnerabilities
- optimized production build — 59 Workflow steps, 11 workflows, 74 routes
- fresh isolated Neon — all migrations, deterministic seed, 13 DB files / 58 tests, and direct constraint inspection passed; disposable branch deleted and confirmed absent
- notification Neon suite — 3/3, including exactly one concurrent lease winner and stale failure unable to downgrade `sent`
- authenticated Settings Playwright — persistence after reload, keyboard controls, light/dark, and axe passed
- authenticated responsive matrix — 320/390px light/dark passed with no page overflow and no serious/critical axe findings
- in-app Browser QA — toggle → save → reload persistence → restore passed; 390px wrapping and console/network health were clean
- DB-backed interrupted recovery — light and dark passed, including first/repeated hash activation, visible-panel focus, dispatch, canonical queued action, removal of stale Resume, RunViewer focus, 320/390px zero overflow, and axe
- public reader prose reflow — 320/390px passed with axe
- independent finish review — no remaining correctness, privacy, idempotency, Workflow, migration, accessibility, mobile, or release blockers

## Release notes

- Ready for review; do not merge from this PR.
- Existing deployment-pinned authoring/reminder workflows contain their original email bundle. Preferences are guaranteed for books started after these controls ship; the product discloses that an older in-flight book or already-delivering message may still send a scheduled update.
- Exact-SHA CI, CodeQL, Lighthouse, Vercel, bot review, and protected-preview verification are monitored on the latest commit before handoff.
