### PR TITLE
Fix structured authoring retries and dead-end status actions

### DIFF
--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -104,8 +104,8 @@ test("library exposes one truthful action for every authoring state", async ({
     },
     {
       title: "The House That Counted",
-      label: "Contact support",
-      href: /^mailto:support@sopher\.ai/,
+      label: "Review production status",
+      href: `/projects/${PROJECTS.invalidCompletion}/write#production-status`,
       detail: "without a complete, verifiable manuscript",
     },
   ] as const;

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -67,7 +67,7 @@ test("library exposes one truthful action for every authoring state", async ({
     {
       title: "Signal at Low Tide",
       label: "Reconnect this start",
-      href: `/projects/${PROJECTS.dispatchUncertain}/write`,
+      href: `/projects/${PROJECTS.dispatchUncertain}/write#production-status`,
       detail: "did not receive a start confirmation",
     },
     {
@@ -93,13 +93,13 @@ test("library exposes one truthful action for every authoring state", async ({
     {
       title: "The Last Weather Station",
       label: "Watch production",
-      href: `/projects/${PROJECTS.degradedTelemetry}/write`,
+      href: `/projects/${PROJECTS.degradedTelemetry}/write#production-status`,
       detail: "live connection is delayed",
     },
     {
       title: "Glasswing County",
       label: "View the safe stop",
-      href: `/projects/${PROJECTS.cancellationRequested}/write`,
+      href: `/projects/${PROJECTS.cancellationRequested}/write#production-status`,
       detail: "stopping before another model call",
     },
     {

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -142,6 +142,23 @@ test("a contradictory completion opens its recovery evidence", async ({ page }) 
   await expect(recovery).toBeFocused();
 });
 
+test("an active book card opens and focuses live production status", async ({ page }) => {
+  await page.goto("/studio");
+  await page
+    .getByRole("link", {
+      name: "Watch production: The Last Weather Station",
+      exact: true,
+    })
+    .click();
+
+  await expect(page).toHaveURL(
+    new RegExp(`/projects/${PROJECTS.degradedTelemetry}/write#production-status$`),
+  );
+  const productionStatus = page.locator("#production-status");
+  await expect(productionStatus).toBeVisible();
+  await expect(productionStatus).toBeFocused();
+});
+
 test("project surfaces repeat the authoritative next step", async ({ page }, testInfo) => {
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1440, height: 900 });

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -159,6 +159,27 @@ test("an active book card opens and focuses live production status", async ({ pa
   await expect(productionStatus).toBeFocused();
 });
 
+test("cross-page Editor and Manuscript actions focus their destination", async ({ page }) => {
+  const destinations = [
+    {
+      route: `/projects/${PROJECTS.partialFailure}/editor#editor-production-status`,
+      target: "#editor-production-status",
+    },
+    {
+      route: `/projects/${PROJECTS.partialFailure}/manuscript#manuscript-actions`,
+      target: "#manuscript-actions",
+    },
+  ] as const;
+
+  for (const destination of destinations) {
+    await page.goto(destination.route);
+    await expect(page).toHaveURL(new RegExp(`${destination.target}$`));
+    const target = page.locator(destination.target);
+    await expect(target).toBeVisible();
+    await expect(target).toBeFocused();
+  }
+});
+
 test("project surfaces repeat the authoritative next step", async ({ page }, testInfo) => {
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1440, height: 900 });

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -174,7 +174,7 @@ test("cross-page Editor and Manuscript actions focus their destination", async (
   for (const destination of destinations) {
     await page.goto(destination.route);
     await expect(page).toHaveURL(new RegExp(`${destination.target}$`));
-    const target = page.locator(destination.target);
+    const target = page.locator(destination.target).filter({ visible: true });
     await expect(target).toBeVisible();
     await expect(target).toBeFocused();
   }

--- a/e2e/authoring-journey.spec.ts
+++ b/e2e/authoring-journey.spec.ts
@@ -105,7 +105,7 @@ test("library exposes one truthful action for every authoring state", async ({
     {
       title: "The House That Counted",
       label: "Review production status",
-      href: `/projects/${PROJECTS.invalidCompletion}/write#production-status`,
+      href: `/projects/${PROJECTS.invalidCompletion}/write#authoring-recovery`,
       detail: "without a complete, verifiable manuscript",
     },
   ] as const;
@@ -123,6 +123,23 @@ test("library exposes one truthful action for every authoring state", async ({
   await expectNoPageOverflow(page, "authoring-state library");
   await axeCheck(page);
   await screenshot(page, testInfo.project.name, "journey-library");
+});
+
+test("a contradictory completion opens its recovery evidence", async ({ page }) => {
+  await page.goto("/studio");
+  await page
+    .getByRole("link", {
+      name: "Review production status: The House That Counted",
+      exact: true,
+    })
+    .click();
+
+  await expect(page).toHaveURL(
+    new RegExp(`/projects/${PROJECTS.invalidCompletion}/write#authoring-recovery$`),
+  );
+  const recovery = page.locator("#authoring-recovery");
+  await expect(recovery).toBeVisible();
+  await expect(recovery).toBeFocused();
 });
 
 test("project surfaces repeat the authoritative next step", async ({ page }, testInfo) => {

--- a/e2e/creative-flows.spec.ts
+++ b/e2e/creative-flows.spec.ts
@@ -53,7 +53,9 @@ test("authoring mode stays reversible and live assembly has a complete reduced-m
   await expectNoPageOverflow(page, "authoring-mode settings");
 
   await page.goto(`/projects/${ACTIVE_PROJECT_ID}/write`);
-  const assembly = page.locator('section[aria-labelledby="book-assembly-title"]');
+  const assembly = page
+    .locator('section[aria-labelledby="book-assembly-title"]')
+    .filter({ visible: true });
   await expect(
     assembly.getByRole("heading", { name: "Watch the story become a book" }),
   ).toBeVisible({ timeout: 20_000 });
@@ -173,13 +175,18 @@ test("whole-manuscript review fails safely and Book Package preserves the seeded
   await expect(page.getByRole("heading", { name: "Editorial workbench" })).toBeVisible({
     timeout: 20_000,
   });
-  await expect(page.getByText("Whole-manuscript direction", { exact: true })).toBeVisible();
-  const instruction = page.getByLabel("What should change across the book?");
+  const direction = page
+    .locator('section[aria-labelledby="manuscript-direction-heading"]')
+    .filter({ visible: true });
+  await expect(direction.getByText("Whole-manuscript direction", { exact: true })).toBeVisible();
+  const instruction = direction.getByLabel("What should change across the book?");
   await instruction.fill("Make every scene more adventurous without changing the plot.");
-  const review = page.getByRole("button", { name: "Review the whole manuscript" });
+  const review = direction.getByRole("button", { name: "Review the whole manuscript" });
   await review.click();
   await expect(
-    page.getByRole("alert").filter({ hasText: "The review service is temporarily unavailable." }),
+    direction
+      .getByRole("alert")
+      .filter({ hasText: "The review service is temporarily unavailable." }),
   ).toHaveText("The review service is temporarily unavailable.");
   await expect(instruction).toHaveValue(
     "Make every scene more adventurous without changing the plot.",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
       "jayson>uuid": "11.1.1",
       "minimatch@3.1.5>brace-expansion": "1.1.18",
       "minimatch@10.2.6>brace-expansion": "5.0.9",
-      "next>postcss": "8.5.18",
+      "next>postcss": "8.5.23",
       "next>sharp": "0.35.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
       "ejs>jake": "12.10.1",
       "external-editor>tmp": "0.2.7",
       "jayson>uuid": "11.1.1",
-      "minimatch@3.1.5>brace-expansion": "1.1.17",
+      "minimatch@3.1.5>brace-expansion": "1.1.18",
+      "minimatch@10.2.6>brace-expansion": "5.0.9",
       "next>postcss": "8.5.18",
       "next>sharp": "0.35.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,8 @@ overrides:
   ejs>jake: 12.10.1
   external-editor>tmp: 0.2.7
   jayson>uuid: 11.1.1
-  minimatch@3.1.5>brace-expansion: 1.1.17
+  minimatch@3.1.5>brace-expansion: 1.1.18
+  minimatch@10.2.6>brace-expansion: 5.0.9
   next>postcss: 8.5.18
   next>sharp: 0.35.0
 
@@ -4086,11 +4087,11 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.17:
-    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -12809,12 +12810,12 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15755,11 +15756,11 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.17
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   jayson>uuid: 11.1.1
   minimatch@3.1.5>brace-expansion: 1.1.18
   minimatch@10.2.6>brace-expansion: 5.0.9
-  next>postcss: 8.5.18
+  next>postcss: 8.5.23
   next>sharp: 0.35.0
 
 importers:
@@ -7138,10 +7138,6 @@ packages:
   postcss-selector-parser@7.1.4:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
-
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -15812,7 +15808,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.5
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.18
+      postcss: 8.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.4)
@@ -16207,12 +16203,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.5.18:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:

--- a/src/ai/metering.test.ts
+++ b/src/ai/metering.test.ts
@@ -1,4 +1,4 @@
-import { NoOutputGeneratedError } from "ai";
+import { NoObjectGeneratedError, NoOutputGeneratedError } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -378,6 +378,61 @@ describe("metered atomic authorization", () => {
     expect(provider).toHaveBeenCalledOnce();
     expect(mocks.abort).not.toHaveBeenCalled();
     expect(mocks.recordMany).not.toHaveBeenCalled();
+  });
+
+  it("settles and compensates a rejected structured response before a durable retry", async () => {
+    const malformed = new NoObjectGeneratedError({
+      message: "No object generated: response did not match schema.",
+      text: '{"entities":[]}',
+      response: {
+        id: "gateway-response-1",
+        timestamp: new Date("2026-08-03T00:00:00.000Z"),
+        modelId: "anthropic/claude-sonnet-5",
+      },
+      usage,
+      finishReason: "stop",
+    });
+    const provider = vi
+      .fn<() => Promise<{ usage: typeof usage }>>()
+      .mockRejectedValueOnce(malformed)
+      .mockResolvedValueOnce({ usage });
+    const ctx = {
+      userId: "user-1",
+      runId: "run-1",
+      billingScope: "generation:run-1:entity-bible",
+      reservationRef: "generation-reservation:run-1:entity-bible",
+    };
+    const info = {
+      role: "entity-bible",
+      operation: "entity.bible",
+      model: "anthropic/claude-sonnet-5",
+    };
+
+    await expect(metered(ctx, info, provider)).rejects.toMatchObject({
+      name: "MeteredOutputDeliveryError",
+      operation: "entity.bible",
+      finishReason: "stop",
+      isRetryable: true,
+    });
+    expect(mocks.recordMany).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          model: "anthropic/claude-sonnet-5",
+          operation: "entity.bible",
+          usage: expect.objectContaining({ inputTokens: 1_000, outputTokens: 500 }),
+        }),
+      ],
+      expect.objectContaining({
+        compensateDelivery: {
+          description: "Provider output for entity.bible was incomplete and not delivered",
+        },
+      }),
+    );
+    expect(mocks.abort).not.toHaveBeenCalled();
+
+    await expect(metered(ctx, info, provider)).resolves.toEqual({ usage });
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(mocks.recordMany).toHaveBeenCalledTimes(2);
   });
 
   it("releases a first-step input guard failure that proves no provider dispatch", async () => {

--- a/src/ai/metering.ts
+++ b/src/ai/metering.ts
@@ -1,4 +1,4 @@
-import type { JSONValue, LanguageModelUsage } from "ai";
+import { NoObjectGeneratedError, type JSONValue, type LanguageModelUsage } from "ai";
 import {
   abortMeteredCallIntent,
   attachGatewayGenerationIds,
@@ -438,6 +438,62 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
   };
 
   const startedAt = Date.now();
+  const settleProviderUsage = async (input: {
+    carrier: UsageCarrier & { usage: LanguageModelUsage };
+    imageCount?: number;
+    outputDeliveryFailure?: unknown;
+  }) => {
+    const calls = actualCalls(input.carrier, info.model);
+    if (calls.length === 0) {
+      calls.push({ usage: input.carrier.usage, model: info.model });
+    }
+    const generationIds = calls.flatMap((call) => (call.generationId ? [call.generationId] : []));
+    await attachGatewayGenerationIds({
+      userId: ctx.userId,
+      externalRef: intentRef,
+      generationIds,
+    });
+    const externalRefPrefix = `llm:${logicalScope}:${info.operation}:attempt:${attemptId}`;
+    const settlementResult = await recordLlmCallsAndDebit(
+      calls.map((call, index) => ({
+        userId: ctx.userId,
+        projectId: ctx.projectId,
+        runId: ctx.runId,
+        agentRole: info.role,
+        operation: info.operation,
+        model: call.model,
+        usage: {
+          inputTokens: call.usage.inputTokens ?? 0,
+          outputTokens: call.usage.outputTokens ?? 0,
+          cachedInputTokens: call.usage.inputTokenDetails?.cacheReadTokens ?? 0,
+          cacheWriteTokens: call.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+          reasoningTokens: call.usage.outputTokenDetails?.reasoningTokens ?? 0,
+          imageCount: index === calls.length - 1 ? (input.imageCount ?? 0) : 0,
+        },
+        latencyMs: Date.now() - startedAt,
+      })),
+      {
+        description: info.operation,
+        externalRefPrefix,
+        intentRef,
+        reservationRef: intent.reservationRef,
+        ...(input.outputDeliveryFailure
+          ? {
+              compensateDelivery: {
+                description: `Provider output for ${info.operation} was incomplete and not delivered`,
+              },
+            }
+          : {}),
+      },
+    );
+    const settlement = {
+      meteredUsd: settlementResult.meteredUsd,
+      credits: settlementResult.debitedCredits,
+      externalRefPrefix,
+    };
+    ctx.lastSettlement = settlement;
+    ctx.settlements?.push(settlement);
+  };
   let providerPromise: Promise<T>;
   try {
     // Cancellation may arrive after a phase hold was granted but before this
@@ -445,9 +501,9 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
     // release the untouched intent when the author has asked us to stop.
     await throwIfAuthoringCancellationRequested(ctx.runId);
     // A synchronous throw proves dispatch never returned a provider promise.
-    // Once a promise exists, every rejection is ambiguous (the Gateway may
-    // have accepted or partially streamed it) and must remain held for
-    // generation-tag reconciliation.
+    // Once a promise exists, a rejection is normally ambiguous (the Gateway
+    // may have accepted or partially streamed it). AI SDK structured-output
+    // errors are the narrow exception because they carry completed usage.
     providerPromise = fn();
   } catch (error) {
     await abortKnownUnsent();
@@ -474,56 +530,11 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
       (result as { files?: Array<{ mediaType?: string }> }).files?.filter((f) =>
         f.mediaType?.startsWith("image/"),
       ).length ?? 0;
-    const calls = actualCalls(result, info.model);
-    if (calls.length === 0) {
-      calls.push({ usage: result.usage, model: info.model });
-    }
-    const generationIds = calls.flatMap((call) => (call.generationId ? [call.generationId] : []));
-    await attachGatewayGenerationIds({
-      userId: ctx.userId,
-      externalRef: intentRef,
-      generationIds,
+    await settleProviderUsage({
+      carrier: result,
+      imageCount,
+      outputDeliveryFailure,
     });
-    const externalRefPrefix = `llm:${logicalScope}:${info.operation}:attempt:${attemptId}`;
-    const settlementResult = await recordLlmCallsAndDebit(
-      calls.map((call, index) => ({
-        userId: ctx.userId,
-        projectId: ctx.projectId,
-        runId: ctx.runId,
-        agentRole: info.role,
-        operation: info.operation,
-        model: call.model,
-        usage: {
-          inputTokens: call.usage.inputTokens ?? 0,
-          outputTokens: call.usage.outputTokens ?? 0,
-          cachedInputTokens: call.usage.inputTokenDetails?.cacheReadTokens ?? 0,
-          cacheWriteTokens: call.usage.inputTokenDetails?.cacheWriteTokens ?? 0,
-          reasoningTokens: call.usage.outputTokenDetails?.reasoningTokens ?? 0,
-          imageCount: index === calls.length - 1 ? imageCount : 0,
-        },
-        latencyMs: Date.now() - startedAt,
-      })),
-      {
-        description: info.operation,
-        externalRefPrefix,
-        intentRef,
-        reservationRef: intent.reservationRef,
-        ...(outputDeliveryFailure
-          ? {
-              compensateDelivery: {
-                description: `Provider output for ${info.operation} was incomplete and not delivered`,
-              },
-            }
-          : {}),
-      },
-    );
-    const settlement = {
-      meteredUsd: settlementResult.meteredUsd,
-      credits: settlementResult.debitedCredits,
-      externalRefPrefix,
-    };
-    ctx.lastSettlement = settlement;
-    ctx.settlements?.push(settlement);
 
     if (outputDeliveryFailure) {
       const finishReason =
@@ -541,16 +552,36 @@ export async function metered<T extends { usage: LanguageModelUsage }>(
     await throwIfAuthoringCancellationRequested(ctx.runId);
     return result;
   } catch (error) {
+    if (NoObjectGeneratedError.isInstance(error) && error.usage) {
+      // AI SDK rejects generateText(Output.object(...)) after the provider has
+      // returned when its response cannot be parsed or validated. The usage
+      // attached to this error is authoritative: settle and compensate it so
+      // Workflow can safely retry the structured output instead of mistaking
+      // its own completed attempt for unresolved external billing.
+      await settleProviderUsage({
+        carrier: {
+          usage: error.usage,
+          ...(error.response ? { response: error.response } : {}),
+        },
+        outputDeliveryFailure: error,
+      });
+      throw new MeteredOutputDeliveryError(
+        info.operation,
+        error.finishReason ?? "unknown",
+        error.usage.outputTokens ?? 0,
+        error.usage.outputTokenDetails?.reasoningTokens ?? 0,
+      );
+    }
     if (error instanceof MeteredInputLimitError && error.stepNumber === 0) {
       // AI SDK prepareStep runs before the corresponding provider request.
       // A first-step guard failure therefore proves no model call was sent.
       await abortKnownUnsent();
       throw error;
     }
-    // Provider promise rejection, stream interruption, generation-id write
-    // failure, and settlement failure are all ambiguous after dispatch. Keep
-    // the claim and intent pending; an operator can reconcile it against the
-    // unique Gateway attempt tag.
+    // Every other provider rejection, stream interruption, generation-id
+    // write failure, and settlement failure remains ambiguous after dispatch.
+    // Keep the claim and intent pending for operator reconciliation against
+    // the unique Gateway attempt tag.
     throw error;
   }
 }

--- a/src/app/(studio)/projects/[projectId]/editor/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/editor/page.tsx
@@ -135,21 +135,29 @@ export default async function EditorIndexPage({
         </p>
       </header>
 
-      {journey ? <IncompleteProductionNotice journey={journey} /> : null}
+      <div
+        id="editor-production-status"
+        tabIndex={-1}
+        role="region"
+        aria-label="Editor production status"
+        className="scroll-mt-28 space-y-5 rounded-sm outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+      >
+        {journey ? <IncompleteProductionNotice journey={journey} /> : null}
 
-      {chapters.some((chapter) => chapter.wordCount > 0) ? (
-        <ManuscriptRevisionPanel
-          projectId={projectId}
-          chapterCount={chapters.filter((chapter) => chapter.wordCount > 0).length}
-          maximumCredits={manuscriptEditMaximumCredits(
-            data.project.settings.qualityTier ?? "standard",
-            chapters.filter((chapter) => chapter.wordCount > 0).length,
-          )}
-          initialRun={initialRevisionRun}
-          initialSuggestionCount={Number(latestSuggestionFacts.count)}
-          initialFirstSuggestionChapter={firstLatestSuggestion?.chapterNumber ?? null}
-        />
-      ) : null}
+        {chapters.some((chapter) => chapter.wordCount > 0) ? (
+          <ManuscriptRevisionPanel
+            projectId={projectId}
+            chapterCount={chapters.filter((chapter) => chapter.wordCount > 0).length}
+            maximumCredits={manuscriptEditMaximumCredits(
+              data.project.settings.qualityTier ?? "standard",
+              chapters.filter((chapter) => chapter.wordCount > 0).length,
+            )}
+            initialRun={initialRevisionRun}
+            initialSuggestionCount={Number(latestSuggestionFacts.count)}
+            initialFirstSuggestionChapter={firstLatestSuggestion?.chapterNumber ?? null}
+          />
+        ) : null}
+      </div>
 
       {chapters.length === 0 ? (
         <div className="instrument-surface relative flex min-h-56 flex-col items-center justify-center overflow-hidden px-6 py-12 text-center">

--- a/src/app/(studio)/projects/[projectId]/editor/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/editor/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/editor/chapter-status";
 import { getAuthoringJourneySnapshot } from "@/db/queries/authoring-journey";
 import { IncompleteProductionNotice } from "@/components/studio/incomplete-production-notice";
+import { HashFocusTarget } from "@/components/studio/hash-focus-target";
 import {
   manuscriptEditMaximumCredits,
   readManuscriptEditPassCompletion,
@@ -135,12 +136,11 @@ export default async function EditorIndexPage({
         </p>
       </header>
 
-      <div
+      <HashFocusTarget
         id="editor-production-status"
-        tabIndex={-1}
         role="region"
         aria-label="Editor production status"
-        className="scroll-mt-28 space-y-5 rounded-sm outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+        className="scroll-mt-28 space-y-5 rounded-sm"
       >
         {journey ? <IncompleteProductionNotice journey={journey} /> : null}
 
@@ -157,7 +157,7 @@ export default async function EditorIndexPage({
             initialFirstSuggestionChapter={firstLatestSuggestion?.chapterNumber ?? null}
           />
         ) : null}
-      </div>
+      </HashFocusTarget>
 
       {chapters.length === 0 ? (
         <div className="instrument-surface relative flex min-h-56 flex-col items-center justify-center overflow-hidden px-6 py-12 text-center">

--- a/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
@@ -18,6 +18,7 @@ import { closingBookMatter, openingBookMatter, readBookMatter } from "@/lib/book
 import { getChapterList, getChapterWithContent, getProjectWithBook } from "@/db/queries/books";
 import { getAuthoringJourneySnapshot } from "@/db/queries/authoring-journey";
 import { IncompleteProductionNotice } from "@/components/studio/incomplete-production-notice";
+import { HashFocusTarget } from "@/components/studio/hash-focus-target";
 
 function EmptyManuscript() {
   return (
@@ -97,7 +98,8 @@ export default async function ManuscriptPage({
       <h2 className="sr-only">Manuscript</h2>
       {journey ? <IncompleteProductionNotice journey={journey} /> : null}
 
-      <header
+      <HashFocusTarget
+        as="header"
         id="manuscript-actions"
         className="instrument-surface scroll-mt-28 flex flex-wrap items-center justify-between gap-4 rounded-sm p-4"
       >
@@ -137,7 +139,7 @@ export default async function ManuscriptPage({
           <ShareReaderDialog projectId={projectId} />
           <ExportDialog projectId={projectId} />
         </div>
-      </header>
+      </HashFocusTarget>
 
       <div className="manuscript-sheet min-w-0 px-4 py-8 sm:px-12 sm:py-16">
         {isOpening ? (

--- a/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
+++ b/src/app/(studio)/projects/[projectId]/manuscript/page.tsx
@@ -97,7 +97,10 @@ export default async function ManuscriptPage({
       <h2 className="sr-only">Manuscript</h2>
       {journey ? <IncompleteProductionNotice journey={journey} /> : null}
 
-      <header className="instrument-surface flex flex-wrap items-center justify-between gap-4 rounded-sm p-4">
+      <header
+        id="manuscript-actions"
+        className="instrument-surface scroll-mt-28 flex flex-wrap items-center justify-between gap-4 rounded-sm p-4"
+      >
         <div className="min-w-0 space-y-2">
           <p className="folio-label text-muted-foreground">
             Chapter {active.chapterNumber} of {readable.length} readable ·{" "}

--- a/src/app/(studio)/studio/page.tsx
+++ b/src/app/(studio)/studio/page.tsx
@@ -26,10 +26,11 @@ export const metadata: Metadata = {
 
 function toCard(journey: AuthoringJourneySnapshot): ProjectCardData {
   const { project, artifacts } = journey;
-  const statusHref =
-    journey.run?.kind && journey.run.kind !== "full_book"
-      ? `/projects/${project.id}/editor`
-      : `/projects/${project.id}/write`;
+  const statusHref = journey.run
+    ? journey.run.kind !== "full_book"
+      ? `/projects/${project.id}/editor#editor-production-status`
+      : `/projects/${project.id}/write#production-status`
+    : `/projects/${project.id}/write`;
   return {
     id: project.id,
     title: project.title,

--- a/src/app/(studio)/studio/page.tsx
+++ b/src/app/(studio)/studio/page.tsx
@@ -14,7 +14,7 @@ import {
 import { StudioInlineChecklist } from "@/components/studio/first-book-checklist";
 import { listAuthoringJourneySnapshots } from "@/db/queries/authoring-journey";
 import { requireUser } from "@/lib/auth";
-import type { AuthoringJourneySnapshot } from "@/lib/authoring-journey";
+import { authoringStatusHref, type AuthoringJourneySnapshot } from "@/lib/authoring-journey";
 import { getAuthoringOnboardingSnapshot } from "@/lib/authoring-onboarding";
 import { getStudioAccess, shouldOfferFullBookUnlock } from "@/lib/studio-access";
 import { getBalance } from "@/lib/billing/credits";
@@ -26,11 +26,6 @@ export const metadata: Metadata = {
 
 function toCard(journey: AuthoringJourneySnapshot): ProjectCardData {
   const { project, artifacts } = journey;
-  const statusHref = journey.run
-    ? journey.run.kind !== "full_book"
-      ? `/projects/${project.id}/editor#editor-production-status`
-      : `/projects/${project.id}/write#production-status`
-    : `/projects/${project.id}/write`;
   return {
     id: project.id,
     title: project.title,
@@ -48,7 +43,7 @@ function toCard(journey: AuthoringJourneySnapshot): ProjectCardData {
       project.targetWordsPerChapter,
     ).totalUsd,
     nextAction: journey.nextAction,
-    statusHref,
+    statusHref: authoringStatusHref(project.id, journey.run),
   };
 }
 

--- a/src/app/(studio)/studio/page.tsx
+++ b/src/app/(studio)/studio/page.tsx
@@ -26,6 +26,10 @@ export const metadata: Metadata = {
 
 function toCard(journey: AuthoringJourneySnapshot): ProjectCardData {
   const { project, artifacts } = journey;
+  const statusHref =
+    journey.run?.kind && journey.run.kind !== "full_book"
+      ? `/projects/${project.id}/editor`
+      : `/projects/${project.id}/write`;
   return {
     id: project.id,
     title: project.title,
@@ -43,6 +47,7 @@ function toCard(journey: AuthoringJourneySnapshot): ProjectCardData {
       project.targetWordsPerChapter,
     ).totalUsd,
     nextAction: journey.nextAction,
+    statusHref,
   };
 }
 

--- a/src/app/(studio)/studio/settings/settings-cards.test.tsx
+++ b/src/app/(studio)/studio/settings/settings-cards.test.tsx
@@ -32,6 +32,7 @@ describe("NotificationPreferencesCard", () => {
 
     for (const name of ["My book needs me", "Follow-up reminders", "My book is finished"]) {
       expect(screen.getByRole("switch", { name })).toBeChecked();
+      expect(screen.getByRole("switch", { name })).toHaveAttribute("aria-label", name);
       expect(screen.getByRole("switch", { name })).toHaveAccessibleDescription();
     }
     expect(screen.getByText("author@example.com")).toBeVisible();

--- a/src/app/(studio)/studio/settings/settings-cards.tsx
+++ b/src/app/(studio)/studio/settings/settings-cards.tsx
@@ -305,6 +305,7 @@ export function NotificationPreferencesCard({
                   <span className="flex min-h-11 min-w-11 shrink-0 items-center justify-end">
                     <Switch
                       id={inputId}
+                      aria-label={row.label}
                       checked={preferences[row.key]}
                       aria-describedby={descriptionId}
                       onCheckedChange={(checked) => {

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -23,6 +23,7 @@ import {
   creativeDecisionCardKey,
 } from "@/components/generation/creative-decision-card";
 import { ResponsiveInspector } from "@/components/studio/product-primitives";
+import { useHashTargetFocus } from "@/components/studio/hash-focus-target";
 import type { Stage } from "@/lib/run-events";
 import type { QualityTier } from "@/ai/models";
 import { PRODUCTION_STAGE_LABELS } from "@/lib/project-progress";
@@ -96,29 +97,6 @@ function formatEventTime(value: string | undefined): string {
     minute: "2-digit",
     second: "2-digit",
   }).format(date);
-}
-
-function useHashTargetFocus<T extends HTMLElement>(targetId: string) {
-  const targetRef = React.useRef<T | null>(null);
-  React.useEffect(() => {
-    let frame: number | undefined;
-    const focusTarget = () => {
-      if (window.location.hash !== `#${targetId}`) return;
-      if (frame !== undefined) window.cancelAnimationFrame(frame);
-      frame = window.requestAnimationFrame(() => {
-        const target = targetRef.current;
-        if (!target || target.getClientRects().length === 0) return;
-        target.focus({ preventScroll: true });
-      });
-    };
-    focusTarget();
-    window.addEventListener("hashchange", focusTarget);
-    return () => {
-      window.removeEventListener("hashchange", focusTarget);
-      if (frame !== undefined) window.cancelAnimationFrame(frame);
-    };
-  }, [targetId]);
-  return targetRef;
 }
 
 function ProductionTelemetry({

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -139,8 +139,9 @@ function ProductionTelemetry({
 
   return (
     <section
+      id="production-status"
       aria-labelledby="production-now-title"
-      className="instrument-surface-raised overflow-hidden rounded-sm"
+      className="instrument-surface-raised scroll-mt-28 overflow-hidden rounded-sm"
     >
       <div className="flex flex-wrap items-start justify-between gap-4 border-b border-border px-4 py-4 sm:px-5">
         <div>

--- a/src/components/generation/run-viewer.tsx
+++ b/src/components/generation/run-viewer.tsx
@@ -98,6 +98,29 @@ function formatEventTime(value: string | undefined): string {
   }).format(date);
 }
 
+function useHashTargetFocus<T extends HTMLElement>(targetId: string) {
+  const targetRef = React.useRef<T | null>(null);
+  React.useEffect(() => {
+    let frame: number | undefined;
+    const focusTarget = () => {
+      if (window.location.hash !== `#${targetId}`) return;
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        const target = targetRef.current;
+        if (!target || target.getClientRects().length === 0) return;
+        target.focus({ preventScroll: true });
+      });
+    };
+    focusTarget();
+    window.addEventListener("hashchange", focusTarget);
+    return () => {
+      window.removeEventListener("hashchange", focusTarget);
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+    };
+  }, [targetId]);
+  return targetRef;
+}
+
 function ProductionTelemetry({
   state,
   now,
@@ -113,6 +136,7 @@ function ProductionTelemetry({
   estimatedMinutes?: number;
   cancellationRequested: boolean;
 }) {
+  const statusTargetRef = useHashTargetFocus<HTMLElement>("production-status");
   const acceptedAt = state.health.acceptedAt ? Date.parse(state.health.acceptedAt) : Number.NaN;
   const completedAt = state.health.completedAt ? Date.parse(state.health.completedAt) : Number.NaN;
   const elapsedMs = Number.isFinite(acceptedAt)
@@ -139,9 +163,11 @@ function ProductionTelemetry({
 
   return (
     <section
+      ref={statusTargetRef}
       id="production-status"
+      tabIndex={-1}
       aria-labelledby="production-now-title"
-      className="instrument-surface-raised scroll-mt-28 overflow-hidden rounded-sm"
+      className="instrument-surface-raised scroll-mt-28 overflow-hidden rounded-sm outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
     >
       <div className="flex flex-wrap items-start justify-between gap-4 border-b border-border px-4 py-4 sm:px-5">
         <div>
@@ -777,22 +803,7 @@ function RecoveryCard({
   error: string | null;
 }) {
   const [copied, setCopied] = React.useState(false);
-  const recoveryTargetRef = React.useRef<HTMLElement | null>(null);
-  React.useEffect(() => {
-    let frame: number | undefined;
-    const focusRecoveryTarget = () => {
-      if (window.location.hash !== "#authoring-recovery") return;
-      frame = window.requestAnimationFrame(() => {
-        recoveryTargetRef.current?.focus({ preventScroll: true });
-      });
-    };
-    focusRecoveryTarget();
-    window.addEventListener("hashchange", focusRecoveryTarget);
-    return () => {
-      window.removeEventListener("hashchange", focusRecoveryTarget);
-      if (frame !== undefined) window.cancelAnimationFrame(frame);
-    };
-  }, []);
+  const recoveryTargetRef = useHashTargetFocus<HTMLElement>("authoring-recovery");
   const saved = Math.max(savedChapterCount, state.health.savedChapterCount ?? 0);
   const checkpoints = Math.max(0, state.health.savedCheckpointCount ?? 0);
   const noWorkStarted = state.health.noWorkStarted && state.totalCredits <= 0 && saved === 0;

--- a/src/components/studio/hash-focus-target.test.tsx
+++ b/src/components/studio/hash-focus-target.test.tsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HashFocusTarget } from "@/components/studio/hash-focus-target";
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "getClientRects").mockReturnValue([
+    { width: 100, height: 40 },
+  ] as unknown as DOMRectList);
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+  window.history.replaceState({}, "", "/studio");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("HashFocusTarget", () => {
+  it("focuses a visible target on initial cross-page hash navigation", async () => {
+    window.history.replaceState({}, "", "/projects/project-id/editor#editor-production-status");
+
+    render(
+      <HashFocusTarget
+        id="editor-production-status"
+        role="region"
+        aria-label="Editor production status"
+      >
+        Editor status
+      </HashFocusTarget>,
+    );
+
+    const target = screen.getByRole("region", { name: "Editor production status" });
+    expect(target).toHaveAttribute("tabindex", "-1");
+    await waitFor(() => expect(target).toHaveFocus());
+  });
+
+  it("focuses the target after a same-page hash change", async () => {
+    render(
+      <HashFocusTarget as="header" id="manuscript-actions">
+        Manuscript actions
+      </HashFocusTarget>,
+    );
+    const target = screen.getByText("Manuscript actions");
+    expect(target).not.toHaveFocus();
+
+    window.history.pushState({}, "", "/projects/project-id/manuscript#manuscript-actions");
+    window.dispatchEvent(new Event("hashchange"));
+
+    await waitFor(() => expect(target).toHaveFocus());
+  });
+
+  it("does not focus a retained hidden route target", async () => {
+    window.history.replaceState({}, "", "/projects/project-id/write#production-status");
+    vi.mocked(HTMLElement.prototype.getClientRects).mockReturnValue([] as unknown as DOMRectList);
+
+    render(<HashFocusTarget id="production-status">Production status</HashFocusTarget>);
+
+    const target = screen.getByText("Production status");
+    await waitFor(() => expect(target).not.toHaveFocus());
+  });
+});

--- a/src/components/studio/hash-focus-target.tsx
+++ b/src/components/studio/hash-focus-target.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Moves focus to a visible fragment target after either an initial cross-page
+ * navigation or a same-page hash change. Next can briefly retain hidden route
+ * trees, so an inert duplicate must never steal assistive-technology focus.
+ */
+export function useHashTargetFocus<T extends HTMLElement = HTMLElement>(targetId: string) {
+  const targetRef = React.useRef<T | null>(null);
+  React.useEffect(() => {
+    let frame: number | undefined;
+    const focusTarget = () => {
+      if (window.location.hash !== `#${targetId}`) return;
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        const target = targetRef.current;
+        if (!target || target.getClientRects().length === 0) return;
+        target.focus({ preventScroll: true });
+      });
+    };
+    focusTarget();
+    window.addEventListener("hashchange", focusTarget);
+    return () => {
+      window.removeEventListener("hashchange", focusTarget);
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+    };
+  }, [targetId]);
+
+  return React.useCallback((node: T | null) => {
+    targetRef.current = node;
+  }, []);
+}
+
+type HashFocusTargetProps = {
+  as?: "div" | "header" | "section";
+  id: string;
+  children: React.ReactNode;
+  className?: string;
+  role?: React.AriaRole;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+};
+
+export function HashFocusTarget({
+  as = "div",
+  id,
+  children,
+  className,
+  ...accessibilityProps
+}: HashFocusTargetProps) {
+  const focusRef = useHashTargetFocus(id);
+  const targetClassName = cn(
+    "outline-none focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring",
+    className,
+  );
+  const props = {
+    id,
+    tabIndex: -1,
+    className: targetClassName,
+    ...accessibilityProps,
+  };
+
+  if (as === "header") {
+    return (
+      <header ref={focusRef} {...props}>
+        {children}
+      </header>
+    );
+  }
+  if (as === "section") {
+    return (
+      <section ref={focusRef} {...props}>
+        {children}
+      </section>
+    );
+  }
+  return (
+    <div ref={focusRef} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/studio/project-card.test.tsx
+++ b/src/components/studio/project-card.test.tsx
@@ -98,6 +98,32 @@ describe("project journey destinations", () => {
     expect(screen.getByText("Review production status")).toBeVisible();
     expect(screen.getByText("Needs attention")).toBeVisible();
   });
+
+  it("opens a failed scoped run at the editor status surface", () => {
+    render(
+      <ProjectCard
+        project={{
+          ...project,
+          statusHref:
+            "/projects/11111111-1111-4111-8111-111111111111/editor#editor-production-status",
+          nextAction: {
+            kind: "contact_support",
+            href: "mailto:support@sopher.ai?subject=Authoring%20help",
+            label: "Contact support",
+            description: "The manuscript review needs a safe evidence check.",
+            requiresMeteredAccess: false,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Review production status: The Night Ferry" }),
+    ).toHaveAttribute(
+      "href",
+      "/projects/11111111-1111-4111-8111-111111111111/editor#editor-production-status",
+    );
+  });
 });
 
 describe("NewBookCard", () => {

--- a/src/components/studio/project-card.test.tsx
+++ b/src/components/studio/project-card.test.tsx
@@ -26,6 +26,7 @@ const project: ProjectCardData = {
   chaptersTotal: 3,
   creditsUsed: 0,
   estimateUsd: 0.6,
+  statusHref: "/projects/11111111-1111-4111-8111-111111111111/write",
   nextAction: {
     kind: "start_production",
     href: "/projects/11111111-1111-4111-8111-111111111111/write",
@@ -71,6 +72,31 @@ describe("project journey destinations", () => {
     expect(screen.getByText("Review needed")).toBeInTheDocument();
     expect(screen.getByText("Production is paused for your approval.")).toBeInTheDocument();
     expect(screen.queryByText("Continue where you left off")).not.toBeInTheDocument();
+  });
+
+  it("opens a failed book's internal status before offering email support", () => {
+    render(
+      <ProjectCard
+        project={{
+          ...project,
+          nextAction: {
+            kind: "contact_support",
+            href: "mailto:support@sopher.ai?subject=Authoring%20help",
+            label: "Contact support",
+            description: "Production stopped and needs a safe evidence review.",
+            requiresMeteredAccess: false,
+          },
+        }}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "Review production status: The Night Ferry",
+    });
+    expect(link).toHaveAttribute("href", "/projects/11111111-1111-4111-8111-111111111111/write");
+    expect(link.getAttribute("href")).not.toContain("mailto:");
+    expect(screen.getByText("Review production status")).toBeVisible();
+    expect(screen.getByText("Needs attention")).toBeVisible();
   });
 });
 

--- a/src/components/studio/project-card.test.tsx
+++ b/src/components/studio/project-card.test.tsx
@@ -79,6 +79,7 @@ describe("project journey destinations", () => {
       <ProjectCard
         project={{
           ...project,
+          statusHref: "/projects/11111111-1111-4111-8111-111111111111/write#authoring-recovery",
           nextAction: {
             kind: "contact_support",
             href: "mailto:support@sopher.ai?subject=Authoring%20help",
@@ -93,7 +94,10 @@ describe("project journey destinations", () => {
     const link = screen.getByRole("link", {
       name: "Review production status: The Night Ferry",
     });
-    expect(link).toHaveAttribute("href", "/projects/11111111-1111-4111-8111-111111111111/write");
+    expect(link).toHaveAttribute(
+      "href",
+      "/projects/11111111-1111-4111-8111-111111111111/write#authoring-recovery",
+    );
     expect(link.getAttribute("href")).not.toContain("mailto:");
     expect(screen.getByText("Review production status")).toBeVisible();
     expect(screen.getByText("Needs attention")).toBeVisible();

--- a/src/components/studio/project-card.tsx
+++ b/src/components/studio/project-card.tsx
@@ -34,7 +34,22 @@ export interface ProjectCardData {
   creditsUsed: number;
   estimateUsd: number;
   nextAction: AuthoringNextAction;
+  /** Internal project surface that explains the current run state. */
+  statusHref: string;
   archived?: boolean;
+}
+
+function projectCardDestination(project: ProjectCardData): { href: string; label: string } {
+  if (project.nextAction.kind === "contact_support") {
+    return {
+      href: project.statusHref,
+      label: "Review production status",
+    };
+  }
+  return {
+    href: project.nextAction.href,
+    label: project.nextAction.label,
+  };
 }
 
 function formatSpendCredits(value: number): string {
@@ -78,6 +93,7 @@ export function ProjectCard({ project }: { project: ProjectCardData }) {
   const progress =
     project.chaptersTotal > 0 ? (project.chaptersDone / project.chaptersTotal) * 100 : 0;
   const needsAttention = journeyNeedsAttention(project.nextAction);
+  const destination = projectCardDestination(project);
 
   return (
     <div className="group relative h-full">
@@ -87,8 +103,8 @@ export function ProjectCard({ project }: { project: ProjectCardData }) {
         <ProjectMenu projectId={project.id} title={project.title} archived={project.archived} />
       </div>
       <Link
-        href={project.nextAction.href as Route}
-        aria-label={`${project.nextAction.label}: ${project.title}`}
+        href={destination.href as Route}
+        aria-label={`${destination.label}: ${project.title}`}
         className="instrument-surface relative flex h-full min-h-36 flex-col overflow-hidden rounded-sm p-4 transition-colors hover:border-foreground/30 md:min-h-64 md:p-5"
       >
         <span
@@ -170,7 +186,7 @@ export function ProjectCard({ project }: { project: ProjectCardData }) {
               </span>
             </span>
             <span className="max-w-36 text-right text-muted-foreground">
-              <span className="block font-medium text-foreground">{project.nextAction.label}</span>
+              <span className="block font-medium text-foreground">{destination.label}</span>
               <span className="mt-1 block">
                 Updated <RelativeTime iso={project.updatedAt} />
               </span>
@@ -189,6 +205,7 @@ export function ProjectCard({ project }: { project: ProjectCardData }) {
 export function FeaturedProjectCard({ project }: { project: ProjectCardData }) {
   const progress =
     project.chaptersTotal > 0 ? (project.chaptersDone / project.chaptersTotal) * 100 : 0;
+  const destination = projectCardDestination(project);
 
   return (
     <div className="group relative">
@@ -196,8 +213,8 @@ export function FeaturedProjectCard({ project }: { project: ProjectCardData }) {
         <ProjectMenu projectId={project.id} title={project.title} archived={project.archived} />
       </div>
       <Link
-        href={project.nextAction.href as Route}
-        aria-label={`${project.nextAction.label}: ${project.title}`}
+        href={destination.href as Route}
+        aria-label={`${destination.label}: ${project.title}`}
         className="instrument-surface-raised relative grid min-h-72 overflow-hidden rounded-sm transition-colors hover:border-foreground/30 md:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)]"
       >
         <span aria-hidden="true" className="spectral-rule absolute inset-y-0 left-0 w-px" />
@@ -219,7 +236,7 @@ export function FeaturedProjectCard({ project }: { project: ProjectCardData }) {
             </p>
           </div>
           <span className="mt-8 inline-flex min-h-11 w-fit items-center gap-2 rounded-sm bg-primary px-4 text-sm font-semibold text-primary-foreground">
-            {project.nextAction.label}
+            {destination.label}
             <ArrowUpRight
               aria-hidden="true"
               className="size-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"

--- a/src/components/studio/project-next-step.test.tsx
+++ b/src/components/studio/project-next-step.test.tsx
@@ -153,7 +153,9 @@ function renderNextStep(journey: ReturnType<typeof snapshot>) {
 afterEach(() => {
   cleanup();
   document
-    .querySelectorAll("#authoring-recovery, #production-status, #manuscript-actions")
+    .querySelectorAll(
+      "#authoring-recovery, #production-status, #editor-production-status, #manuscript-actions",
+    )
     .forEach((target) => target.remove());
   navigation.pathname = `/projects/${PROJECT_ID}/write`;
   window.history.replaceState({}, "", navigation.pathname);
@@ -179,6 +181,42 @@ describe("ProjectNextStep presentation", () => {
     expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
     expect(target).toHaveFocus();
   });
+
+  it.each(["chapter", "edit_pass", "continuity"] as const)(
+    "moves a same-page %s action to the editor production status",
+    (kind) => {
+      navigation.pathname = `/projects/${PROJECT_ID}/editor`;
+      window.history.replaceState({}, "", navigation.pathname);
+      const target = document.createElement("section");
+      target.id = "editor-production-status";
+      target.tabIndex = -1;
+      target.scrollIntoView = vi.fn();
+      target.getClientRects = vi.fn(() => [{ width: 1, height: 1 }] as unknown as DOMRectList);
+      document.body.append(target);
+
+      renderNextStep(
+        snapshot(
+          run({
+            kind,
+            stage: kind === "continuity" ? "continuity" : "editing",
+            progressPct: 41,
+          }),
+        ),
+      );
+      const label = kind === "edit_pass" ? "Follow the manuscript review" : "Watch production";
+      const link = screen.getByRole("link", { name: label });
+      expect(link).toHaveAttribute(
+        "href",
+        `/projects/${PROJECT_ID}/editor#editor-production-status`,
+      );
+
+      fireEvent.click(link);
+
+      expect(window.location.hash).toBe("#editor-production-status");
+      expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+      expect(target).toHaveFocus();
+    },
+  );
 
   it("moves the same-page manuscript action to the reading and export controls", () => {
     navigation.pathname = `/projects/${PROJECT_ID}/manuscript`;

--- a/src/components/studio/project-next-step.test.tsx
+++ b/src/components/studio/project-next-step.test.tsx
@@ -152,13 +152,61 @@ function renderNextStep(journey: ReturnType<typeof snapshot>) {
 
 afterEach(() => {
   cleanup();
-  document.querySelectorAll("#authoring-recovery").forEach((target) => target.remove());
+  document
+    .querySelectorAll("#authoring-recovery, #production-status, #manuscript-actions")
+    .forEach((target) => target.remove());
   navigation.pathname = `/projects/${PROJECT_ID}/write`;
   window.history.replaceState({}, "", navigation.pathname);
   navigation.refresh.mockClear();
 });
 
 describe("ProjectNextStep presentation", () => {
+  it("moves the same-page writing-room action to the live production status", () => {
+    window.history.replaceState({}, "", `/projects/${PROJECT_ID}/write`);
+    const target = document.createElement("section");
+    target.id = "production-status";
+    target.scrollIntoView = vi.fn();
+    target.getClientRects = vi.fn(() => [{ width: 1, height: 1 }] as unknown as DOMRectList);
+    document.body.append(target);
+
+    renderNextStep(snapshot(run({ stage: "queued", progressPct: 0 })));
+    const link = screen.getByRole("link", { name: "Watch the writing room" });
+    expect(link).toHaveAttribute("href", `/projects/${PROJECT_ID}/write#production-status`);
+
+    fireEvent.click(link);
+
+    expect(window.location.hash).toBe("#production-status");
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(target).toHaveFocus();
+  });
+
+  it("moves the same-page manuscript action to the reading and export controls", () => {
+    navigation.pathname = `/projects/${PROJECT_ID}/manuscript`;
+    window.history.replaceState({}, "", navigation.pathname);
+    const target = document.createElement("header");
+    target.id = "manuscript-actions";
+    target.scrollIntoView = vi.fn();
+    target.getClientRects = vi.fn(() => [{ width: 1, height: 1 }] as unknown as DOMRectList);
+    document.body.append(target);
+
+    render(
+      <JourneyActionLink
+        action={{
+          kind: "read_or_export",
+          href: `/projects/${PROJECT_ID}/manuscript#manuscript-actions`,
+          label: "Read or export the manuscript",
+          description: "The manuscript is ready.",
+          requiresMeteredAccess: false,
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("link", { name: "Read or export the manuscript" }));
+
+    expect(window.location.hash).toBe("#manuscript-actions");
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(target).toHaveFocus();
+  });
+
   it("sets and retains the recovery hash while focusing the target on every activation", () => {
     window.history.replaceState({}, "", `/projects/${PROJECT_ID}/write`);
     const target = document.createElement("section");

--- a/src/db/index.integration.test.ts
+++ b/src/db/index.integration.test.ts
@@ -969,6 +969,81 @@ describeIsolated("withDbTransaction against isolated Neon", () => {
     }
   });
 
+  it("allows a durable authoring retry after malformed structured output is settled and compensated", async () => {
+    const fixture = await createMeteringFixture("structured-output-retry");
+    const intentPrefix = `metering-intent:generation:${fixture.runId}:entity-bible:attempt:`;
+    const usagePrefix = `llm:generation:${fixture.runId}:entity-bible:`;
+    const firstIntentRef = `${intentPrefix}one`;
+    const firstUsageRef = `${usagePrefix}attempt:one`;
+    try {
+      const first = await beginMeteredCallIntent({
+        ...fixture,
+        intentRef: firstIntentRef,
+        intentPrefix,
+        usagePrefix,
+        maxCredits: 1,
+        description: "Structured-output provider attempt",
+      });
+      expect(first.status).toBe("started");
+      if (first.status !== "started") throw new Error("First provider attempt was not authorized");
+
+      await recordLlmCallsAndDebit(
+        [
+          {
+            userId: fixture.userId,
+            projectId: fixture.projectId,
+            runId: fixture.runId,
+            agentRole: "entity-bible",
+            operation: "entity.bible",
+            model: "anthropic/claude-sonnet-5",
+            usage: {
+              inputTokens: 1_000,
+              outputTokens: 500,
+              cachedInputTokens: 0,
+              cacheWriteTokens: 0,
+            },
+          },
+        ],
+        {
+          description: "entity.bible",
+          externalRefPrefix: firstUsageRef,
+          intentRef: firstIntentRef,
+          reservationRef: first.reservationRef,
+          compensateDelivery: {
+            description: "Malformed structured output was not delivered",
+          },
+        },
+      );
+
+      const retry = await beginMeteredCallIntent({
+        ...fixture,
+        intentRef: `${intentPrefix}two`,
+        intentPrefix,
+        usagePrefix,
+        maxCredits: 1,
+        description: "Safe structured-output retry",
+      });
+      expect(retry.status).toBe("started");
+
+      const facts = firstRow<{ refunds: number; settled: number }>(
+        await observer`
+          select
+            count(*) filter (
+              where external_ref = ${`delivery-refund:${firstUsageRef}`}
+            )::int as refunds,
+            count(*) filter (
+              where external_ref = ${`intent-settled:${firstIntentRef}`}
+            )::int as settled
+          from credit_ledger
+          where user_id = ${fixture.userId}
+        `,
+      );
+      expect(facts).toEqual({ refunds: 1, settled: 1 });
+    } finally {
+      await observer`delete from users where id = ${fixture.userId}`;
+    }
+  });
+
   it("blocks compensated redo while optional delivery is pending and after its receipt commits", async () => {
     const userId = `e2e-optional-delivery-${suffix}`;
     const projectId = randomUUID();

--- a/src/lib/authoring-journey.test.ts
+++ b/src/lib/authoring-journey.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  authoringStatusHref,
   authoringJourneyWithProgress,
   deriveAuthoringJourney,
   type AuthoringJourneyRun,
@@ -81,6 +82,49 @@ function seed(
     run: overrides.run === undefined ? null : overrides.run,
   };
 }
+
+describe("authoringStatusHref", () => {
+  it("targets the mounted full-book status surface for every run state", () => {
+    expect(authoringStatusHref(PROJECT_ID, null)).toBe(`/projects/${PROJECT_ID}/write`);
+    expect(authoringStatusHref(PROJECT_ID, run())).toBe(
+      `/projects/${PROJECT_ID}/write#production-status`,
+    );
+    expect(
+      authoringStatusHref(PROJECT_ID, run({ effectiveStatus: "failed", stage: "failed" })),
+    ).toBe(`/projects/${PROJECT_ID}/write#authoring-recovery`);
+    expect(
+      authoringStatusHref(PROJECT_ID, run({ effectiveStatus: "cancelled", stage: "cancelled" })),
+    ).toBe(`/projects/${PROJECT_ID}/write#authoring-recovery`);
+    expect(
+      authoringStatusHref(
+        PROJECT_ID,
+        run({
+          databaseStatus: "completed",
+          effectiveStatus: "completed",
+          stage: "done",
+          completionArtifactsReady: true,
+        }),
+      ),
+    ).toBe(`/projects/${PROJECT_ID}/write`);
+    expect(
+      authoringStatusHref(
+        PROJECT_ID,
+        run({
+          databaseStatus: "completed",
+          effectiveStatus: "completed",
+          stage: "done",
+          completionArtifactsReady: false,
+        }),
+      ),
+    ).toBe(`/projects/${PROJECT_ID}/write#authoring-recovery`);
+  });
+
+  it("targets the persistent editor status surface for scoped runs", () => {
+    expect(authoringStatusHref(PROJECT_ID, run({ kind: "chapter", stage: "failed" }))).toBe(
+      `/projects/${PROJECT_ID}/editor#editor-production-status`,
+    );
+  });
+});
 
 describe("deriveAuthoringJourney", () => {
   const cases: Array<{

--- a/src/lib/authoring-journey.test.ts
+++ b/src/lib/authoring-journey.test.ts
@@ -105,7 +105,7 @@ describe("deriveAuthoringJourney", () => {
       name: "keeps an active run in the writing room",
       input: seed({ run: run() }),
       action: "watch_production",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#production-status`,
     },
     {
       name: "takes a creative pause to the exact Write decision",
@@ -186,13 +186,13 @@ describe("deriveAuthoringJourney", () => {
         }),
       }),
       action: "recover_dispatch",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#production-status`,
     },
     {
       name: "shows an explicit safe-stop state",
       input: seed({ run: run({ cancellationRequestedAt: NOW }) }),
       action: "finish_cancellation",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#production-status`,
     },
     {
       name: "offers checkpoint recovery after an interrupted included story",
@@ -520,7 +520,7 @@ describe("deriveAuthoringJourney", () => {
 
     expect(journey.nextAction).toMatchObject({
       kind: "finish_cancellation",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#production-status`,
       requiresMeteredAccess: false,
     });
     expect(journey.nextAction.label).toMatch(/safe stop/i);
@@ -589,7 +589,9 @@ describe("deriveAuthoringJourney", () => {
       );
 
       expect(journey.nextAction.kind).toBe("watch_production");
-      expect(journey.nextAction.href).toBe(`/projects/${PROJECT_ID}/editor`);
+      expect(journey.nextAction.href).toBe(
+        `/projects/${PROJECT_ID}/editor#editor-production-status`,
+      );
       if (kind === "edit_pass") {
         expect(journey.nextAction.label).toMatch(/manuscript review/i);
         expect(journey.nextAction.description).toMatch(/chapter-by-chapter review/i);
@@ -921,7 +923,7 @@ describe("authoringJourneyWithProgress", () => {
     expect(stopping.nextAction).toMatchObject({
       kind: "finish_cancellation",
       label: "View the safe stop",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#production-status`,
     });
   });
 

--- a/src/lib/authoring-journey.test.ts
+++ b/src/lib/authoring-journey.test.ts
@@ -682,7 +682,7 @@ describe("deriveAuthoringJourney", () => {
 
     expect(journey.nextAction).toMatchObject({
       kind: "read_or_export",
-      href: `/projects/${PROJECT_ID}/manuscript`,
+      href: `/projects/${PROJECT_ID}/manuscript#manuscript-actions`,
     });
     expect(journey.purchaseAction).toMatchObject({
       kind: "unlock_full_book",
@@ -719,7 +719,7 @@ describe("deriveAuthoringJourney", () => {
 
     expect(journey.nextAction).toMatchObject({
       kind: "read_or_export",
-      href: `/projects/${PROJECT_ID}/manuscript`,
+      href: `/projects/${PROJECT_ID}/manuscript#manuscript-actions`,
     });
     expect(journey.purchaseAction).toMatchObject({
       kind: "unlock_full_book",
@@ -970,7 +970,7 @@ describe("authoringJourneyWithProgress", () => {
     expect(resumed.nextAction).toMatchObject({
       kind: "watch_production",
       label: "Watch production",
-      href: `/projects/${PROJECT_ID}/write`,
+      href: `/projects/${PROJECT_ID}/write#production-status`,
     });
   });
 

--- a/src/lib/authoring-journey.ts
+++ b/src/lib/authoring-journey.ts
@@ -169,6 +169,37 @@ function projectHref(projectId: string, stage: string): string {
   return `/projects/${projectId}/${stage}`;
 }
 
+/**
+ * Points a library status action at a surface that is actually mounted for the
+ * current run. Active full-book runs expose live telemetry, terminal failures
+ * expose recovery details, and completed runs render their completion moment
+ * without either fragment target.
+ */
+export function authoringStatusHref(
+  projectId: string,
+  run: Pick<
+    AuthoringJourneyRun,
+    "kind" | "databaseStatus" | "effectiveStatus" | "stage" | "completionArtifactsReady"
+  > | null,
+): string {
+  const writeHref = projectHref(projectId, "write");
+  if (!run) return writeHref;
+  if (run.kind !== undefined && run.kind !== "full_book") {
+    return `${projectHref(projectId, "editor")}#editor-production-status`;
+  }
+  if (
+    run.effectiveStatus === "failed" ||
+    run.effectiveStatus === "cancelled" ||
+    run.stage === "failed" ||
+    run.stage === "cancelled" ||
+    (run.databaseStatus === "completed" && run.completionArtifactsReady === false)
+  ) {
+    return `${writeHref}#authoring-recovery`;
+  }
+  if (run.effectiveStatus === "completed" || run.stage === "done") return writeHref;
+  return `${writeHref}#production-status`;
+}
+
 function supportReferenceFor(projectId: string, runId?: string | null): string {
   const projectPart = projectId.replaceAll("-", "").slice(0, 8).toUpperCase();
   const runPart = runId ? runId.replaceAll("-", "").slice(0, 8).toUpperCase() : "PROJECT";

--- a/src/lib/authoring-journey.ts
+++ b/src/lib/authoring-journey.ts
@@ -298,6 +298,10 @@ function actionForSeed(
     run?.kind && run.kind !== "full_book"
       ? projectHref(project.id, "editor")
       : projectHref(project.id, "write");
+  const projectStatusHref =
+    run?.kind && run.kind !== "full_book"
+      ? `${projectWriteHref}#editor-production-status`
+      : `${projectWriteHref}#production-status`;
 
   if (project.status === "archived") {
     return artifacts.savedChapters > 0
@@ -313,7 +317,7 @@ function actionForSeed(
   if (run?.cancellationRequestedAt && ACTIVE_RUN_STATUSES.has(run.effectiveStatus)) {
     return nextAction(
       "finish_cancellation",
-      projectWriteHref,
+      projectStatusHref,
       "View the safe stop",
       "The studio is stopping before another model call or manuscript commit begins.",
     );
@@ -385,7 +389,7 @@ function actionForSeed(
     if (run.acceptanceUncertain && run.safeToRetry) {
       return nextAction(
         "recover_dispatch",
-        projectWriteHref,
+        projectStatusHref,
         run.kind === "edit_pass" ? "Reconnect this review" : "Reconnect this start",
         run.kind === "edit_pass"
           ? "The manuscript direction is saved, but the studio did not receive a start confirmation. Reconnect the same review without creating another."
@@ -404,7 +408,7 @@ function actionForSeed(
     if (run.kind === "edit_pass") {
       return nextAction(
         "watch_production",
-        projectWriteHref,
+        projectStatusHref,
         run.stage === "queued" ? "Watch the manuscript review" : "Follow the manuscript review",
         run.health === "degraded"
           ? "The live status is delayed. The durable review remains active, and the Editor will keep checking it."
@@ -414,9 +418,7 @@ function actionForSeed(
 
     return nextAction(
       "watch_production",
-      run.kind && run.kind !== "full_book"
-        ? projectWriteHref
-        : `${projectWriteHref}#production-status`,
+      projectStatusHref,
       run.stage === "queued" ? "Watch the writing room" : "Watch production",
       run.health === "degraded"
         ? "The live connection is delayed. The durable run remains active, and the Write page will keep checking it."

--- a/src/lib/authoring-journey.ts
+++ b/src/lib/authoring-journey.ts
@@ -210,7 +210,7 @@ function fullBookContinuationAction(
 function readAction(projectId: string): AuthoringNextAction {
   return nextAction(
     "read_or_export",
-    projectHref(projectId, "manuscript"),
+    `${projectHref(projectId, "manuscript")}#manuscript-actions`,
     "Read or export the manuscript",
     "Your assembled manuscript is ready to read, download, or take back into the editor.",
   );
@@ -414,7 +414,9 @@ function actionForSeed(
 
     return nextAction(
       "watch_production",
-      projectWriteHref,
+      run.kind && run.kind !== "full_book"
+        ? projectWriteHref
+        : `${projectWriteHref}#production-status`,
       run.stage === "queued" ? "Watch the writing room" : "Watch production",
       run.health === "degraded"
         ? "The live connection is delayed. The durable run remains active, and the Write page will keep checking it."

--- a/src/lib/authoring-reliability.integration.test.ts
+++ b/src/lib/authoring-reliability.integration.test.ts
@@ -942,7 +942,7 @@ describeIsolated("authoring reliability against isolated Neon", () => {
     expect(libraryProject?.nextAction).toEqual(openProject?.nextAction);
     expect(openProject?.nextAction).toMatchObject({
       kind: "read_or_export",
-      href: `/projects/${projectId}/manuscript`,
+      href: `/projects/${projectId}/manuscript#manuscript-actions`,
     });
   });
 


### PR DESCRIPTION
## What changed

- settles and compensates AI SDK `NoObjectGeneratedError` responses using their authoritative usage before Workflow retries
- preserves the fail-closed hold for genuinely ambiguous provider or database failures
- routes failed library cards to the internal production status rather than opening email
- makes writing-room and manuscript actions target visible, focusable sections
- adds unit and real-Neon regression coverage for same-lineage retries

## Production diagnosis

Workflow events for the affected runs show the same sequence: a structured response failed schema validation, Workflow scheduled a retry, and the retry encountered the unresolved local metering intent created by the first completed response. The new narrow handling uses the usage carried by `NoObjectGeneratedError`, refunds the undelivered output, and leaves all other ambiguous failures blocked.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 168 files / 1,241 tests
- `pnpm test:db-integration` on a disposable Neon branch — 13 files / 60 tests
- `pnpm check:migrations`
- `pnpm db:check`
- `pnpm build`

## Release notes

Existing terminal runs are not restarted automatically. Their pending attempts are being reconciled only from authoritative AI Gateway usage, after which the authors can explicitly resume from saved work. Leave this PR open and unmerged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Metering changes affect billing settlement and workflow retries on structured provider failures; navigation changes are mostly UX but touch critical authoring journey entry points.
> 
> **Overview**
> Fixes **Workflow retries** that stalled after AI SDK schema validation failures by treating **`NoObjectGeneratedError`** as authoritative usage: **`metered()`** settles and **compensates** undelivered structured output, then surfaces a retryable **`MeteredOutputDeliveryError`**, while other post-dispatch failures stay **fail-closed** for reconciliation.
> 
> **Authoring navigation** now routes library cards and next-step links to **in-app status surfaces** (`#production-status`, `#authoring-recovery`, `#editor-production-status`, `#manuscript-actions`) via **`authoringStatusHref`** and **`statusHref`**; **`contact_support`** cards open **“Review production status”** instead of **`mailto:`**. Shared **`HashFocusTarget` / `useHashTargetFocus`** focus visible fragment targets after cross-page or same-page hash navigation.
> 
> Minor: notification switch **`aria-label`**s, dependency overrides (**postcss**, **brace-expansion**), and expanded unit, DB integration, and Playwright coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5394eeed4dfc511828b949f44f7ba923d10c99. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->